### PR TITLE
Switch all links towards tools.ietf.org to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@ function errorHandler(evt) {
           “<span class="rfc2119">MAY</span>” and
           “<span class="rfc2119">OPTIONAL</span>” in this document are to be
           interpreted as described in
-          <cite><a href="http://www.ietf.org/rfc/rfc2119">Key words for use in RFCs to
+          <cite><a href="https://www.ietf.org/rfc/rfc2119">Key words for use in RFCs to
               Indicate Requirement Levels</a></cite>
           <a href="#RFC2119">[RFC2119]</a>.
         </p>
@@ -2017,15 +2017,15 @@ var windowRef = openPopup(blobURLAnchorRef, "Application Info");
 	        <h3>15.1. Normative references</h3>
 		<dl class="bibliography">
 		<dt id="RFC2119">RFC2119</dt>
-		<dd><cite><a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite>, S. Bradner. IETF.</dd>
+		<dd><cite><a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite>, S. Bradner. IETF.</dd>
 		<dt id="HTML">HTML</dt>
 		<dd><cite><a href="http://www.w3.org/TR/html5/">HTML 5: A vocabulary and associated APIs for HTML and XHTML</a></cite>, I. Hickson, R. Berjon, S. Faulkner, T. Leithead, E. Doyle Navara, E. O'Connor, S. Pfeiffer. W3C.</dd>
     <dt id="WEBORIGIN">Web Origin Concept</dt>
-    <dd><cite><a href="http://tools.ietf.org/html/rfc6454/">Web Origin Concept</a></cite>, A. Barth. IETF.</dd>
+    <dd><cite><a href="https://tools.ietf.org/html/rfc6454/">Web Origin Concept</a></cite>, A. Barth. IETF.</dd>
 	        <dt id="ProgressEvents">ProgressEvents</dt>
 	        <dd><cite><a href="http://www.w3.org/TR/progress-events/">Progress Events</a></cite>, A. van Kesteren. W3C.</dd>
 		<dt id="DataURL">RFC2397</dt>
-		<dd><cite><a href="http://tools.ietf.org/html/rfc2397">The "data" URL Scheme</a></cite>, L. Masinter. IETF.</dd>
+		<dd><cite><a href="https://tools.ietf.org/html/rfc2397">The "data" URL Scheme</a></cite>, L. Masinter. IETF.</dd>
 		<dt id="Workers">Web Workers</dt>
 		<dd><cite><a href="http://dev.w3.org/html5/workers/">Web Workers (work in progress)</a></cite>, I. Hickson. W3C.</dd>
 		<dt id="DOM4">DOM4</dt>
@@ -2033,13 +2033,13 @@ var windowRef = openPopup(blobURLAnchorRef, "Application Info");
 		<dt id="Unicode">Unicode</dt>
 		<dd><cite><a href="http://www.unicode.org/versions/Unicode5.2.0/">The Unicode Standard, Version 5.2.0.</a></cite>, J. D. Allen, D. Anderson, et al. Unicode Consortium.</dd>  	
 		<dt id="RFC7230">RFC7230</dt>
-		<dd><cite><a href="http://tools.ietf.org/html/rfc7230">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a></cite>, R. Fielding, J. Reschke. IETF.</dd>
+		<dd><cite><a href="https://tools.ietf.org/html/rfc7230">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a></cite>, R. Fielding, J. Reschke. IETF.</dd>
     <dt id="RFC7231">RFC7231</dt>
-    <dd><cite><a href="http://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a></cite>, R. Fielding, J. Reschke. IETF.</dd>
+    <dd><cite><a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a></cite>, R. Fielding, J. Reschke. IETF.</dd>
 		<dt id="RFC2046">RFC2046</dt>
-		<dd><cite><a href="http://tools.ietf.org/html/rfc2046">Multipurpose Internet Mail Extensions (MIME) Part Two: Media Extensions</a></cite>, N. Freed, N. Borenstein. IETF.</dd>
+		<dd><cite><a href="https://tools.ietf.org/html/rfc2046">Multipurpose Internet Mail Extensions (MIME) Part Two: Media Extensions</a></cite>, N. Freed, N. Borenstein. IETF.</dd>
     <dt id="RFC6266">RFC6266</dt>
-    <dd><cite><a href="http://tools.ietf.org/html/rfc6266">Use of the Content-Disposition Header Field in the Hypertext Transfer Protocol (HTTP)</a></cite>, J. Reschke. IETF.</dd>
+    <dd><cite><a href="https://tools.ietf.org/html/rfc6266">Use of the Content-Disposition Header Field in the Hypertext Transfer Protocol (HTTP)</a></cite>, J. Reschke. IETF.</dd>
 	        <dt id="encodingSpecification">Encoding Specification</dt>
 	        <dd><cite><a href="https://encoding.spec.whatwg.org/">Encoding Living Standard</a></cite>, A. van Kesteren, J. Bell.</dd>
                 <dt id="streamsSpecification">Streams Specification</dt>
@@ -2047,7 +2047,7 @@ var windowRef = openPopup(blobURLAnchorRef, "Application Info");
 	        <dt id="TypedArrays">Typed Arrays</dt>
 	        <dd><cite><a href="https://cvs.khronos.org/svn/repos/registry/trunk/public/webgl/doc/spec/TypedArray-spec.html">Typed Arrays (work in progress)</a></cite>, V. Vukicevic, K. Russell. Khronos Group.</dd>
 	        <dt id="ABNF">RFC5234</dt>
-	        <dd><cite><a href="http://tools.ietf.org/html/rfc5234">Augmented BNF for Syntax Specifications: ABNF</a></cite>, D. Crocker, P. Overell. IETF.</dd>
+	        <dd><cite><a href="https://tools.ietf.org/html/rfc5234">Augmented BNF for Syntax Specifications: ABNF</a></cite>, D. Crocker, P. Overell. IETF.</dd>
 	        <dt id="URL-API">URL Specification</dt>
 	        <dd><cite><a href="https://url.spec.whatwg.org/">URL Living Standard (work in progress)</a></cite>, A. van Kesteren.</dd>
            <dt id="Fetch">Fetch Specification</dt>
@@ -2068,13 +2068,13 @@ var windowRef = openPopup(blobURLAnchorRef, "Application Info");
 	    <dt id="Blob-REF">Google Gears Blob API</dt>
 	    <dd><cite><a href="https://developers.google.com/gears/?csw=1">Google Gears Blob API (deprecated)</a></cite></dd>
 	    <dt id="UUID">RFC4122</dt>
-	    <dd><cite><a href="http://tools.ietf.org/html/rfc4122">A Universally Unique IDentifier (UUID) URN Namespace</a></cite>, P. Leach, M. Mealling, R. Salz. IETF.</dd>
+	    <dd><cite><a href="https://tools.ietf.org/html/rfc4122">A Universally Unique IDentifier (UUID) URN Namespace</a></cite>, P. Leach, M. Mealling, R. Salz. IETF.</dd>
 	    <dt id="RFC3986">RFC3986</dt>
-	    <dd><cite><a href="http://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a></cite>, T. Berners-Lee, R. Fielding, L. Masinter. IETF.</dd>
+	    <dd><cite><a href="https://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a></cite>, T. Berners-Lee, R. Fielding, L. Masinter. IETF.</dd>
 	    <dt id="RFC1630">RFC1630</dt>
-	    <dd><cite><a href="http://tools.ietf.org/html/rfc1630">Universal Resource Identifiers in WWW</a></cite>, T. Berners-Lee. IETF.</dd>
+	    <dd><cite><a href="https://tools.ietf.org/html/rfc1630">Universal Resource Identifiers in WWW</a></cite>, T. Berners-Lee. IETF.</dd>
 	    <dt id="RFC1738">RFC1738</dt>
-	    <dd><cite><a href="http://tools.ietf.org/html/rfc1738">Uniform Resource Locators (URL)</a></cite>, T. Berners-Lee, L. Masinter, M. McCahill. IETF.</dd>
+	    <dd><cite><a href="https://tools.ietf.org/html/rfc1738">Uniform Resource Locators (URL)</a></cite>, T. Berners-Lee, L. Masinter, M. McCahill. IETF.</dd>
 	    <dt id="WebRTC">WebRTC 1.0</dt>
 	    <dd><cite><a href="http://dev.w3.org/2011/webrtc/editor/webrtc.html">WebRTC 1.0</a></cite>, A. Bergkvist, D. Burnett, C. Jennings, A. Narayanan. W3C.</dd>
 	    </dl>


### PR DESCRIPTION
I checked that all of them were actually sourced as HTTPS by https://labs.w3.org/specrefs/bibrefs?refs=rfcXXXX