### PR TITLE
Make the Blob URL creating/revoking methods not be exposed on the ser…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1928,6 +1928,7 @@ This section describes a supplemental interface to the URL specification [[URL]]
 and presents methods for <a>Blob URL</a> creation and revocation.
 
 <pre class="idl">
+[Exposed=Window,DedicatedWorker,SharedWorker]
 partial interface URL {
   static DOMString createObjectURL(Blob blob);
   static DOMString createFor(Blob blob);

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
  *
  * Indices
  *   - .toc for the Table of Contents (<ol class="toc">)
- *     + <span class="secno"> for the section numbers
+ *     -> <span class="secno"> for the section numbers
  *   - #toc for the Table of Contents (<nav id="toc">)
  *   - ul.index for Indices (<a href="#ref">term</a><span>, in §N.M</span>)
  *   - table.index for Index Tables (e.g. for properties or elements)
@@ -114,36 +114,39 @@
 
 	div.head h2 { margin-bottom: 1.5em;}
 
-/** W3C Logo ******************************************************************/
-
-	.head .logo {
+	div.head .logo {
 		float: right;
-		margin: 0.4rem 0 0.2rem .4rem;
+		margin: 0;
 	}
 
-	.head img[src*="logos/W3C"] {
-		display: block;
-		border: solid #1a5e9a;
-		border-width: .65rem .7rem .6rem;
-		border-radius: .4rem;
-		background: #1a5e9a;
-		color: white;
-		font-weight: bold;
+	@media screen {
+		div.head .logo > a {
+			display: inline-block;
+			margin: 0.4rem 0 0.2rem .4rem;
+		}
+
+		div.head img[src*="logos/W3C"] {
+			display: block;
+			border: solid #1a5e9a;
+			border-width: .65rem .7rem .6rem;
+			border-radius: .4rem;
+			background: #1a5e9a;
+			color: white;
+			font-weight: bold;
+		}
+
+		div.head a:hover > img[src*="logos/W3C"],
+		div.head a:focus > img[src*="logos/W3C"] {
+			background: #457cad;
+			border-color: #457cad;
+		}
+
+		div.head a:active > img[src*="logos/W3C"] {
+			background: #c00;
+			border-color: #c00;
+		}
 	}
 
-	.head a:hover > img[src*="logos/W3C"],
-	.head a:focus > img[src*="logos/W3C"] {
-		opacity: .8;
-	}
-
-	.head a:active > img[src*="logos/W3C"] {
-		background: #c00;
-		border-color: #c00;
-	}
-
-	/* see also additional rules in Link Styling section */
-
-/** Copyright *****************************************************************/
 
 	p.copyright,
 	p.copyright small { font-size: small }
@@ -329,7 +332,6 @@
 		font: 100% sans-serif;   /* Reset all font styling to clear out UA styles */
 		font-family: inherit;    /* Inherit the font family. */
 		line-height: 1.2;        /* Keep wrapped headings compact */
-		hyphens: manual;         /* Hyphenated headings look weird */
 	}
 
 	h2, h3, h4, h5, h6 {
@@ -533,11 +535,9 @@
 	}
 
 	/* Backout above styling for W3C logo */
-	.head .logo,
-	.head .logo a {
+	.head > p:first-child > a {
 		border: none;
 		text-decoration: none;
-		background: transparent;
 	}
 
 /******************************************************************************/
@@ -829,8 +829,8 @@
 	table.index {
 		margin: 1em auto;
 		border-collapse: collapse;
-		border: hidden;
 		width: 100%;
+		border: hidden;
 	}
 	table.data caption,
 	table.index caption {
@@ -937,7 +937,7 @@ Possible extra rowspan handling
 
 	.toc a {
 		/* More spacing; use padding to make it part of the click target. */
-		padding-top: 0.1rem;
+		padding-top: 0.1em;
 		/* Larger, more consistently-sized click target */
 		display: block;
 		/* Reverse color scheme */
@@ -968,14 +968,19 @@ Possible extra rowspan handling
 	.toc > li li li li li { font-style:  italic;
 	                        font-size:   85%;    }
 
-	.toc > li             { margin: 1.5rem 0;    }
+	.toc > li             { margin: 1.5em 0;     }
 	.toc > li li          { margin: 0.3rem 0;    }
-	.toc > li li li       { margin-left: 2rem;   }
+	.toc > li li li       { margin-left: 2em;
+	                        margin-left: 2rem;   }
 
 	/* Section numbers in a column of their own */
+	:not(li) > .toc {
+		margin-left: 5em;
+	}
+
 	.toc .secno {
 		float: left;
-		width: 4rem;
+		width: 4em;
 		white-space: nowrap;
 	}
 	.toc > li li li li .secno {
@@ -1023,7 +1028,7 @@ Possible extra rowspan handling
 /** Index *********************************************************************/
 
 	/* Index Lists: Layout */
-	ul.index       { margin-left: 0; columns: 15em; text-indent: 1em hanging; }
+	ul.index       { margin-left: 0; columns: 15em; -webkit-columns: 15em; -moz-columns: 15em; text-indent: 1em hanging; }
 	ul.index li    { margin-left: 0; list-style: none; break-inside: avoid; }
 	ul.index li li { margin-left: 1em }
 	ul.index dl    { margin-top: 0; }
@@ -1102,12 +1107,6 @@ Possible extra rowspan handling
 	.figure .caption, .sidefigure .caption, figcaption {
 		/* in case figure is overlarge, limit caption to 50em */
 		max-width: 50rem;
-		margin-left: auto;
-		margin-right: auto;
-	}
-	.overlarge > table {
-		/* limit preferred width of table */
-		max-width: 50em;
 		margin-left: auto;
 		margin-right: auto;
 	}
@@ -1295,7 +1294,7 @@ Possible extra rowspan handling
 
 
 /********************************************
- Remember to fix the logo section when copypasting freshly.
+ Remember to remove the logo section when copypasting freshly.
  */
 </style>
   <meta content="Bikeshed 1.0.0" name="generator">
@@ -1342,8 +1341,10 @@ Possible extra rowspan handling
 .highlight .n { color: #0077aa } /* Name */
 .highlight .o { color: #999999 } /* Operator */
 .highlight .p { color: #999999 } /* Punctuation */
+.highlight .ch { color: #708090 } /* Comment.Hashbang */
 .highlight .cm { color: #708090 } /* Comment.Multiline */
 .highlight .cp { color: #708090 } /* Comment.Preproc */
+.highlight .cpf { color: #708090 } /* Comment.PreprocFile */
 .highlight .c1 { color: #708090 } /* Comment.Single */
 .highlight .cs { color: #708090 } /* Comment.Special */
 .highlight .kc { color: #990055 } /* Keyword.Constant */
@@ -1394,9 +1395,9 @@ Possible extra rowspan handling
         </style>
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
+   <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">File API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-03-25">25 March 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-04-15">15 April 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1408,7 +1409,7 @@ Possible extra rowspan handling
      <dt>Feedback:
      <dd><span><a href="mailto:public-webapps@w3.org?subject=%5Bfileapi%5D%20YOUR%20TOPIC%20HERE">public-webapps@w3.org</a> with subject line “<kbd>[fileapi] <i data-lt="">… message topic …</i></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-webapps/" rel="discussion">archives</a>)</span>
      <dt>Issue Tracking:
-     <dd><a href="https://github.com/w3c/FileAPI/issues/">GitHub</a>
+     <dd><a href="https://github.com/jungkees/FileAPI/issues/">GitHub</a>
      <dd><a href="#issues-index">Inline In Spec</a>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-url url" href="http://arunranga.com/">Arun Ranganathan</a> (<span class="p-org org">Mozilla Corporation</span>) <a class="u-email email" href="mailto:arun@mozilla.com">arun@mozilla.com</a>
@@ -1417,7 +1418,7 @@ Possible extra rowspan handling
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
@@ -1451,7 +1452,7 @@ These kinds of behaviors are defined in the appropriate affiliated specification
   It is provided for discussion only and may change at any moment.
   Its publication here does not imply endorsement of its contents by W3C.
   Don’t cite this document other than as work in progress. </p>
-   <p> <strong>Changes to this document may be tracked at <a href="https://github.com/w3c/FileAPI">https://github.com/w3c/FileAPI</a>.</strong> </p>
+   <p> <strong>Changes to this document may be tracked at <a href="https://github.com/jungkees/FileAPI">https://github.com/jungkees/FileAPI</a>.</strong> </p>
    <p> The (<a href="http://lists.w3.org/Archives/Public/public-webapps/">archived</a>) public mailing list <a href="mailto:public-webapps@w3.org?Subject=%5Bfileapi%5D%20PUT%20SUBJECT%20HERE">public-webapps@w3.org</a> (see <a href="http://www.w3.org/Mail/Request">instructions</a>)
   is preferred for discussion of this specification.
   When sending e-mail,
@@ -1461,13 +1462,11 @@ These kinds of behaviors are defined in the appropriate affiliated specification
    <p> This document was produced by the <a href="https://www.w3.org/WebPlatform/WG/">Web Platform Working Group</a>. </p>
    <p> This document was produced by a group operating under
   the <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
-  W3C maintains a <a href="http://www.w3.org/2004/01/pp-impl/83482/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
+  W3C maintains a <a href="http://www.w3.org/2004/01/pp-impl/49309/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
   An individual who has actual knowledge of a patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
    <p> This document is governed by the <a href="http://www.w3.org/2015/Process-20150901/" id="w3c_process_revision">1 September 2015 W3C Process Document</a>. </p>
-   <p></p>
-   <p>Previous discussion of this specification has taken place on two other mailing lists: <a href="mailto:public-webapps@w3.org">public-webapps@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-webapps/">archive</a>) and <a href="mailto:public-webapi@w3.org">public-webapi@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-webapi/">archive</a>). Ongoing discussion will be on the <a href="mailto:public-webapps@w3.org">public-webapps@w3.org</a> mailing list.</p>
-   <p>This draft consists of changes made to the previous Last Call Working Draft. Please send comments to the <a href="mailto:public-webapi@w3.org">public-webapi@w3.org</a> as described above. You can see Last Call Feedback on the W3C Wiki: <a href="http://www.w3.org/wiki/Webapps/LCWD-FileAPI-20130912">http://www.w3.org/wiki/Webapps/LCWD-FileAPI-20130912</a></p>
+   <p> This draft consists of changes made to the previous Last Call Working Draft. Please send comments to the <a href="mailto:public-webapi@w3.org">public-webapi@w3.org</a> as described above. You can see Last Call Feedback on the W3C Wiki: <a href="http://www.w3.org/wiki/Webapps/LCWD-FileAPI-20130912">http://www.w3.org/wiki/Webapps/LCWD-FileAPI-20130912</a> </p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
@@ -1598,6 +1597,12 @@ These kinds of behaviors are defined in the appropriate affiliated specification
      </ol>
     <li><a href="#acknowledgements-section"><span class="secno"></span> <span class="content"> Acknowledgements</span></a>
     <li>
+     <a href="#conformance0"><span class="secno"></span> <span class="content">Conformance</span></a>
+     <ol class="toc">
+      <li><a href="#conventions"><span class="secno"></span> <span class="content">Document conventions</span></a>
+      <li><a href="#conformant-algorithms"><span class="secno"></span> <span class="content">Conformant Algorithms</span></a>
+     </ol>
+    <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
@@ -1707,7 +1712,7 @@ examples and sections marked as being informative.</p>
 interpreted as described in <cite><a href="http://www.ietf.org/rfc/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite> <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a>.</p>
    <p>The following conformance classes are defined by this specification:</p>
    <dl>
-    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="conforming user agent" data-noexport="" id="dfn-conforming-implementation">conforming user agent<span class="dfn-panel" data-deco=""><b><a href="#dfn-conforming-implementation">#dfn-conforming-implementation</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-conforming-implementation-1">2. 
+    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-conforming-implementation">conforming user agent<span class="dfn-panel"><b><a href="#dfn-conforming-implementation">#dfn-conforming-implementation</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-conforming-implementation-1">2. 
 Conformance</a></span><span><a href="#ref-for-dfn-conforming-implementation-2">2.1. 
 Dependencies</a> <a href="#ref-for-dfn-conforming-implementation-3">(2)</a> <a href="#ref-for-dfn-conforming-implementation-4">(3)</a> <a href="#ref-for-dfn-conforming-implementation-5">(4)</a> <a href="#ref-for-dfn-conforming-implementation-6">(5)</a></span></span></dfn> 
     <dd>
@@ -1742,7 +1747,7 @@ defined in the Web IDL specification <a data-link-type="biblio" href="#biblio-we
    <p>Parts of this specification rely on the Web Workers specification;
 for those parts of this specification, the Web Workers specification is a normative dependency. <a data-link-type="biblio" href="#biblio-workers">[Workers]</a></p>
    <h2 class="heading settled" data-level="3" id="terminology"><span class="secno">3. </span><span class="content"> Terminology and Algorithms</span><a class="self-link" href="#terminology"></a></h2>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="terminate an algorithm|terminate this algorithm" data-noexport="" id="terminate-an-algorithm">terminate an algorithm<span class="dfn-panel" data-deco=""><b><a href="#terminate-an-algorithm">#terminate-an-algorithm</a></b><b>Referenced in:</b><span><a href="#ref-for-terminate-an-algorithm-1">4.3.2. 
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="terminate an algorithm|terminate this algorithm" data-noexport="" id="terminate-an-algorithm">terminate an algorithm<span class="dfn-panel"><b><a href="#terminate-an-algorithm">#terminate-an-algorithm</a></b><b>Referenced in:</b><span><a href="#ref-for-terminate-an-algorithm-1">4.3.2. 
 The close method</a></span><span><a href="#ref-for-terminate-an-algorithm-2">7.1. 
 The Read Operation</a> <a href="#ref-for-terminate-an-algorithm-3">(2)</a> <a href="#ref-for-terminate-an-algorithm-4">(3)</a></span><span><a href="#ref-for-terminate-an-algorithm-5">7.3.4.2. 
 The readAsDataURL() method</a> <a href="#ref-for-terminate-an-algorithm-6">(2)</a> <a href="#ref-for-terminate-an-algorithm-7">(3)</a></span><span><a href="#ref-for-terminate-an-algorithm-8">7.3.4.3. 
@@ -1770,7 +1775,7 @@ This operation is also defined in ECMAScript <a data-link-type="biblio" href="#b
     <li data-md="">
      <p>Mathematical comparisons such as &lt; (less than), ≤ (less than or equal to), and > (greater than) are as in ECMAScript <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a>.</p>
    </ul>
-   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Unix Epoch" data-noexport="" id="UnixEpoch">Unix Epoch<span class="dfn-panel" data-deco=""><b><a href="#UnixEpoch">#UnixEpoch</a></b><b>Referenced in:</b><span><a href="#ref-for-UnixEpoch-1">5.1. 
+   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="UnixEpoch">Unix Epoch<span class="dfn-panel"><b><a href="#UnixEpoch">#UnixEpoch</a></b><b>Referenced in:</b><span><a href="#ref-for-UnixEpoch-1">5.1. 
 Constructor</a> <a href="#ref-for-UnixEpoch-2">(2)</a></span><span><a href="#ref-for-UnixEpoch-3">5.2. 
 Attributes</a> <a href="#ref-for-UnixEpoch-4">(2)</a></span></span></dfn> is used in this specification to refer to the time 00:00:00 UTC on January 1 1970
 (or 1970-01-01T00:00:00Z ISO 8601);
@@ -1780,7 +1785,7 @@ this is the same time that is conceptually "<code>0</code>" in ECMA-262 <a data-
 and has a <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-1">size</a></code> attribute which is the total number of bytes in the byte sequence,
 and a <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-1">type</a></code> attribute,
 which is an ASCII-encoded string in lower case representing the media type of the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence.</p>
-   <p>A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-5">Blob</a></code> must have a <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-lt="readability state" data-noexport="" id="readabilityState">readability state<span class="dfn-panel" data-deco=""><b><a href="#readabilityState">#readabilityState</a></b><b>Referenced in:</b><span><a href="#ref-for-readabilityState-1">4. 
+   <p>A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-5">Blob</a></code> must have a <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-noexport="" id="readabilityState">readability state<span class="dfn-panel"><b><a href="#readabilityState">#readabilityState</a></b><b>Referenced in:</b><span><a href="#ref-for-readabilityState-1">4. 
 The Blob Interface and Binary Data</a> <a href="#ref-for-readabilityState-2">(2)</a></span><span><a href="#ref-for-readabilityState-3">4.1. 
 Constructors</a> <a href="#ref-for-readabilityState-4">(2)</a></span><span><a href="#ref-for-readabilityState-5">4.2. 
 Attributes</a> <a href="#ref-for-readabilityState-6">(2)</a> <a href="#ref-for-readabilityState-7">(3)</a></span><span><a href="#ref-for-readabilityState-8">4.3.1. 
@@ -1795,16 +1800,16 @@ Methods and Parameters</a> <a href="#ref-for-readabilityState-19">(2)</a> <a hre
 which is one of <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-1"><code>OPENED</code></a> or <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-1"><code>CLOSED</code></a>.
 A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-6">Blob</a></code> that refers to a <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence,
 including one of 0 bytes,
-is said to be in the <dfn class="dfn-paneled" data-dfn-for="Blob/readability state" data-dfn-type="dfn" data-lt="OPENED" data-noexport="" id="dfn-openState"><code>OPENED</code><span class="dfn-panel" data-deco=""><b><a href="#dfn-openState">#dfn-openState</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-openState-1">4. 
+is said to be in the <dfn class="dfn-paneled" data-dfn-for="Blob/readability state" data-dfn-type="dfn" data-noexport="" id="dfn-openState"><code>OPENED</code><span class="dfn-panel"><b><a href="#dfn-openState">#dfn-openState</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-openState-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-openState-2">4.1. 
 Constructors</a> <a href="#ref-for-dfn-openState-3">(2)</a></span><span><a href="#ref-for-dfn-openState-4">4.2. 
 Attributes</a></span><span><a href="#ref-for-dfn-openState-5">5.1. 
 Constructor</a></span></span></dfn> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-1">readability state</a>.
-A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-7">Blob</a></code> is said to be <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-lt="closed" data-noexport="" id="closed">closed<span class="dfn-panel" data-deco=""><b><a href="#closed">#closed</a></b><b>Referenced in:</b><span><a href="#ref-for-closed-1">4. 
+A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-7">Blob</a></code> is said to be <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-noexport="" id="closed">closed<span class="dfn-panel"><b><a href="#closed">#closed</a></b><b>Referenced in:</b><span><a href="#ref-for-closed-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-closed-2">4.3.2. 
 The close method</a></span><span><a href="#ref-for-closed-3">9.4.3. 
 Network Errors</a></span></span></dfn> if its <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-1">close()</a></code> method has been called.
-A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-8">Blob</a></code> that is <a data-link-type="dfn" href="#closed" id="ref-for-closed-1">closed</a> is said to be in the <dfn class="dfn-paneled" data-dfn-for="Blob/readability state" data-dfn-type="dfn" data-lt="CLOSED" data-noexport="" id="dfn-closedState"><code>CLOSED</code><span class="dfn-panel" data-deco=""><b><a href="#dfn-closedState">#dfn-closedState</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-closedState-1">4. 
+A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-8">Blob</a></code> that is <a data-link-type="dfn" href="#closed" id="ref-for-closed-1">closed</a> is said to be in the <dfn class="dfn-paneled" data-dfn-for="Blob/readability state" data-dfn-type="dfn" data-noexport="" id="dfn-closedState"><code>CLOSED</code><span class="dfn-panel"><b><a href="#dfn-closedState">#dfn-closedState</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-closedState-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-closedState-2">4.2. 
 Attributes</a> <a href="#ref-for-dfn-closedState-3">(2)</a> <a href="#ref-for-dfn-closedState-4">(3)</a></span><span><a href="#ref-for-dfn-closedState-5">4.3.2. 
 The close method</a> <a href="#ref-for-dfn-closedState-6">(2)</a></span><span><a href="#ref-for-dfn-closedState-7">7.1. 
@@ -1813,7 +1818,7 @@ The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-closedState-9">
 The readAsText() method</a></span><span><a href="#ref-for-dfn-closedState-10">7.3.4.4. 
 The readAsArrayBuffer() method</a></span><span><a href="#ref-for-dfn-closedState-11">9.5.1. 
 Methods and Parameters</a> <a href="#ref-for-dfn-closedState-12">(2)</a> <a href="#ref-for-dfn-closedState-13">(3)</a></span></span></dfn> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-2">readability state</a>.</p>
-   <p>Each <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-9">Blob</a></code> must have an internal <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-lt="snapshot state" data-noexport="" id="snapshot-state">snapshot state<span class="dfn-panel" data-deco=""><b><a href="#snapshot-state">#snapshot-state</a></b><b>Referenced in:</b><span><a href="#ref-for-snapshot-state-1">4. 
+   <p>Each <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-9">Blob</a></code> must have an internal <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-noexport="" id="snapshot-state">snapshot state<span class="dfn-panel"><b><a href="#snapshot-state">#snapshot-state</a></b><b>Referenced in:</b><span><a href="#ref-for-snapshot-state-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-snapshot-state-2">5. 
 The File Interface</a> <a href="#ref-for-snapshot-state-3">(2)</a> <a href="#ref-for-snapshot-state-4">(3)</a> <a href="#ref-for-snapshot-state-5">(4)</a></span><span><a href="#ref-for-snapshot-state-6">8. 
 Errors and Exceptions</a></span><span><a href="#ref-for-snapshot-state-7">8.1. 
@@ -1822,11 +1827,11 @@ which must be initially set to the state of the underlying storage,
 if any such underlying storage exists,
 and must be preserved through <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#structured-clone">structured clone</a>.
 Further normative definition of <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-1">snapshot state</a> can be found for <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-4">File</a></code>s.</p>
-<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="constructor" data-export="" data-lt="Blob()" id="dom-blob-blob">Constructor<span class="dfn-panel" data-deco=""><b><a href="#dom-blob-blob">#dom-blob-blob</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-blob-blob-1">4.1. 
+<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="constructor" data-export="" data-lt="Blob()" id="dom-blob-blob">Constructor<span class="dfn-panel"><b><a href="#dom-blob-blob">#dom-blob-blob</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-blob-blob-1">4.1. 
 Constructors</a> <a href="#ref-for-dom-blob-blob-2">(2)</a></span><span><a href="#ref-for-dom-blob-blob-3">4.1.1. 
-Constructor Parameters</a></span></span></dfn>, <dfn class="idl-code" data-dfn-for="Blob" data-dfn-type="constructor" data-export="" data-lt="Blob(blobParts, options)|Blob(blobParts)" id="dom-blob-blob-blobparts-options">Constructor<a class="self-link" href="#dom-blob-blob-blobparts-options"></a></dfn>(sequence&lt;<a data-link-type="idl-name" href="#typedefdef-blobpart" id="ref-for-typedefdef-blobpart-1">BlobPart</a>> <a class="idl-code" data-link-type="argument" href="#dfn-blobParts" id="ref-for-dfn-blobParts-1">blobParts</a>, optional <a data-link-type="idl-name" href="#dfn-BlobPropertyBag" id="ref-for-dfn-BlobPropertyBag-1">BlobPropertyBag</a> <dfn class="idl-code" data-dfn-for="Blob/Blob(blobParts, options)" data-dfn-type="argument" data-export="" id="dom-blob-blob-blobparts-options-options">options<a class="self-link" href="#dom-blob-blob-blobparts-options-options"></a></dfn>),
+Constructor Parameters</a></span></span></dfn>, <dfn class="idl-code" data-dfn-for="Blob" data-dfn-type="constructor" data-export="" data-lt="Blob(blobParts, options)" id="dom-blob-blob-blobparts-options">Constructor<a class="self-link" href="#dom-blob-blob-blobparts-options"></a></dfn>(sequence&lt;<a data-link-type="idl-name" href="#typedefdef-blobpart" id="ref-for-typedefdef-blobpart-1">BlobPart</a>> <a class="idl-code" data-link-type="argument" href="#dfn-blobParts" id="ref-for-dfn-blobParts-1">blobParts</a>, optional <a data-link-type="idl-name" href="#dfn-BlobPropertyBag" id="ref-for-dfn-BlobPropertyBag-1">BlobPropertyBag</a> <dfn class="idl-code" data-dfn-for="Blob/Blob(blobParts, options)" data-dfn-type="argument" data-export="" id="dom-blob-blob-blobparts-options-options">options<a class="self-link" href="#dom-blob-blob-blobparts-options-options"></a></dfn>),
 Exposed=(Window,Worker)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-lt="Blob" id="dfn-Blob">Blob<span class="dfn-panel" data-deco=""><b><a href="#dfn-Blob">#dfn-Blob</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-Blob-1">1. 
+interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-Blob">Blob<span class="dfn-panel"><b><a href="#dfn-Blob">#dfn-Blob</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-Blob-1">1. 
 Introduction</a> <a href="#ref-for-dfn-Blob-2">(2)</a> <a href="#ref-for-dfn-Blob-3">(3)</a></span><span><a href="#ref-for-dfn-Blob-4">4. 
 The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-Blob-5">(2)</a> <a href="#ref-for-dfn-Blob-6">(3)</a> <a href="#ref-for-dfn-Blob-7">(4)</a> <a href="#ref-for-dfn-Blob-8">(5)</a> <a href="#ref-for-dfn-Blob-9">(6)</a> <a href="#ref-for-dfn-Blob-10">(7)</a> <a href="#ref-for-dfn-Blob-11">(8)</a></span><span><a href="#ref-for-dfn-Blob-12">4.1. 
 Constructors</a> <a href="#ref-for-dfn-Blob-13">(2)</a> <a href="#ref-for-dfn-Blob-14">(3)</a> <a href="#ref-for-dfn-Blob-15">(4)</a> <a href="#ref-for-dfn-Blob-16">(5)</a> <a href="#ref-for-dfn-Blob-17">(6)</a></span><span><a href="#ref-for-dfn-Blob-18">4.1.1. 
@@ -1873,13 +1878,13 @@ Lifetime of Blob URLs</a> <a href="#ref-for-dfn-Blob-103">(2)</a> <a href="#ref-
 
 };
 
-dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" data-lt="BlobPropertyBag" id="dfn-BlobPropertyBag">BlobPropertyBag<span class="dfn-panel" data-deco=""><b><a href="#dfn-BlobPropertyBag">#dfn-BlobPropertyBag</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-BlobPropertyBag-1">4. 
+dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dfn-BlobPropertyBag">BlobPropertyBag<span class="dfn-panel"><b><a href="#dfn-BlobPropertyBag">#dfn-BlobPropertyBag</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-BlobPropertyBag-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-BlobPropertyBag-2">4.1.1. 
 Constructor Parameters</a></span></span></dfn> {
   DOMString <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dfn-BPtype" id="ref-for-dfn-BPtype-1">type</a> = "";
 };
 
-typedef (ArrayBuffer or <a data-link-type="idl-name" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBufferView">ArrayBufferView</a> or <a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-11">Blob</a> or DOMString) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export="" data-lt="BlobPart" id="typedefdef-blobpart">BlobPart<span class="dfn-panel" data-deco=""><b><a href="#typedefdef-blobpart">#typedefdef-blobpart</a></b><b>Referenced in:</b><span><a href="#ref-for-typedefdef-blobpart-1">4. 
+typedef (ArrayBuffer or <a data-link-type="idl-name" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBufferView">ArrayBufferView</a> or <a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-11">Blob</a> or DOMString) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export="" id="typedefdef-blobpart">BlobPart<span class="dfn-panel"><b><a href="#typedefdef-blobpart">#typedefdef-blobpart</a></b><b>Referenced in:</b><span><a href="#ref-for-typedefdef-blobpart-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-typedefdef-blobpart-2">5. 
 The File Interface</a></span></span></dfn>;
 </pre>
@@ -1905,7 +1910,7 @@ For 0 ≤ <var>i</var> &lt; <var>length</var>, repeat the following steps:</p>
       <li data-md="">
        <p>Let <var>element</var> be the <var>i</var>th element of <var>a</var>.</p>
       <li data-md="">
-       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, run the following substeps:</p>
+       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, run the following substeps:</p>
        <ol>
         <li data-md="">
          <p>Let <var>s</var> be the result of converting <var>element</var> to a sequence of Unicode characters <a data-link-type="biblio" href="#biblio-unicode">[Unicode]</a> using the algorithm for doing so in WebIDL <a data-link-type="biblio" href="#biblio-webidl">[WebIDL]</a>.</p>
@@ -1956,7 +1961,7 @@ does not return undefined for the <a data-link-type="dfn" href="https://mimesnif
    <h4 class="heading settled" data-level="4.1.1" id="constructorParams"><span class="secno">4.1.1. </span><span class="content"> Constructor Parameters</span><a class="self-link" href="#constructorParams"></a></h4>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-blob-blob" id="ref-for-dom-blob-blob-3">Blob()</a></code> constructor can be invoked with the parameters below:</p>
    <dl>
-    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/Blob(blobParts, options)" data-dfn-type="argument" data-export="" data-lt="blobParts" id="dfn-blobParts"><code>blobParts</code><span class="dfn-panel" data-deco=""><b><a href="#dfn-blobParts">#dfn-blobParts</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-blobParts-1">4. 
+    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/Blob(blobParts, options)" data-dfn-type="argument" data-export="" id="dfn-blobParts"><code>blobParts</code><span class="dfn-panel"><b><a href="#dfn-blobParts">#dfn-blobParts</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-blobParts-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-blobParts-2">4.1. 
 Constructors</a></span></span></dfn> <code>sequence</code> 
     <dd>
@@ -1969,14 +1974,14 @@ Constructors</a></span></span></dfn> <code>sequence</code>
       <li data-md="">
        <p><code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-18">Blob</a></code> elements.</p>
       <li data-md="">
-       <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> elements.</p>
+       <p><code class="idl"><a data-link-type="idl" href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> elements.</p>
      </ul>
     <dt>An <em>optional</em> <code class="idl"><a data-link-type="idl" href="#dfn-BlobPropertyBag" id="ref-for-dfn-BlobPropertyBag-2">BlobPropertyBag</a></code> 
     <dd>
      which takes one member: 
      <ul>
       <li data-md="">
-       <p><dfn class="dfn-paneled idl-code" data-dfn-for="BlobPropertyBag" data-dfn-type="dict-member" data-export="" data-lt="type" id="dfn-BPtype">type<span class="dfn-panel" data-deco=""><b><a href="#dfn-BPtype">#dfn-BPtype</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-BPtype-1">4. 
+       <p><dfn class="dfn-paneled idl-code" data-dfn-for="BlobPropertyBag" data-dfn-type="dict-member" data-export="" id="dfn-BPtype">type<span class="dfn-panel"><b><a href="#dfn-BPtype">#dfn-BPtype</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-BPtype-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-BPtype-2">4.1. 
 Constructors</a> <a href="#ref-for-dfn-BPtype-3">(2)</a></span></span></dfn>,
 the ASCII-encoded string in lower case representing the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-19">Blob</a></code>.
@@ -2009,7 +2014,7 @@ Normative conditions for this member are provided in the <a href="#constructorBl
    </div>
    <h3 class="heading settled" data-level="4.2" id="attributes-blob"><span class="secno">4.2. </span><span class="content"> Attributes</span><a class="self-link" href="#attributes-blob"></a></h3>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" data-lt="size" id="dfn-size">size<span class="dfn-panel" data-deco=""><b><a href="#dfn-size">#dfn-size</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-size-1">4. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" id="dfn-size">size<span class="dfn-panel"><b><a href="#dfn-size">#dfn-size</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-size-1">4. 
 The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-size-2">(2)</a></span><span><a href="#ref-for-dfn-size-3">4.1. 
 Constructors</a> <a href="#ref-for-dfn-size-4">(2)</a></span><span><a href="#ref-for-dfn-size-5">4.2. 
 Attributes</a></span><span><a href="#ref-for-dfn-size-6">4.3.1. 
@@ -2021,7 +2026,7 @@ Response Headers</a></span></span></dfn> , <span> of type <a data-link-type="idl
     On getting, conforming user agents must return the total number of bytes that can be read by a <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-2">FileReader</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-1">FileReaderSync</a></code> object,
     or 0 if the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-20">Blob</a></code> has no bytes to be read.
     If the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-21">Blob</a></code> has a readability state of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-2"><code>CLOSED</code></a> then <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-5">size</a></code> must return 0. 
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" data-lt="type" id="dfn-type">type<span class="dfn-panel" data-deco=""><b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-type-1">4. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" id="dfn-type">type<span class="dfn-panel"><b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-type-1">4. 
 The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-type-2">(2)</a></span><span><a href="#ref-for-dfn-type-3">4.1. 
 Constructors</a> <a href="#ref-for-dfn-type-4">(2)</a> <a href="#ref-for-dfn-type-5">(3)</a></span><span><a href="#ref-for-dfn-type-6">4.2. 
 Attributes</a> <a href="#ref-for-dfn-type-7">(2)</a> <a href="#ref-for-dfn-type-8">(3)</a></span><span><a href="#ref-for-dfn-type-9">4.3.1. 
@@ -2032,7 +2037,7 @@ The readAsDataURL() method</a> <a href="#ref-for-dfn-type-16">(2)</a></span><spa
 Determining Encoding</a> <a href="#ref-for-dfn-type-18">(2)</a></span><span><a href="#ref-for-dfn-type-19">7.6.1.3. 
 The readAsDataURL() method</a> <a href="#ref-for-dfn-type-20">(2)</a></span><span><a href="#ref-for-dfn-type-21">9.4.2. 
 Response Headers</a></span><span><a href="#ref-for-dfn-type-22">9.4.4. 
-Sample Request and Response Headers</a></span></span></dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
+Sample Request and Response Headers</a></span></span></dfn> , <span> of type <a data-link-type="idl-name" href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
     <dd>
      The ASCII-encoded string in lower case representing the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-22">Blob</a></code>.
     On getting, user agents must return the type of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-23">Blob</a></code> as an ASCII-encoded string in lower case,
@@ -2046,7 +2051,7 @@ Sample Request and Response Headers</a></span></span></dfn> , <span> of type <a 
     User agents can also determine the <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-7">type</a></code> of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-24">Blob</a></code>,
     especially if the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence is from an on-disk file;
     in this case, further normative conditions are in the <a data-link-type="dfn" href="#file-type-guidelines" id="ref-for-file-type-guidelines-1">file type guidelines</a>.</p>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" data-lt="isClosed" id="dfn-isClosed">isClosed<span class="dfn-panel" data-deco=""><b><a href="#dfn-isClosed">#dfn-isClosed</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-isClosed-1">4. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" id="dfn-isClosed">isClosed<span class="dfn-panel"><b><a href="#dfn-isClosed">#dfn-isClosed</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-isClosed-1">4. 
 The Blob Interface and Binary Data</a></span></span></dfn> , <span> of type <a data-link-type="idl-name">boolean</a>, readonly</span>
     <dd>The boolean value that indicates whether the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-25">Blob</a></code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-3"><code>CLOSED</code></a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-5">readability state</a>.
     On getting, user agents must return <code>false</code> if the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-26">Blob</a></code> is in the <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-4"><code>OPENED</code></a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-6">readability state</a>,
@@ -2055,7 +2060,7 @@ The Blob Interface and Binary Data</a></span></span></dfn> , <span> of type <a d
    <p class="note" role="note">Note: Use of the <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-8">type</a></code> attribute informs the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-1">encoding determination</a> and <a href="#processing-media-types">parsing the Content-Type header</a> when <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-1">dereferencing</a> <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-1">Blob URLs</a>.</p>
    <h3 class="heading settled" data-level="4.3" id="methodsandparams-blob"><span class="secno">4.3. </span><span class="content"> Methods and Parameters</span><a class="self-link" href="#methodsandparams-blob"></a></h3>
    <h4 class="heading settled" data-level="4.3.1" id="slice-method-algo"><span class="secno">4.3.1. </span><span class="content"> The slice method</span><a class="self-link" href="#slice-method-algo"></a></h4>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="method" data-export="" data-lt="slice(start, end, contentType), slice(start, end), slice(start), slice()" id="dfn-slice">slice()<span class="dfn-panel" data-deco=""><b><a href="#dfn-slice">#dfn-slice</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-slice-1">4. 
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="method" data-export="" data-lt="slice(start, end, contentType), slice(start, end), slice(start), slice()" id="dfn-slice">slice()<span class="dfn-panel"><b><a href="#dfn-slice">#dfn-slice</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-slice-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-slice-2">4.2. 
 Attributes</a></span><span><a href="#ref-for-dfn-slice-3">4.3.1. 
 The slice method</a> <a href="#ref-for-dfn-slice-4">(2)</a> <a href="#ref-for-dfn-slice-5">(3)</a> <a href="#ref-for-dfn-slice-6">(4)</a> <a href="#ref-for-dfn-slice-7">(5)</a> <a href="#ref-for-dfn-slice-8">(6)</a> <a href="#ref-for-dfn-slice-9">(7)</a> <a href="#ref-for-dfn-slice-10">(8)</a></span></span></dfn> method
@@ -2068,7 +2073,7 @@ It must act as follows:</p>
     <li data-md="">
      <p>Let <var>O</var> be the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-29">Blob</a></code> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> on which the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-3">slice()</a></code> method is being called.</p>
     <li data-md="">
-     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" data-lt="start" id="dfn-start">start<span class="dfn-panel" data-deco=""><b><a href="#dfn-start">#dfn-start</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-start-1">4. 
+     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" id="dfn-start">start<span class="dfn-panel"><b><a href="#dfn-start">#dfn-start</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-start-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-start-2">4.3.1. 
 The slice method</a> <a href="#ref-for-dfn-start-3">(2)</a> <a href="#ref-for-dfn-start-4">(3)</a> <a href="#ref-for-dfn-start-5">(4)</a> <a href="#ref-for-dfn-start-6">(5)</a></span></span></dfn> parameter
 is a value for the start point of a <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-4">slice()</a></code> call,
@@ -2081,7 +2086,7 @@ User agents must process <code class="idl"><a data-link-type="idl" href="#dfn-sl
       <li>Else, let <var>relativeStart</var> be <code>min(start, size)</code>. 
      </ol>
     <li data-md="">
-     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" data-lt="end" id="dfn-end">end<span class="dfn-panel" data-deco=""><b><a href="#dfn-end">#dfn-end</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-end-1">4. 
+     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" id="dfn-end">end<span class="dfn-panel"><b><a href="#dfn-end">#dfn-end</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-end-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-end-2">4.3.1. 
 The slice method</a> <a href="#ref-for-dfn-end-3">(2)</a> <a href="#ref-for-dfn-end-4">(3)</a> <a href="#ref-for-dfn-end-5">(4)</a></span></span></dfn> parameter
 is a value for the end point of a <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-6">slice()</a></code> call.
@@ -2092,7 +2097,7 @@ User agents must process <code class="idl"><a data-link-type="idl" href="#dfn-sl
       <li>Else, let <var>relativeEnd</var> be <code>min(end, size)</code>. 
      </ol>
     <li data-md="">
-     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" data-lt="contentType" id="dfn-contentTypeBlob">contentType<span class="dfn-panel" data-deco=""><b><a href="#dfn-contentTypeBlob">#dfn-contentTypeBlob</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-contentTypeBlob-1">4. 
+     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" id="dfn-contentTypeBlob">contentType<span class="dfn-panel"><b><a href="#dfn-contentTypeBlob">#dfn-contentTypeBlob</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-contentTypeBlob-1">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-contentTypeBlob-2">4.3.1. 
 The slice method</a> <a href="#ref-for-dfn-contentTypeBlob-3">(2)</a> <a href="#ref-for-dfn-contentTypeBlob-4">(3)</a> <a href="#ref-for-dfn-contentTypeBlob-5">(4)</a></span></span></dfn> parameter
 is used to set the ASCII-encoded string in lower case representing the media type of the Blob.
@@ -2158,7 +2163,7 @@ then set <var>relativeContentType</var> to the empty string and return from thes
 <span class="p">}</span></pre>
    </div>
    <h4 class="heading settled" data-level="4.3.2" id="close-method"><span class="secno">4.3.2. </span><span class="content"> The close method</span><a class="self-link" href="#close-method"></a></h4>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="method" data-export="" data-lt="close()" id="dfn-close">close()<span class="dfn-panel" data-deco=""><b><a href="#dfn-close">#dfn-close</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-close-1">4. 
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="method" data-export="" id="dfn-close">close()<span class="dfn-panel"><b><a href="#dfn-close">#dfn-close</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-close-1">4. 
 The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-close-2">(2)</a></span><span><a href="#ref-for-dfn-close-3">4.2. 
 Attributes</a></span><span><a href="#ref-for-dfn-close-4">7.6.1.2. 
 The readAsText() method</a></span><span><a href="#ref-for-dfn-close-5">7.6.1.3. 
@@ -2188,7 +2193,7 @@ User agents may use modification time stamps and other mechanisms to maintain <a
 but this is left as an implementation detail.</p>
    <p>When a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-12">File</a></code> object refers to a file on disk,
 user agents must return the <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-11">type</a></code> of that file,
-and must follow the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="file type guidelines" id="file-type-guidelines">file type guidelines<span class="dfn-panel" data-deco=""><b><a href="#file-type-guidelines">#file-type-guidelines</a></b><b>Referenced in:</b><span><a href="#ref-for-file-type-guidelines-1">4.2. 
+and must follow the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="file-type-guidelines">file type guidelines<span class="dfn-panel"><b><a href="#file-type-guidelines">#file-type-guidelines</a></b><b>Referenced in:</b><span><a href="#ref-for-file-type-guidelines-1">4.2. 
 Attributes</a></span></span></dfn> below:</p>
    <ul>
     <li data-md="">
@@ -2201,13 +2206,13 @@ or the empty string – 0 bytes – if the type cannot be determined.</p>
     <li data-md="">
      <p>User agents must not attempt heuristic determination of encoding,
 including statistical methods.</p>
-<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="File" data-dfn-type="constructor" data-export="" data-lt="File(fileBits, fileName, options)|File(fileBits, fileName)" id="dom-file-file">Constructor<span class="dfn-panel" data-deco=""><b><a href="#dom-file-file">#dom-file-file</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-file-file-1">5.1. 
+<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="File" data-dfn-type="constructor" data-export="" data-lt="File(fileBits, fileName, options)" id="dom-file-file">Constructor<span class="dfn-panel"><b><a href="#dom-file-file">#dom-file-file</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-file-file-1">5.1. 
 Constructor</a></span><span><a href="#ref-for-dom-file-file-2">5.1.1. 
 Constructor Parameters</a></span></span></dfn>(sequence&lt;<a data-link-type="idl-name" href="#typedefdef-blobpart" id="ref-for-typedefdef-blobpart-2">BlobPart</a>> <a class="idl-code" data-link-type="argument" href="#dfn-fileBits" id="ref-for-dfn-fileBits-1">fileBits</a>,
             [EnsureUTF16] DOMString <a class="idl-code" data-link-type="argument" href="#dfn-fileName" id="ref-for-dfn-fileName-1">fileName</a>,
             optional <a data-link-type="idl-name" href="#dfn-FilePropertyBag" id="ref-for-dfn-FilePropertyBag-1">FilePropertyBag</a> <dfn class="idl-code" data-dfn-for="File/File(fileBits, fileName, options)" data-dfn-type="argument" data-export="" id="dom-file-file-filebits-filename-options-options">options<a class="self-link" href="#dom-file-file-filebits-filename-options-options"></a></dfn>),
 Exposed=(Window,Worker)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-lt="File" id="dfn-file">File<span class="dfn-panel" data-deco=""><b><a href="#dfn-file">#dfn-file</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-file-1">1. 
+interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-file">File<span class="dfn-panel"><b><a href="#dfn-file">#dfn-file</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-file-1">1. 
 Introduction</a> <a href="#ref-for-dfn-file-2">(2)</a> <a href="#ref-for-dfn-file-3">(3)</a></span><span><a href="#ref-for-dfn-file-4">4. 
 The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-file-5">4.3.1. 
 The slice method</a> <a href="#ref-for-dfn-file-6">(2)</a></span><span><a href="#ref-for-dfn-file-7">5. 
@@ -2234,7 +2239,7 @@ Requirements and Use Cases</a></span></span></dfn> : <a data-link-type="idl-name
   readonly attribute long long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="long long " href="#dfn-lastModified" id="ref-for-dfn-lastModified-1">lastModified</a>;
 };
 
-dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" data-lt="FilePropertyBag" id="dfn-FilePropertyBag">FilePropertyBag<span class="dfn-panel" data-deco=""><b><a href="#dfn-FilePropertyBag">#dfn-FilePropertyBag</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-FilePropertyBag-1">5. 
+dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dfn-FilePropertyBag">FilePropertyBag<span class="dfn-panel"><b><a href="#dfn-FilePropertyBag">#dfn-FilePropertyBag</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-FilePropertyBag-1">5. 
 The File Interface</a></span><span><a href="#ref-for-dfn-FilePropertyBag-2">5.1. 
 Constructor</a></span><span><a href="#ref-for-dfn-FilePropertyBag-3">5.1.1. 
 Constructor Parameters</a></span></span></dfn> {
@@ -2258,7 +2263,7 @@ For 0 ≤ i &lt; <var>length</var>, repeat the following steps:</p>
       <li data-md="">
        <p>Let <var>element</var> be the <var>i</var>’th element of <var>a</var>.</p>
       <li data-md="">
-       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, run the following substeps:</p>
+       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, run the following substeps:</p>
        <ol>
         <li data-md="">
          <p>Let <var>s</var> be the result of converting <var>element</var> to a sequence of Unicode characters <a data-link-type="biblio" href="#biblio-unicode">[Unicode]</a> using the algorithm for doing so in WebIDL <a data-link-type="biblio" href="#biblio-webidl">[WebIDL]</a>.</p>
@@ -2331,7 +2336,7 @@ does not return undefined for the <a data-link-type="dfn" href="https://mimesnif
    <h4 class="heading settled" data-level="5.1.1" id="file-constructor-params"><span class="secno">5.1.1. </span><span class="content"> Constructor Parameters</span><a class="self-link" href="#file-constructor-params"></a></h4>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-file-file" id="ref-for-dom-file-file-2">File()</a></code> constructor can be invoked with the parameters below:</p>
    <dl>
-    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="File/File(fileBits, fileName, options)" data-dfn-type="argument" data-export="" data-lt="fileBits" id="dfn-fileBits"><code>fileBits</code><span class="dfn-panel" data-deco=""><b><a href="#dfn-fileBits">#dfn-fileBits</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-fileBits-1">5. 
+    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="File/File(fileBits, fileName, options)" data-dfn-type="argument" data-export="" id="dfn-fileBits"><code>fileBits</code><span class="dfn-panel"><b><a href="#dfn-fileBits">#dfn-fileBits</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-fileBits-1">5. 
 The File Interface</a></span><span><a href="#ref-for-dfn-fileBits-2">5.1. 
 Constructor</a></span></span></dfn> <code>sequence</code> 
     <dd>
@@ -2344,25 +2349,25 @@ Constructor</a></span></span></dfn> <code>sequence</code>
       <li data-md="">
        <p><code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-42">Blob</a></code> elements, which includes <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-16">File</a></code> elements.</p>
       <li data-md="">
-       <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> elements.</p>
+       <p><code class="idl"><a data-link-type="idl" href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> elements.</p>
      </ul>
-    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="File/File(fileBits, fileName, options)" data-dfn-type="argument" data-export="" data-lt="fileName" id="dfn-fileName"><code>fileName</code><span class="dfn-panel" data-deco=""><b><a href="#dfn-fileName">#dfn-fileName</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-fileName-1">5. 
+    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="File/File(fileBits, fileName, options)" data-dfn-type="argument" data-export="" id="dfn-fileName"><code>fileName</code><span class="dfn-panel"><b><a href="#dfn-fileName">#dfn-fileName</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-fileName-1">5. 
 The File Interface</a></span><span><a href="#ref-for-dfn-fileName-2">5.1. 
 Constructor</a> <a href="#ref-for-dfn-fileName-3">(2)</a></span></span></dfn> parameter 
-    <dd>A <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> parameter representing the name of the file;
+    <dd>A <code class="idl"><a data-link-type="idl" href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> parameter representing the name of the file;
     normative conditions for this constructor parameter can be found in <a href="#file-constructor">§5.1 Constructor</a>. 
     <dt id="def-Properties"><a class="self-link" href="#def-Properties"></a>An optional <code class="idl"><a data-link-type="idl" href="#dfn-FilePropertyBag" id="ref-for-dfn-FilePropertyBag-3">FilePropertyBag</a></code> dictionary 
     <dd>
      which takes the following members: 
      <ul>
       <li data-md="">
-       <p>An optional <dfn class="dfn-paneled idl-code" data-dfn-for="FilePropertyBag" data-dfn-type="dict-member" data-export="" data-lt="type" id="dfn-FPtype">type<span class="dfn-panel" data-deco=""><b><a href="#dfn-FPtype">#dfn-FPtype</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-FPtype-1">5. 
+       <p>An optional <dfn class="dfn-paneled idl-code" data-dfn-for="FilePropertyBag" data-dfn-type="dict-member" data-export="" id="dfn-FPtype">type<span class="dfn-panel"><b><a href="#dfn-FPtype">#dfn-FPtype</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-FPtype-1">5. 
 The File Interface</a></span><span><a href="#ref-for-dfn-FPtype-2">5.1. 
 Constructor</a> <a href="#ref-for-dfn-FPtype-3">(2)</a></span></span></dfn> member;
 the ASCII-encoded string in lower case representing the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-17">File</a></code>.
 Normative conditions for this member are provided in <a href="#file-constructor">§5.1 Constructor</a>.</p>
       <li data-md="">
-       <p>An optional <dfn class="dfn-paneled idl-code" data-dfn-for="FilePropertyBag" data-dfn-type="dict-member" data-export="" data-lt="lastModified" id="dfn-FPdate">lastModified<span class="dfn-panel" data-deco=""><b><a href="#dfn-FPdate">#dfn-FPdate</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-FPdate-1">5. 
+       <p>An optional <dfn class="dfn-paneled idl-code" data-dfn-for="FilePropertyBag" data-dfn-type="dict-member" data-export="" id="dfn-FPdate">lastModified<span class="dfn-panel"><b><a href="#dfn-FPdate">#dfn-FPdate</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-FPdate-1">5. 
 The File Interface</a></span><span><a href="#ref-for-dfn-FPdate-2">5.1. 
 Constructor</a> <a href="#ref-for-dfn-FPdate-3">(2)</a> <a href="#ref-for-dfn-FPdate-4">(3)</a></span></span></dfn> member,
 which must be a <code>long long</code>;
@@ -2371,10 +2376,10 @@ normative conditions for this member are provided in <a href="#file-constructor"
    </dl>
    <h3 class="heading settled" data-level="5.2" id="file-attrs"><span class="secno">5.2. </span><span class="content"> Attributes</span><a class="self-link" href="#file-attrs"></a></h3>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="File" data-dfn-type="attribute" data-export="" data-lt="name" id="dfn-name">name<span class="dfn-panel" data-deco=""><b><a href="#dfn-name">#dfn-name</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-name-1">5. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="File" data-dfn-type="attribute" data-export="" id="dfn-name">name<span class="dfn-panel"><b><a href="#dfn-name">#dfn-name</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-name-1">5. 
 The File Interface</a> <a href="#ref-for-dfn-name-2">(2)</a></span><span><a href="#ref-for-dfn-name-3">5.1. 
 Constructor</a></span><span><a href="#ref-for-dfn-name-4">9.4.2. 
-Response Headers</a> <a href="#ref-for-dfn-name-5">(2)</a> <a href="#ref-for-dfn-name-6">(3)</a></span></span></dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
+Response Headers</a> <a href="#ref-for-dfn-name-5">(2)</a> <a href="#ref-for-dfn-name-6">(3)</a></span></span></dfn> , <span> of type <a data-link-type="idl-name" href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
     <dd>The name of the file.
     On getting, this must return the name of the file as a string.
     There are numerous file name variations and conventions used by different underlying OS file systems;
@@ -2383,7 +2388,7 @@ Response Headers</a> <a href="#ref-for-dfn-name-5">(2)</a> <a href="#ref-for-dfn
     they must return the empty string.
     If a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-18">File</a></code> object is created using a constructor,
     further normative conditions for this attribute are found in <a href="#file-constructor">§5.1 Constructor</a>. 
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="File" data-dfn-type="attribute" data-export="" data-lt="lastModified" id="dfn-lastModified">lastModified<span class="dfn-panel" data-deco=""><b><a href="#dfn-lastModified">#dfn-lastModified</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-lastModified-1">5. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="File" data-dfn-type="attribute" data-export="" id="dfn-lastModified">lastModified<span class="dfn-panel"><b><a href="#dfn-lastModified">#dfn-lastModified</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-lastModified-1">5. 
 The File Interface</a></span><span><a href="#ref-for-dfn-lastModified-2">5.1. 
 Constructor</a></span></span></dfn> , <span> of type <a data-link-type="idl-name">long long</a>, readonly</span>
     <dd>The last modified date of the file.
@@ -2428,7 +2433,7 @@ In particular, this means syntax of the sort <code class="lang-javascript highli
 most other programmatic use of <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-3">FileList</a></code> is unlikely to be affected by the eventual migration to an <code class="idl"><a data-link-type="idl">Array</a></code> type.</p>
    <p>This interface is a list of <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-22">File</a></code> objects.</p>
 <pre class="idl def">[Exposed=(Window,Worker)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-lt="FileList" id="dfn-filelist">FileList<span class="dfn-panel" data-deco=""><b><a href="#dfn-filelist">#dfn-filelist</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-filelist-1">5.2. 
+interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-filelist">FileList<span class="dfn-panel"><b><a href="#dfn-filelist">#dfn-filelist</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-filelist-1">5.2. 
 Attributes</a></span><span><a href="#ref-for-dfn-filelist-2">6. 
 The FileList Interface</a> <a href="#ref-for-dfn-filelist-3">(2)</a></span><span><a href="#ref-for-dfn-filelist-4">6.1. 
 Attributes</a></span><span><a href="#ref-for-dfn-filelist-5">6.2. 
@@ -2456,20 +2461,20 @@ Security Considerations</a></span></span></dfn> {
    </div>
    <h3 class="heading settled" data-level="6.1" id="attributes-filelist"><span class="secno">6.1. </span><span class="content"> Attributes</span><a class="self-link" href="#attributes-filelist"></a></h3>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileList" data-dfn-type="attribute" data-export="" data-lt="length" id="dfn-length">length<span class="dfn-panel" data-deco=""><b><a href="#dfn-length">#dfn-length</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-length-1">6. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileList" data-dfn-type="attribute" data-export="" id="dfn-length">length<span class="dfn-panel"><b><a href="#dfn-length">#dfn-length</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-length-1">6. 
 The FileList Interface</a></span></span></dfn> , <span> of type <a data-link-type="idl-name">unsigned long</a>, readonly</span>
     <dd>must return the number of files in the <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-4">FileList</a></code> object.
       If there are no files, this attribute must return 0. 
    </dl>
    <h3 class="heading settled" data-level="6.2" id="filelist-methods-params"><span class="secno">6.2. </span><span class="content"> Methods and Parameters</span><a class="self-link" href="#filelist-methods-params"></a></h3>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileList" data-dfn-type="method" data-export="" data-lt="item(index)" id="dfn-item">item(index)<span class="dfn-panel" data-deco=""><b><a href="#dfn-item">#dfn-item</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-item-1">6. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileList" data-dfn-type="method" data-export="" id="dfn-item">item(index)<span class="dfn-panel"><b><a href="#dfn-item">#dfn-item</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-item-1">6. 
 The FileList Interface</a></span></span></dfn> 
     <dd>
      must return the <em>indexth</em> <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-24">File</a></code> object in the <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-5">FileList</a></code>.
     If there is no <em>indexth</em> <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-25">File</a></code> object in the <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-6">FileList</a></code>,
     then this method must return <code>null</code>. 
-     <p><dfn class="dfn-paneled idl-code" data-dfn-for="FileList/item(index)" data-dfn-type="argument" data-export="" data-lt="index" id="dfn-index">index<span class="dfn-panel" data-deco=""><b><a href="#dfn-index">#dfn-index</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-index-1">6. 
+     <p><dfn class="dfn-paneled idl-code" data-dfn-for="FileList/item(index)" data-dfn-type="argument" data-export="" id="dfn-index">index<span class="dfn-panel"><b><a href="#dfn-index">#dfn-index</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-index-1">6. 
 The FileList Interface</a></span></span></dfn> must be treated by user agents
     as value for the position of a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-26">File</a></code> object in the <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-7">FileList</a></code>,
     with 0 representing the first file. <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-supported-property-indices">Supported property indices</a> are the numbers in the range zero
@@ -2488,7 +2493,7 @@ and reads <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">
 which is returned as the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-4">read operation</a>,
 or else fails along with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-1">failure reason</a>.
 Methods in this specification invoke the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-5">read operation</a> with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-2">synchronous flag</a> either set or unset.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="synchronous flag" data-noexport="" id="synchronousFlag">synchronous flag<span class="dfn-panel" data-deco=""><b><a href="#synchronousFlag">#synchronousFlag</a></b><b>Referenced in:</b><span><a href="#ref-for-synchronousFlag-1">7.1. 
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="synchronousFlag">synchronous flag<span class="dfn-panel"><b><a href="#synchronousFlag">#synchronousFlag</a></b><b>Referenced in:</b><span><a href="#ref-for-synchronousFlag-1">7.1. 
 The Read Operation</a> <a href="#ref-for-synchronousFlag-2">(2)</a> <a href="#ref-for-synchronousFlag-3">(3)</a> <a href="#ref-for-synchronousFlag-4">(4)</a> <a href="#ref-for-synchronousFlag-5">(5)</a> <a href="#ref-for-synchronousFlag-6">(6)</a> <a href="#ref-for-synchronousFlag-7">(7)</a> <a href="#ref-for-synchronousFlag-8">(8)</a></span><span><a href="#ref-for-synchronousFlag-9">7.6.1.2. 
 The readAsText() method</a></span><span><a href="#ref-for-synchronousFlag-10">7.6.1.3. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-synchronousFlag-11">7.6.1.4. 
@@ -2498,7 +2503,7 @@ Methods may set it.
 If it is set,
 the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-6">read operation</a> takes place synchronously.
 Otherwise, it takes place asynchronously.</p>
-   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="read operation" data-noexport="" id="readOperation">read operation<span class="dfn-panel" data-deco=""><b><a href="#readOperation">#readOperation</a></b><b>Referenced in:</b><span><a href="#ref-for-readOperation-1">4.3.1. 
+   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="readOperation">read operation<span class="dfn-panel"><b><a href="#readOperation">#readOperation</a></b><b>Referenced in:</b><span><a href="#ref-for-readOperation-1">4.3.1. 
 The slice method</a></span><span><a href="#ref-for-readOperation-2">5.2. 
 Attributes</a></span><span><a href="#ref-for-readOperation-3">7.1. 
 The Read Operation</a> <a href="#ref-for-readOperation-4">(2)</a> <a href="#ref-for-readOperation-5">(3)</a> <a href="#ref-for-readOperation-6">(4)</a> <a href="#ref-for-readOperation-7">(5)</a> <a href="#ref-for-readOperation-8">(6)</a> <a href="#ref-for-readOperation-9">(7)</a> <a href="#ref-for-readOperation-10">(8)</a> <a href="#ref-for-readOperation-11">(9)</a> <a href="#ref-for-readOperation-12">(10)</a></span><span><a href="#ref-for-readOperation-13">7.3.4.2. 
@@ -2561,7 +2566,7 @@ Reset <var>bytes</var> to the empty byte sequence
 and continue reading <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s as above.</p>
      </ol>
    </ol>
-   <p>To perform an <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="annotated task read operation" data-noexport="" id="task-read-operation">annotated task read operation<span class="dfn-panel" data-deco=""><b><a href="#task-read-operation">#task-read-operation</a></b><b>Referenced in:</b><span><a href="#ref-for-task-read-operation-1">7.3.4.2. 
+   <p>To perform an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="task-read-operation">annotated task read operation<span class="dfn-panel"><b><a href="#task-read-operation">#task-read-operation</a></b><b>Referenced in:</b><span><a href="#ref-for-task-read-operation-1">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-task-read-operation-2">7.3.4.3. 
 The readAsText() method</a></span><span><a href="#ref-for-task-read-operation-3">7.3.4.4. 
 The readAsArrayBuffer() method</a></span></span></dfn> on a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-48">Blob</a></code> <var>b</var>,
@@ -2571,20 +2576,20 @@ perform the steps below:</p>
      <p>Perform a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-8">read operation</a> on <var>b</var> with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-8">synchronous flag</a> unset,
 along with the additional steps below.</p>
     <li data-md="">
-     <p>If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-9">read operation</a> terminates with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-6">failure reason</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="process read error" data-noexport="" id="process-read-error">process read error<span class="dfn-panel" data-deco=""><b><a href="#process-read-error">#process-read-error</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-error-1">7.3.4.2. 
+     <p>If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-9">read operation</a> terminates with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-6">failure reason</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read-error">process read error<span class="dfn-panel"><b><a href="#process-read-error">#process-read-error</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-error-1">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-process-read-error-2">7.3.4.3. 
 The readAsText() method</a></span><span><a href="#ref-for-process-read-error-3">7.3.4.4. 
 The readAsArrayBuffer() method</a></span><span><a href="#ref-for-process-read-error-4">7.3.4.5. 
 Error Steps</a></span><span><a href="#ref-for-process-read-error-5">8.1. 
 Throwing an Exception or Returning an Error</a></span></span></dfn> with the <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-7">failure reason</a> and terminate this algorithm.</p>
     <li data-md="">
-     <p>When the first <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> is being pushed to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> during the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-10">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="process read" data-noexport="" id="process-read">process read<span class="dfn-panel" data-deco=""><b><a href="#process-read">#process-read</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-1">7.3.4.2. 
+     <p>When the first <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> is being pushed to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> during the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-10">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read">process read<span class="dfn-panel"><b><a href="#process-read">#process-read</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-1">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-process-read-2">7.3.4.3. 
 The readAsText() method</a></span><span><a href="#ref-for-process-read-3">7.3.4.4. 
 The readAsArrayBuffer() method</a></span></span></dfn>.</p>
     <li data-md="">
      <p>Once the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> from the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-11">read operation</a> has at least one <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> read into it,
-or there are no <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s left to read from <var>b</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="process read data" data-noexport="" id="process-read-data">process read data<span class="dfn-panel" data-deco=""><b><a href="#process-read-data">#process-read-data</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-data-1">7.1. 
+or there are no <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s left to read from <var>b</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read-data">process read data<span class="dfn-panel"><b><a href="#process-read-data">#process-read-data</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-data-1">7.1. 
 The Read Operation</a></span><span><a href="#ref-for-process-read-data-2">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-process-read-data-3">7.3.4.3. 
 The readAsText() method</a></span><span><a href="#ref-for-process-read-data-4">7.3.4.4. 
@@ -2592,14 +2597,14 @@ The readAsArrayBuffer() method</a></span></span></dfn>.
 Keep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queuing tasks</a> to <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-1">process read data</a> for every <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> read or every 50ms,
 whichever is <em>least frequent</em>.</p>
     <li data-md="">
-     <p>When all of the <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s from <var>b</var> are read into the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> from the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-12">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="process read EOF" data-noexport="" id="process-read-EOF">process read EOF<span class="dfn-panel" data-deco=""><b><a href="#process-read-EOF">#process-read-EOF</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-EOF-1">7.3.4.2. 
+     <p>When all of the <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s from <var>b</var> are read into the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> from the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-12">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read-EOF">process read EOF<span class="dfn-panel"><b><a href="#process-read-EOF">#process-read-EOF</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-EOF-1">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-process-read-EOF-2">7.3.4.3. 
 The readAsText() method</a></span><span><a href="#ref-for-process-read-EOF-3">7.3.4.4. 
 The readAsArrayBuffer() method</a></span></span></dfn>.</p>
    </ol>
    <p>Use the <a data-link-type="dfn" href="#fileReadingTaskSource" id="ref-for-fileReadingTaskSource-1">file reading task source</a> for all these tasks.</p>
    <h3 class="heading settled" data-level="7.2" id="blobreader-task-source"><span class="secno">7.2. </span><span class="content"> The File Reading Task Source</span><a class="self-link" href="#blobreader-task-source"></a></h3>
-   <p>This specification defines a new generic <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="file reading task source" data-noexport="" id="fileReadingTaskSource">file reading task source<span class="dfn-panel" data-deco=""><b><a href="#fileReadingTaskSource">#fileReadingTaskSource</a></b><b>Referenced in:</b><span><a href="#ref-for-fileReadingTaskSource-1">7.1. 
+   <p>This specification defines a new generic <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fileReadingTaskSource">file reading task source<span class="dfn-panel"><b><a href="#fileReadingTaskSource">#fileReadingTaskSource</a></b><b>Referenced in:</b><span><a href="#ref-for-fileReadingTaskSource-1">7.1. 
 The Read Operation</a></span><span><a href="#ref-for-fileReadingTaskSource-2">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-fileReadingTaskSource-3">7.3.4.3. 
 The readAsText() method</a></span><span><a href="#ref-for-fileReadingTaskSource-4">7.3.4.4. 
@@ -2609,9 +2614,9 @@ which is used for all <a data-link-type="dfn" href="https://html.spec.whatwg.org
 to read byte sequences associated with <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-49">Blob</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-29">File</a></code> objects.
 It is to be used for features that trigger in response to asynchronously reading binary data.</p>
    <h3 class="heading settled" data-level="7.3" id="APIASynch"><span class="secno">7.3. </span><span class="content"> The FileReader API</span><a class="self-link" href="#APIASynch"></a></h3>
-<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="constructor" data-export="" data-lt="FileReader()" id="dom-filereader-filereader">Constructor<span class="dfn-panel" data-deco=""><b><a href="#dom-filereader-filereader">#dom-filereader-filereader</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-filereader-filereader-1">7.3.1. 
+<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="constructor" data-export="" data-lt="FileReader()" id="dom-filereader-filereader">Constructor<span class="dfn-panel"><b><a href="#dom-filereader-filereader">#dom-filereader-filereader</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-filereader-filereader-1">7.3.1. 
 Constructor</a></span></span></dfn>, Exposed=(Window,Worker)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-lt="FileReader" id="dfn-filereader">FileReader<span class="dfn-panel" data-deco=""><b><a href="#dfn-filereader">#dfn-filereader</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-filereader-1">1. 
+interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-filereader">FileReader<span class="dfn-panel"><b><a href="#dfn-filereader">#dfn-filereader</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-filereader-1">1. 
 Introduction</a></span><span><a href="#ref-for-dfn-filereader-2">4.2. 
 Attributes</a></span><span><a href="#ref-for-dfn-filereader-3">7.3.1. 
 Constructor</a> <a href="#ref-for-dfn-filereader-4">(2)</a></span><span><a href="#ref-for-dfn-filereader-5">7.3.2. 
@@ -2671,33 +2676,33 @@ that user agents must support on <code class="idl"><a data-link-type="idl" href=
       <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event type</a> 
     <tbody>
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onloadstart" id="dfn-onloadstart">onloadstart<span class="dfn-panel" data-deco=""><b><a href="#dfn-onloadstart">#dfn-onloadstart</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onloadstart-1">7.3. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onloadstart">onloadstart<span class="dfn-panel"><b><a href="#dfn-onloadstart">#dfn-onloadstart</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onloadstart-1">7.3. 
 The FileReader API</a></span></span></dfn> 
       <td><code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-1">loadstart</a></code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onprogress" id="dfn-onprogress">onprogress<span class="dfn-panel" data-deco=""><b><a href="#dfn-onprogress">#dfn-onprogress</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onprogress-1">7.3. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onprogress">onprogress<span class="dfn-panel"><b><a href="#dfn-onprogress">#dfn-onprogress</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onprogress-1">7.3. 
 The FileReader API</a></span></span></dfn> 
       <td><code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-1">progress</a></code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onabort" id="dfn-onabort">onabort<span class="dfn-panel" data-deco=""><b><a href="#dfn-onabort">#dfn-onabort</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onabort-1">7.3. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onabort">onabort<span class="dfn-panel"><b><a href="#dfn-onabort">#dfn-onabort</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onabort-1">7.3. 
 The FileReader API</a></span></span></dfn> 
       <td><code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-1">abort</a></code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onerror" id="dfn-onerror">onerror<span class="dfn-panel" data-deco=""><b><a href="#dfn-onerror">#dfn-onerror</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onerror-1">7.3. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onerror">onerror<span class="dfn-panel"><b><a href="#dfn-onerror">#dfn-onerror</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onerror-1">7.3. 
 The FileReader API</a></span></span></dfn> 
       <td><code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-2">error</a></code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onload" id="dfn-onload">onload<span class="dfn-panel" data-deco=""><b><a href="#dfn-onload">#dfn-onload</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onload-1">7.3. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onload">onload<span class="dfn-panel"><b><a href="#dfn-onload">#dfn-onload</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onload-1">7.3. 
 The FileReader API</a></span></span></dfn> 
       <td><code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-1">load</a></code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onloadend" id="dfn-onloadend">onloadend<span class="dfn-panel" data-deco=""><b><a href="#dfn-onloadend">#dfn-onloadend</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onloadend-1">7.3. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onloadend">onloadend<span class="dfn-panel"><b><a href="#dfn-onloadend">#dfn-onloadend</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onloadend-1">7.3. 
 The FileReader API</a></span></span></dfn> 
       <td><code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-1">loadend</a></code> 
    </table>
    <h4 class="heading settled" data-level="7.3.3" id="blobreader-state"><span class="secno">7.3.3. </span><span class="content"> FileReader States</span><a class="self-link" href="#blobreader-state"></a></h4>
    <p>The <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-6">FileReader</a></code> object can be in one of 3 states.
-The <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="readyState" id="dfn-readyState">readyState<span class="dfn-panel" data-deco=""><b><a href="#dfn-readyState">#dfn-readyState</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readyState-1">7.3. 
+The <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-readyState">readyState<span class="dfn-panel"><b><a href="#dfn-readyState">#dfn-readyState</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readyState-1">7.3. 
 The FileReader API</a></span><span><a href="#ref-for-dfn-readyState-2">7.3.3. 
 FileReader States</a></span><span><a href="#ref-for-dfn-readyState-3">7.3.4. 
 Reading a File or Blob</a></span><span><a href="#ref-for-dfn-readyState-4">7.3.4.1. 
@@ -2714,7 +2719,7 @@ on getting,
 must return the current state,
 which must be one of the following values:</p>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" data-lt="EMPTY" id="dfn-empty">EMPTY<span class="dfn-panel" data-deco=""><b><a href="#dfn-empty">#dfn-empty</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-empty-1">7.3. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" id="dfn-empty">EMPTY<span class="dfn-panel"><b><a href="#dfn-empty">#dfn-empty</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-empty-1">7.3. 
 The FileReader API</a></span><span><a href="#ref-for-dfn-empty-2">7.3.4.1. 
 The result attribute</a></span><span><a href="#ref-for-dfn-empty-3">7.3.4.6. 
 The abort() method</a></span></span></dfn> (numeric value 0) 
@@ -2723,7 +2728,7 @@ The abort() method</a></span></span></dfn> (numeric value 0)
     None of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-2">read methods</a> have been called.
     This is the default state of a newly minted <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-8">FileReader</a></code> object,
     until one of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-3">read methods</a> have been called on it. 
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" data-lt="LOADING" id="dfn-loading">LOADING<span class="dfn-panel" data-deco=""><b><a href="#dfn-loading">#dfn-loading</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-loading-1">7.3. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" id="dfn-loading">LOADING<span class="dfn-panel"><b><a href="#dfn-loading">#dfn-loading</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-loading-1">7.3. 
 The FileReader API</a></span><span><a href="#ref-for-dfn-loading-2">7.3.4. 
 Reading a File or Blob</a></span><span><a href="#ref-for-dfn-loading-3">7.3.4.2. 
 The readAsDataURL() method</a> <a href="#ref-for-dfn-loading-4">(2)</a> <a href="#ref-for-dfn-loading-5">(3)</a> <a href="#ref-for-dfn-loading-6">(4)</a></span><span><a href="#ref-for-dfn-loading-7">7.3.4.3. 
@@ -2737,7 +2742,7 @@ The readAsArrayBuffer() method</a></span></span></dfn> (numeric value 1)
     <dd>A <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-30">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-53">Blob</a></code> is being read.
     One of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-4">read methods</a> is being processed,
     and no error has occurred during the read. 
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" data-lt="DONE" id="dfn-done">DONE<span class="dfn-panel" data-deco=""><b><a href="#dfn-done">#dfn-done</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-done-1">7.3. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" id="dfn-done">DONE<span class="dfn-panel"><b><a href="#dfn-done">#dfn-done</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-done-1">7.3. 
 The FileReader API</a></span><span><a href="#ref-for-dfn-done-2">7.3.3. 
 FileReader States</a></span><span><a href="#ref-for-dfn-done-3">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-done-4">7.3.4.3. 
@@ -2752,7 +2757,7 @@ The abort() method</a> <a href="#ref-for-dfn-done-8">(2)</a></span></span></dfn>
     If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-2">readyState</a></code> is set to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-2">DONE</a></code> it means at least one of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-5">read methods</a> have been called on this <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-10">FileReader</a></code>. 
    </dl>
    <h4 class="heading settled" data-level="7.3.4" id="reading-a-file"><span class="secno">7.3.4. </span><span class="content"> Reading a File or Blob</span><a class="self-link" href="#reading-a-file"></a></h4>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-11">FileReader</a></code> interface makes available three <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="asynchronous read method" data-noexport="" id="asynchronous-read-methods">asynchronous read methods<span class="dfn-panel" data-deco=""><b><a href="#asynchronous-read-methods">#asynchronous-read-methods</a></b><b>Referenced in:</b><span><a href="#ref-for-asynchronous-read-methods-1">7.3.4.7. 
+   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-11">FileReader</a></code> interface makes available three <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="asynchronous read method" data-noexport="" id="asynchronous-read-methods">asynchronous read methods<span class="dfn-panel"><b><a href="#asynchronous-read-methods">#asynchronous-read-methods</a></b><b>Referenced in:</b><span><a href="#ref-for-asynchronous-read-methods-1">7.3.4.7. 
 Blob Parameters</a></span><span><a href="#ref-for-asynchronous-read-methods-2">8. 
 Errors and Exceptions</a></span></span></dfn>—<wbr><code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-2">readAsArrayBuffer()</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-2">readAsText()</a></code>, and <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-2">readAsDataURL()</a></code>,
 which read files into memory.
@@ -2760,7 +2765,7 @@ If multiple concurrent read methods are called on the same <code class="idl"><a 
 user agents must throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> on any of the read methods that occur
 when <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-3">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-2">LOADING</a></code>.</p>
    <p>(<code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-3">FileReaderSync</a></code> makes available three <a data-link-type="dfn" href="#read-method-sync" id="ref-for-read-method-sync-1">synchronous read methods</a>.
-  Collectively, the sync and async read methods of <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-13">FileReader</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-4">FileReaderSync</a></code> are referred to as just <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="read method" data-noexport="" id="read-method">read methods<span class="dfn-panel" data-deco=""><b><a href="#read-method">#read-method</a></b><b>Referenced in:</b><span><a href="#ref-for-read-method-1">3. 
+  Collectively, the sync and async read methods of <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-13">FileReader</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-4">FileReaderSync</a></code> are referred to as just <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="read method" data-noexport="" id="read-method">read methods<span class="dfn-panel"><b><a href="#read-method">#read-method</a></b><b>Referenced in:</b><span><a href="#ref-for-read-method-1">3. 
 Terminology and Algorithms</a></span><span><a href="#ref-for-read-method-2">7.3.3. 
 FileReader States</a> <a href="#ref-for-read-method-3">(2)</a> <a href="#ref-for-read-method-4">(3)</a> <a href="#ref-for-read-method-5">(4)</a></span><span><a href="#ref-for-read-method-6">7.3.4.1. 
 The result attribute</a> <a href="#ref-for-read-method-7">(2)</a> <a href="#ref-for-read-method-8">(3)</a> <a href="#ref-for-read-method-9">(4)</a> <a href="#ref-for-read-method-10">(5)</a></span><span><a href="#ref-for-read-method-11">7.3.4.5. 
@@ -2769,7 +2774,7 @@ The abort() method</a></span><span><a href="#ref-for-read-method-13">7.4.
 Determining Encoding</a></span><span><a href="#ref-for-read-method-14">7.5.2. 
 Summary of Event Invariants</a> <a href="#ref-for-read-method-15">(2)</a> <a href="#ref-for-read-method-16">(3)</a></span></span></dfn>.)</p>
    <h5 class="heading settled" data-level="7.3.4.1" id="filedata-attr"><span class="secno">7.3.4.1. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-2">result</a></code> attribute</span><a class="self-link" href="#filedata-attr"></a></h5>
-   <p>On getting, the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="result" id="dfn-result">result<span class="dfn-panel" data-deco=""><b><a href="#dfn-result">#dfn-result</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-result-1">7.3. 
+   <p>On getting, the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-result">result<span class="dfn-panel"><b><a href="#dfn-result">#dfn-result</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-result-1">7.3. 
 The FileReader API</a></span><span><a href="#ref-for-dfn-result-2">7.3.4.1. 
 The result attribute</a> <a href="#ref-for-dfn-result-3">(2)</a> <a href="#ref-for-dfn-result-4">(3)</a> <a href="#ref-for-dfn-result-5">(4)</a> <a href="#ref-for-dfn-result-6">(5)</a> <a href="#ref-for-dfn-result-7">(6)</a> <a href="#ref-for-dfn-result-8">(7)</a></span><span><a href="#ref-for-dfn-result-9">7.3.4.2. 
 The readAsDataURL() method</a> <a href="#ref-for-dfn-result-10">(2)</a></span><span><a href="#ref-for-dfn-result-11">7.3.4.3. 
@@ -2778,7 +2783,7 @@ The readAsArrayBuffer() method</a></span><span><a href="#ref-for-dfn-result-13">
 Error Steps</a></span><span><a href="#ref-for-dfn-result-14">7.3.4.6. 
 The abort() method</a> <a href="#ref-for-dfn-result-15">(2)</a></span><span><a href="#ref-for-dfn-result-16">7.4. 
 Determining Encoding</a></span></span></dfn> attribute returns a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-56">Blob</a></code>'s data
-as a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, or as an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code>, or <code>null</code>,
+as a <code class="idl"><a data-link-type="idl" href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, or as an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code>, or <code>null</code>,
 depending on the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-6">read method</a> that has been called on the <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-14">FileReader</a></code>,
 and any errors that may have occurred.</p>
    <p>The list below is normative for the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-3">result</a></code> attribute
@@ -2795,20 +2800,20 @@ if an error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-
 then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-5">result</a></code> attribute must return <code>null</code>.</p>
     <li data-md="">
      <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-3">readAsDataURL()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-8">read method</a> is used,
-the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-6">result</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> that is a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a> encoding of the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-34">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-58">Blob</a></code>'s data.</p>
+the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-6">result</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> that is a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a> encoding of the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-34">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-58">Blob</a></code>'s data.</p>
     <li data-md="">
      <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-3">readAsText()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-9">read method</a> is called
 and no error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-35">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-59">Blob</a></code> has occurred,
 then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-7">result</a></code> attribute must return a string
 representing the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-36">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-60">Blob</a></code>'s data as a text string,
-and should decode the string into memory in the format specified by the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-2">encoding determination</a> as a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>.</p>
+and should decode the string into memory in the format specified by the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-2">encoding determination</a> as a <code class="idl"><a data-link-type="idl" href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>.</p>
     <li data-md="">
      <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-3">readAsArrayBuffer()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-10">read method</a> is called
 and no error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-37">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-61">Blob</a></code> has occurred,
 then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-8">result</a></code> attribute must return an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code> object.</p>
    </ul>
    <h5 class="heading settled" data-level="7.3.4.2" id="readAsDataURL"><span class="secno">7.3.4.2. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-4">readAsDataURL()</a></code> method</span><a class="self-link" href="#readAsDataURL"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" data-lt="readAsDataURL(blob)" id="dfn-readAsDataURL">readAsDataURL(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsDataURL">#dfn-readAsDataURL</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsDataURL-1">7.3. 
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" id="dfn-readAsDataURL">readAsDataURL(blob)<span class="dfn-panel"><b><a href="#dfn-readAsDataURL">#dfn-readAsDataURL</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsDataURL-1">7.3. 
 The FileReader API</a></span><span><a href="#ref-for-dfn-readAsDataURL-2">7.3.4. 
 Reading a File or Blob</a></span><span><a href="#ref-for-dfn-readAsDataURL-3">7.3.4.1. 
 The result attribute</a></span><span><a href="#ref-for-dfn-readAsDataURL-4">7.3.4.2. 
@@ -2858,12 +2863,13 @@ If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-
      <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-7">Terminate this algorithm</a>.</p>
    </ol>
    <h5 class="heading settled" data-level="7.3.4.3" id="readAsDataText"><span class="secno">7.3.4.3. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-4">readAsText()</a></code> method</span><a class="self-link" href="#readAsDataText"></a></h5>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-5">readAsText()</a></code> method can be called with an optional parameter, <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader/readAsText(blob, label), FileReaderSync/readAsText(blob, label)" data-dfn-type="argument" data-export="" data-lt="label" id="dfn-label">label<span class="dfn-panel" data-deco=""><b><a href="#dfn-label">#dfn-label</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-label-1">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-label-2">7.6.1. 
+   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-5">readAsText()</a></code> method can be called with an optional parameter, <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader/readAsText(blob, label), FileReaderSync/readAsText(blob, label)" data-dfn-type="argument" data-export="" id="dfn-label">label<span class="dfn-panel"><b><a href="#dfn-label">#dfn-label</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-label-1">7.3. 
+The FileReader API</a></span><span><a href="#ref-for-dfn-label-2">7.4. 
+Determining Encoding</a> <a href="#ref-for-dfn-label-3">(2)</a></span><span><a href="#ref-for-dfn-label-4">7.6.1. 
 The FileReaderSync API</a></span></span></dfn>,
-which is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> argument that represents the label of an encoding <a data-link-type="biblio" href="#biblio-whatwg-encoding">[Encoding]</a>;
+which is a <code class="idl"><a data-link-type="idl" href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> argument that represents the label of an encoding <a data-link-type="biblio" href="#biblio-whatwg-encoding">[Encoding]</a>;
 if provided, it must be used as part of the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-3">encoding determination</a> used when processing this method call.</p>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" data-lt="readAsText(blob, label)|readAsText(blob)" id="dfn-readAsText">readAsText(blob, optional label)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsText">#dfn-readAsText</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsText-1">7.3. 
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" data-lt="readAsText(blob, label)|readAsText(blob)" id="dfn-readAsText">readAsText(blob, optional label)<span class="dfn-panel"><b><a href="#dfn-readAsText">#dfn-readAsText</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsText-1">7.3. 
 The FileReader API</a></span><span><a href="#ref-for-dfn-readAsText-2">7.3.4. 
 Reading a File or Blob</a></span><span><a href="#ref-for-dfn-readAsText-3">7.3.4.1. 
 The result attribute</a></span><span><a href="#ref-for-dfn-readAsText-4">7.3.4.3. 
@@ -2906,7 +2912,7 @@ If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-
      <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-10">Terminate this algorithm</a>.</p>
    </ol>
    <h5 class="heading settled" data-level="7.3.4.4" id="readAsArrayBuffer"><span class="secno">7.3.4.4. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-4">readAsArrayBuffer()</a></code> method</span><a class="self-link" href="#readAsArrayBuffer"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" data-lt="readAsArrayBuffer(blob)" id="dfn-readAsArrayBuffer">readAsArrayBuffer(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsArrayBuffer">#dfn-readAsArrayBuffer</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsArrayBuffer-1">7.3. 
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" id="dfn-readAsArrayBuffer">readAsArrayBuffer(blob)<span class="dfn-panel"><b><a href="#dfn-readAsArrayBuffer">#dfn-readAsArrayBuffer</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsArrayBuffer-1">7.3. 
 The FileReader API</a></span><span><a href="#ref-for-dfn-readAsArrayBuffer-2">7.3.4. 
 Reading a File or Blob</a></span><span><a href="#ref-for-dfn-readAsArrayBuffer-3">7.3.4.1. 
 The result attribute</a></span><span><a href="#ref-for-dfn-readAsArrayBuffer-4">7.3.4.4. 
@@ -2962,7 +2968,7 @@ If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-
      <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-14">Terminate the algorithm</a> for any <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-11">read method</a>.</p>
    </ol>
    <h5 class="heading settled" data-level="7.3.4.6" id="abort"><span class="secno">7.3.4.6. </span><span class="content"> The abort() method</span><a class="self-link" href="#abort"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" data-lt="abort()" id="dfn-abort">abort()<span class="dfn-panel" data-deco=""><b><a href="#dfn-abort">#dfn-abort</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-abort-1">3. 
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" id="dfn-abort">abort()<span class="dfn-panel"><b><a href="#dfn-abort">#dfn-abort</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-abort-1">3. 
 Terminology and Algorithms</a></span><span><a href="#ref-for-dfn-abort-2">7.3. 
 The FileReader API</a></span><span><a href="#ref-for-dfn-abort-3">7.3.3. 
 FileReader States</a></span><span><a href="#ref-for-dfn-abort-4">7.5.1. 
@@ -2989,16 +2995,17 @@ then remove those <a data-link-type="dfn" href="https://html.spec.whatwg.org/mul
 the three <a data-link-type="dfn" href="#read-method-sync" id="ref-for-read-method-sync-2">synchronous read methods</a>, <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-1">createObjectURL()</a></code></code> and <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-1">createFor()</a></code></code> take a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-62">Blob</a></code> parameter.
 This section defines this parameter.</p>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader/readAsArrayBuffer(blob), FileReader/readAsText(blob, label), FileReader/readAsDataURL(blob), URL/createObjectURL(blob), URL/createFor(blob), FileReaderSync/readAsArrayBuffer(blob), FileReaderSync/readAsText(blob, label), FileReaderSync/readAsDataURL(blob)" data-dfn-type="argument" data-export="" data-lt="blob" id="dfn-fileBlob">blob<span class="dfn-panel" data-deco=""><b><a href="#dfn-fileBlob">#dfn-fileBlob</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-fileBlob-1">7.3. 
-The FileReader API</a> <a href="#ref-for-dfn-fileBlob-2">(2)</a> <a href="#ref-for-dfn-fileBlob-3">(3)</a></span><span><a href="#ref-for-dfn-fileBlob-4">7.6.1. 
-The FileReaderSync API</a> <a href="#ref-for-dfn-fileBlob-5">(2)</a> <a href="#ref-for-dfn-fileBlob-6">(3)</a></span><span><a href="#ref-for-dfn-fileBlob-7">9.5. 
-Creating and Revoking a Blob URL</a> <a href="#ref-for-dfn-fileBlob-8">(2)</a></span></span></dfn> 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader/readAsArrayBuffer(blob), FileReader/readAsText(blob, label), FileReader/readAsDataURL(blob), URL/createObjectURL(blob), URL/createFor(blob), FileReaderSync/readAsArrayBuffer(blob), FileReaderSync/readAsText(blob, label), FileReaderSync/readAsDataURL(blob)" data-dfn-type="argument" data-export="" id="dfn-fileBlob">blob<span class="dfn-panel"><b><a href="#dfn-fileBlob">#dfn-fileBlob</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-fileBlob-1">7.3. 
+The FileReader API</a> <a href="#ref-for-dfn-fileBlob-2">(2)</a> <a href="#ref-for-dfn-fileBlob-3">(3)</a></span><span><a href="#ref-for-dfn-fileBlob-4">7.4. 
+Determining Encoding</a></span><span><a href="#ref-for-dfn-fileBlob-5">7.6.1. 
+The FileReaderSync API</a> <a href="#ref-for-dfn-fileBlob-6">(2)</a> <a href="#ref-for-dfn-fileBlob-7">(3)</a></span><span><a href="#ref-for-dfn-fileBlob-8">9.5. 
+Creating and Revoking a Blob URL</a> <a href="#ref-for-dfn-fileBlob-9">(2)</a></span></span></dfn> 
     <dd>This is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-63">Blob</a></code> argument
     and must be a reference to a single <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-38">File</a></code> in a <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-11">FileList</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-64">Blob</a></code> argument not obtained from the underlying OS file system. 
    </dl>
    <h3 class="heading settled" data-level="7.4" id="enctype"><span class="secno">7.4. </span><span class="content"> Determining Encoding</span><a class="self-link" href="#enctype"></a></h3>
    <p>When reading <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-65">Blob</a></code> objects using the <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-6">readAsText()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-13">read method</a>,
-the following <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="encoding determination" data-noexport="" id="encoding-determination">encoding determination<span class="dfn-panel" data-deco=""><b><a href="#encoding-determination">#encoding-determination</a></b><b>Referenced in:</b><span><a href="#ref-for-encoding-determination-1">4.2. 
+the following <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="encoding-determination">encoding determination<span class="dfn-panel"><b><a href="#encoding-determination">#encoding-determination</a></b><b>Referenced in:</b><span><a href="#ref-for-encoding-determination-1">4.2. 
 Attributes</a></span><span><a href="#ref-for-encoding-determination-2">7.3.4.1. 
 The result attribute</a></span><span><a href="#ref-for-encoding-determination-3">7.3.4.3. 
 The readAsText() method</a> <a href="#ref-for-encoding-determination-4">(2)</a></span><span><a href="#ref-for-encoding-determination-5">7.6.1.2. 
@@ -3007,14 +3014,14 @@ The readAsText() method</a></span></span></dfn> steps must be followed:</p>
     <li data-md="">
      <p>Let <var>encoding</var> be null.</p>
     <li data-md="">
-     <p>If the <code class="idl"><a data-link-type="idl">label</a></code> argument is present when calling the method,
-set <var>encoding</var> to the result of the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#concept-encoding-get">getting an encoding</a> from <code class="idl"><a data-link-type="idl">label</a></code>.</p>
+     <p>If the <code class="idl"><a data-link-type="idl" href="#dfn-label" id="ref-for-dfn-label-2">label</a></code> argument is present when calling the method,
+set <var>encoding</var> to the result of the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#concept-encoding-get">getting an encoding</a> from <code class="idl"><a data-link-type="idl" href="#dfn-label" id="ref-for-dfn-label-3">label</a></code>.</p>
     <li data-md="">
      <p>If the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#concept-encoding-get">getting an encoding</a> steps above return failure,
 then set <var>encoding</var> to null.</p>
     <li data-md="">
      <p>If <var>encoding</var> is null,
-and the <code class="idl"><a data-link-type="idl">blob</a></code> argument’s <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-17">type</a></code> attribute is present,
+and the <code class="idl"><a data-link-type="idl" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-4">blob</a></code> argument’s <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-17">type</a></code> attribute is present,
 and it uses a Charset Parameter <a data-link-type="biblio" href="#biblio-rfc2046">[RFC2046]</a>,
 set <var>encoding</var> to the result of <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#concept-encoding-get">getting an encoding</a> for the portion of the Charset Parameter that is a <i>label</i> of an encoding.</p>
      <div class="example" id="example-21540bcb"><a class="self-link" href="#example-21540bcb"></a> If <code>blob</code> has a <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-18">type</a></code> attribute of <code>text/plain;charset=utf-8</code> then <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#concept-encoding-get">getting an encoding</a> is run using <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8">utf-8</a> as the label.
@@ -3035,7 +3042,7 @@ returns a string in <var>encoding</var> format.</p>
    </ol>
    <h3 class="heading settled" data-level="7.5" id="events"><span class="secno">7.5. </span><span class="content"> Events</span><a class="self-link" href="#events"></a></h3>
    <p>The <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-16">FileReader</a></code> object must be the event target for all events in this specification.</p>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="fire a progress event" data-noexport="" id="fire-a-progress-event">fire a progress event<span class="dfn-panel" data-deco=""><b><a href="#fire-a-progress-event">#fire-a-progress-event</a></b><b>Referenced in:</b><span><a href="#ref-for-fire-a-progress-event-1">7.3.4.2. 
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fire-a-progress-event">fire a progress event<span class="dfn-panel"><b><a href="#fire-a-progress-event">#fire-a-progress-event</a></b><b>Referenced in:</b><span><a href="#ref-for-fire-a-progress-event-1">7.3.4.2. 
 The readAsDataURL() method</a> <a href="#ref-for-fire-a-progress-event-2">(2)</a> <a href="#ref-for-fire-a-progress-event-3">(3)</a> <a href="#ref-for-fire-a-progress-event-4">(4)</a> <a href="#ref-for-fire-a-progress-event-5">(5)</a></span><span><a href="#ref-for-fire-a-progress-event-6">7.3.4.3. 
 The readAsText() method</a> <a href="#ref-for-fire-a-progress-event-7">(2)</a> <a href="#ref-for-fire-a-progress-event-8">(3)</a> <a href="#ref-for-fire-a-progress-event-9">(4)</a> <a href="#ref-for-fire-a-progress-event-10">(5)</a></span><span><a href="#ref-for-fire-a-progress-event-11">7.3.4.4. 
 The readAsArrayBuffer() method</a> <a href="#ref-for-fire-a-progress-event-12">(2)</a> <a href="#ref-for-fire-a-progress-event-13">(3)</a> <a href="#ref-for-fire-a-progress-event-14">(4)</a> <a href="#ref-for-fire-a-progress-event-15">(5)</a></span><span><a href="#ref-for-fire-a-progress-event-16">7.3.4.5. 
@@ -3058,7 +3065,7 @@ the following are normative:</p>
       <th>Fired when… 
     <tbody>
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="loadstart" id="dfn-loadstart-event">loadstart<span class="dfn-panel" data-deco=""><b><a href="#dfn-loadstart-event">#dfn-loadstart-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-loadstart-event-1">7.3.2. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-loadstart-event">loadstart<span class="dfn-panel"><b><a href="#dfn-loadstart-event">#dfn-loadstart-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-loadstart-event-1">7.3.2. 
 Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-loadstart-event-2">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-loadstart-event-3">7.3.4.3. 
 The readAsText() method</a></span><span><a href="#ref-for-dfn-loadstart-event-4">7.3.4.4. 
@@ -3067,7 +3074,7 @@ Summary of Event Invariants</a> <a href="#ref-for-dfn-loadstart-event-6">(2)</a>
       <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> 
       <td>When the read starts. 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="progress" id="dfn-progress-event">progress<span class="dfn-panel" data-deco=""><b><a href="#dfn-progress-event">#dfn-progress-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-progress-event-1">7.3.2. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-progress-event">progress<span class="dfn-panel"><b><a href="#dfn-progress-event">#dfn-progress-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-progress-event-1">7.3.2. 
 Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-progress-event-2">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-progress-event-3">7.3.4.3. 
 The readAsText() method</a></span><span><a href="#ref-for-dfn-progress-event-4">7.3.4.4. 
@@ -3076,7 +3083,7 @@ Summary of Event Invariants</a> <a href="#ref-for-dfn-progress-event-6">(2)</a> 
       <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> 
       <td>While reading (and decoding) <code>blob</code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="abort" id="dfn-abort-event">abort<span class="dfn-panel" data-deco=""><b><a href="#dfn-abort-event">#dfn-abort-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-abort-event-1">7.3.2. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-abort-event">abort<span class="dfn-panel"><b><a href="#dfn-abort-event">#dfn-abort-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-abort-event-1">7.3.2. 
 Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-abort-event-2">7.3.4.6. 
 The abort() method</a></span><span><a href="#ref-for-dfn-abort-event-3">7.5.2. 
 Summary of Event Invariants</a> <a href="#ref-for-dfn-abort-event-4">(2)</a> <a href="#ref-for-dfn-abort-event-5">(3)</a></span></span></dfn> 
@@ -3084,7 +3091,7 @@ Summary of Event Invariants</a> <a href="#ref-for-dfn-abort-event-4">(2)</a> <a 
       <td>When the read has been aborted.
         For instance, by invoking the <code class="idl"><a data-link-type="idl" href="#dfn-abort" id="ref-for-dfn-abort-4">abort()</a></code> method. 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="error" id="dfn-error-event">error<span class="dfn-panel" data-deco=""><b><a href="#dfn-error-event">#dfn-error-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-error-event-1">5.2. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-error-event">error<span class="dfn-panel"><b><a href="#dfn-error-event">#dfn-error-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-error-event-1">5.2. 
 Attributes</a></span><span><a href="#ref-for-dfn-error-event-2">7.3.2. 
 Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-error-event-3">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-error-event-4">7.3.4.3. 
@@ -3095,7 +3102,7 @@ Summary of Event Invariants</a> <a href="#ref-for-dfn-error-event-8">(2)</a> <a 
       <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> 
       <td>When the read has failed (see <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-6">file read errors</a>). 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="load" id="dfn-load-event">load<span class="dfn-panel" data-deco=""><b><a href="#dfn-load-event">#dfn-load-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-load-event-1">7.3.2. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-load-event">load<span class="dfn-panel"><b><a href="#dfn-load-event">#dfn-load-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-load-event-1">7.3.2. 
 Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-load-event-2">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-load-event-3">7.3.4.3. 
 The readAsText() method</a></span><span><a href="#ref-for-dfn-load-event-4">7.3.4.4. 
@@ -3104,7 +3111,7 @@ Summary of Event Invariants</a> <a href="#ref-for-dfn-load-event-6">(2)</a> <a h
       <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> 
       <td>When the read has successfully completed. 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="loadend" id="dfn-loadend-event">loadend<span class="dfn-panel" data-deco=""><b><a href="#dfn-loadend-event">#dfn-loadend-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-loadend-event-1">7.3.2. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-loadend-event">loadend<span class="dfn-panel"><b><a href="#dfn-loadend-event">#dfn-loadend-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-loadend-event-1">7.3.2. 
 Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-loadend-event-2">7.3.4.2. 
 The readAsDataURL() method</a> <a href="#ref-for-dfn-loadend-event-3">(2)</a></span><span><a href="#ref-for-dfn-loadend-event-4">7.3.4.3. 
 The readAsText() method</a> <a href="#ref-for-dfn-loadend-event-5">(2)</a></span><span><a href="#ref-for-dfn-loadend-event-6">7.3.4.4. 
@@ -3165,13 +3172,13 @@ since such reads on threads do not block the main thread.
 This section defines a synchronous API, which can be used within Workers [[Web Workers]].
 Workers can avail of both the asynchronous API (the <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-19">FileReader</a></code> object) <em>and</em> the synchronous API (the <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-6">FileReaderSync</a></code> object).</p>
    <h4 class="heading settled" data-level="7.6.1" id="FileReaderSync"><span class="secno">7.6.1. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-7">FileReaderSync</a></code> API</span><a class="self-link" href="#FileReaderSync"></a></h4>
-   <p>This interface  provides methods to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="synchronous read method" data-noexport="" id="read-method-sync">synchronously read<span class="dfn-panel" data-deco=""><b><a href="#read-method-sync">#read-method-sync</a></b><b>Referenced in:</b><span><a href="#ref-for-read-method-sync-1">7.3.4. 
+   <p>This interface  provides methods to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="synchronous read method" data-noexport="" id="read-method-sync">synchronously read<span class="dfn-panel"><b><a href="#read-method-sync">#read-method-sync</a></b><b>Referenced in:</b><span><a href="#ref-for-read-method-sync-1">7.3.4. 
 Reading a File or Blob</a></span><span><a href="#ref-for-read-method-sync-2">7.3.4.7. 
 Blob Parameters</a></span><span><a href="#ref-for-read-method-sync-3">8. 
 Errors and Exceptions</a></span></span></dfn> <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-40">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-67">Blob</a></code> objects into memory.</p>
-<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="constructor" data-export="" data-lt="FileReaderSync()" id="dom-filereadersync-filereadersync">Constructor<span class="dfn-panel" data-deco=""><b><a href="#dom-filereadersync-filereadersync">#dom-filereadersync-filereadersync</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-filereadersync-filereadersync-1">7.6.1.1. 
+<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="constructor" data-export="" data-lt="FileReaderSync()" id="dom-filereadersync-filereadersync">Constructor<span class="dfn-panel"><b><a href="#dom-filereadersync-filereadersync">#dom-filereadersync-filereadersync</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-filereadersync-filereadersync-1">7.6.1.1. 
 Constructors</a></span></span></dfn>, Exposed=Worker]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-lt="FileReaderSync" id="dfn-FileReaderSync">FileReaderSync<span class="dfn-panel" data-deco=""><b><a href="#dfn-FileReaderSync">#dfn-FileReaderSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-FileReaderSync-1">4.2. 
+interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-FileReaderSync">FileReaderSync<span class="dfn-panel"><b><a href="#dfn-FileReaderSync">#dfn-FileReaderSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-FileReaderSync-1">4.2. 
 Attributes</a></span><span><a href="#ref-for-dfn-FileReaderSync-2">5.2. 
 Attributes</a></span><span><a href="#ref-for-dfn-FileReaderSync-3">7.3.4. 
 Reading a File or Blob</a> <a href="#ref-for-dfn-FileReaderSync-4">(2)</a></span><span><a href="#ref-for-dfn-FileReaderSync-5">7.4. 
@@ -3181,9 +3188,9 @@ The FileReaderSync API</a></span><span><a href="#ref-for-dfn-FileReaderSync-8">7
 Constructors</a> <a href="#ref-for-dfn-FileReaderSync-9">(2)</a></span></span></dfn> {
   // Synchronously return strings
 
-  ArrayBuffer <a class="idl-code" data-link-type="method" href="#dfn-readAsArrayBufferSync" id="ref-for-dfn-readAsArrayBufferSync-1">readAsArrayBuffer</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-68">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-4">blob</a>);
-  DOMString <a class="idl-code" data-link-type="method" href="#dfn-readAsTextSync" id="ref-for-dfn-readAsTextSync-2">readAsText</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-69">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-5">blob</a>, optional DOMString <a class="idl-code" data-link-type="argument" href="#dfn-label" id="ref-for-dfn-label-2">label</a>);
-  DOMString <a class="idl-code" data-link-type="method" href="#dfn-readAsDataURLSync" id="ref-for-dfn-readAsDataURLSync-1">readAsDataURL</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-70">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-6">blob</a>);
+  ArrayBuffer <a class="idl-code" data-link-type="method" href="#dfn-readAsArrayBufferSync" id="ref-for-dfn-readAsArrayBufferSync-1">readAsArrayBuffer</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-68">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-5">blob</a>);
+  DOMString <a class="idl-code" data-link-type="method" href="#dfn-readAsTextSync" id="ref-for-dfn-readAsTextSync-2">readAsText</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-69">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-6">blob</a>, optional DOMString <a class="idl-code" data-link-type="argument" href="#dfn-label" id="ref-for-dfn-label-4">label</a>);
+  DOMString <a class="idl-code" data-link-type="method" href="#dfn-readAsDataURLSync" id="ref-for-dfn-readAsDataURLSync-1">readAsDataURL</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-70">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-7">blob</a>);
 };
 </pre>
    <h5 class="heading settled" data-level="7.6.1.1" id="filereadersyncConstrctr"><span class="secno">7.6.1.1. </span><span class="content"> Constructors</span><a class="self-link" href="#filereadersyncConstrctr"></a></h5>
@@ -3192,7 +3199,7 @@ the user agent must return a new <code class="idl"><a data-link-type="idl" href=
    <p>In environments where the global object is represented by a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> object,
 the <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-9">FileReaderSync</a></code> constructor must be available.</p>
    <h5 class="heading settled" data-level="7.6.1.2" id="readAsTextSync"><span class="secno">7.6.1.2. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsTextSync" id="ref-for-dfn-readAsTextSync-3">readAsText()</a></code> method</span><a class="self-link" href="#readAsTextSync"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" data-lt="readAsText(blob, label)|readAsText(blob)" id="dfn-readAsTextSync">readAsText(blob, optional label)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsTextSync">#dfn-readAsTextSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsTextSync-1">7.4. 
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" data-lt="readAsText(blob, label)|readAsText(blob)" id="dfn-readAsTextSync">readAsText(blob, optional label)<span class="dfn-panel"><b><a href="#dfn-readAsTextSync">#dfn-readAsTextSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsTextSync-1">7.4. 
 Determining Encoding</a></span><span><a href="#ref-for-dfn-readAsTextSync-2">7.6.1. 
 The FileReaderSync API</a></span><span><a href="#ref-for-dfn-readAsTextSync-3">7.6.1.2. 
 The readAsText() method</a></span></span></dfn> method is called,
@@ -3216,7 +3223,7 @@ return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation
 in a format determined through the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-5">encoding determination</a> algorithm.</p>
    </ol>
    <h5 class="heading settled" data-level="7.6.1.3" id="readAsDataURLSync-section"><span class="secno">7.6.1.3. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURLSync" id="ref-for-dfn-readAsDataURLSync-2">readAsDataURL()</a></code> method</span><a class="self-link" href="#readAsDataURLSync-section"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" data-lt="readAsDataURL(blob)" id="dfn-readAsDataURLSync">readAsDataURL(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsDataURLSync">#dfn-readAsDataURLSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsDataURLSync-1">7.6.1. 
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" id="dfn-readAsDataURLSync">readAsDataURL(blob)<span class="dfn-panel"><b><a href="#dfn-readAsDataURLSync">#dfn-readAsDataURLSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsDataURLSync-1">7.6.1. 
 The FileReaderSync API</a></span><span><a href="#ref-for-dfn-readAsDataURLSync-2">7.6.1.3. 
 The readAsDataURL() method</a></span></span></dfn> method is called,
 the following steps must be followed:</p>
@@ -3245,7 +3252,7 @@ Data URLs that do not have media-types <a data-link-type="biblio" href="#biblio-
      </ul>
    </ol>
    <h5 class="heading settled" data-level="7.6.1.4" id="readAsArrayBufferSyncSection"><span class="secno">7.6.1.4. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBufferSync" id="ref-for-dfn-readAsArrayBufferSync-2">readAsArrayBuffer()</a></code> method</span><a class="self-link" href="#readAsArrayBufferSyncSection"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" data-lt="readAsArrayBuffer(blob)" id="dfn-readAsArrayBufferSync">readAsArrayBuffer(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsArrayBufferSync">#dfn-readAsArrayBufferSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsArrayBufferSync-1">7.6.1. 
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" id="dfn-readAsArrayBufferSync">readAsArrayBuffer(blob)<span class="dfn-panel"><b><a href="#dfn-readAsArrayBufferSync">#dfn-readAsArrayBufferSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsArrayBufferSync-1">7.6.1. 
 The FileReaderSync API</a></span><span><a href="#ref-for-dfn-readAsArrayBufferSync-2">7.6.1.4. 
 The readAsArrayBuffer() method</a></span></span></dfn> method is called,
 the following steps must be followed:</p>
@@ -3266,7 +3273,7 @@ throw the appropriate exception as defined in <a href="#dfn-error-codes">§8.1 T
      <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-23">read operation</a> as an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code>.</p>
    </ol>
    <h2 class="heading settled" data-level="8" id="ErrorAndException"><span class="secno">8. </span><span class="content"> Errors and Exceptions</span><a class="self-link" href="#ErrorAndException"></a></h2>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="file read error" data-noexport="" id="file-error-read">File read errors<span class="dfn-panel" data-deco=""><b><a href="#file-error-read">#file-error-read</a></b><b>Referenced in:</b><span><a href="#ref-for-file-error-read-1">5.2. 
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="file read error" data-noexport="" id="file-error-read">File read errors<span class="dfn-panel"><b><a href="#file-error-read">#file-error-read</a></b><b>Referenced in:</b><span><a href="#ref-for-file-error-read-1">5.2. 
 Attributes</a></span><span><a href="#ref-for-file-error-read-2">7.1. 
 The Read Operation</a> <a href="#ref-for-file-error-read-3">(2)</a> <a href="#ref-for-file-error-read-4">(3)</a></span><span><a href="#ref-for-file-error-read-5">7.3.3. 
 FileReader States</a></span><span><a href="#ref-for-file-error-read-6">7.5.1. 
@@ -3299,7 +3306,7 @@ See <a href="#security-discussion">§10 Security Considerations</a> and <code cl
    <p>Error conditions can arise when reading a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-44">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-74">Blob</a></code>.</p>
    <p>The <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-24">read operation</a> can terminate due to error conditions when reading a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-45">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-75">Blob</a></code>;
 the particular error condition that causes a read operation to return failure
-or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-5">process read error</a> is called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="failure reason" data-noexport="" id="failureReason">failure reason<span class="dfn-panel" data-deco=""><b><a href="#failureReason">#failureReason</a></b><b>Referenced in:</b><span><a href="#ref-for-failureReason-1">7.1. 
+or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-5">process read error</a> is called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="failureReason">failure reason<span class="dfn-panel"><b><a href="#failureReason">#failureReason</a></b><b>Referenced in:</b><span><a href="#ref-for-failureReason-1">7.1. 
 The Read Operation</a> <a href="#ref-for-failureReason-2">(2)</a> <a href="#ref-for-failureReason-3">(3)</a> <a href="#ref-for-failureReason-4">(4)</a> <a href="#ref-for-failureReason-5">(5)</a> <a href="#ref-for-failureReason-6">(6)</a> <a href="#ref-for-failureReason-7">(7)</a></span><span><a href="#ref-for-failureReason-8">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-failureReason-9">7.3.4.3. 
 The readAsText() method</a></span><span><a href="#ref-for-failureReason-10">7.3.4.4. 
@@ -3308,7 +3315,7 @@ Error Steps</a> <a href="#ref-for-failureReason-12">(2)</a></span><span><a href=
 Throwing an Exception or Returning an Error</a> <a href="#ref-for-failureReason-14">(2)</a> <a href="#ref-for-failureReason-15">(3)</a> <a href="#ref-for-failureReason-16">(4)</a> <a href="#ref-for-failureReason-17">(5)</a> <a href="#ref-for-failureReason-18">(6)</a> <a href="#ref-for-failureReason-19">(7)</a> <a href="#ref-for-failureReason-20">(8)</a></span></span></dfn>.</p>
    <p>Synchronous read methods <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> exceptions of the type in the table below
 if there has been an error owing to a particular <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-13">failure reason</a>.</p>
-   <p>Asynchronous read methods use the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="error" id="dfn-error">error<span class="dfn-panel" data-deco=""><b><a href="#dfn-error">#dfn-error</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-error-1">5.2. 
+   <p>Asynchronous read methods use the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-error">error<span class="dfn-panel"><b><a href="#dfn-error">#dfn-error</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-error-1">5.2. 
 Attributes</a></span><span><a href="#ref-for-dfn-error-2">7.3. 
 The FileReader API</a></span><span><a href="#ref-for-dfn-error-3">7.3.4.2. 
 The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-error-4">7.3.4.3. 
@@ -3326,7 +3333,7 @@ or otherwise return null.</p>
       <th>Description and Failure Reason 
     <tbody>
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" data-lt="NotFoundError" id="exceptdef-notfounderror">NotFoundError<span class="dfn-panel" data-deco=""><b><a href="#exceptdef-notfounderror">#exceptdef-notfounderror</a></b><b>Referenced in:</b><span><a href="#ref-for-exceptdef-notfounderror-1">5.2. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="exceptdef-notfounderror">NotFoundError<span class="dfn-panel"><b><a href="#exceptdef-notfounderror">#exceptdef-notfounderror</a></b><b>Referenced in:</b><span><a href="#ref-for-exceptdef-notfounderror-1">5.2. 
 Attributes</a> <a href="#ref-for-exceptdef-notfounderror-2">(2)</a></span><span><a href="#ref-for-exceptdef-notfounderror-3">8. 
 Errors and Exceptions</a></span><span><a href="#ref-for-exceptdef-notfounderror-4">8.1. 
 Throwing an Exception or Returning an Error</a> <a href="#ref-for-exceptdef-notfounderror-5">(2)</a></span></span></dfn> 
@@ -3336,7 +3343,7 @@ Throwing an Exception or Returning an Error</a> <a href="#ref-for-exceptdef-notf
        <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-8">error</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="#exceptdef-notfounderror" id="ref-for-exceptdef-notfounderror-4">NotFoundError</a></code> exception
         and synchronous read methods must <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="#exceptdef-notfounderror" id="ref-for-exceptdef-notfounderror-5">NotFoundError</a></code> exception.</p>
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" data-lt="SecurityError" id="exceptdef-securityerror">SecurityError<span class="dfn-panel" data-deco=""><b><a href="#exceptdef-securityerror">#exceptdef-securityerror</a></b><b>Referenced in:</b><span><a href="#ref-for-exceptdef-securityerror-1">8. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="exceptdef-securityerror">SecurityError<span class="dfn-panel"><b><a href="#exceptdef-securityerror">#exceptdef-securityerror</a></b><b>Referenced in:</b><span><a href="#ref-for-exceptdef-securityerror-1">8. 
 Errors and Exceptions</a></span><span><a href="#ref-for-exceptdef-securityerror-2">8.1. 
 Throwing an Exception or Returning an Error</a> <a href="#ref-for-exceptdef-securityerror-3">(2)</a></span><span><a href="#ref-for-exceptdef-securityerror-4">10. 
 Security Considerations</a> <a href="#ref-for-exceptdef-securityerror-5">(2)</a></span></span></dfn> 
@@ -3352,7 +3359,7 @@ Security Considerations</a> <a href="#ref-for-exceptdef-securityerror-5">(2)</a>
         and synchronous read methods may <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="#exceptdef-securityerror" id="ref-for-exceptdef-securityerror-3">SecurityError</a></code> exception.</p>
        <p>This is a security error to be used in situations not covered by any other <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-18">failure reason</a>.</p>
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" data-lt="NotReadableError" id="exceptdef-notreadableerror">NotReadableError<span class="dfn-panel" data-deco=""><b><a href="#exceptdef-notreadableerror">#exceptdef-notreadableerror</a></b><b>Referenced in:</b><span><a href="#ref-for-exceptdef-notreadableerror-1">8. 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-type="exception" data-export="" id="exceptdef-notreadableerror">NotReadableError<span class="dfn-panel"><b><a href="#exceptdef-notreadableerror">#exceptdef-notreadableerror</a></b><b>Referenced in:</b><span><a href="#ref-for-exceptdef-notreadableerror-1">8. 
 Errors and Exceptions</a></span><span><a href="#ref-for-exceptdef-notreadableerror-2">8.1. 
 Throwing an Exception or Returning an Error</a> <a href="#ref-for-exceptdef-notreadableerror-3">(2)</a></span></span></dfn> 
       <td>
@@ -3449,7 +3456,7 @@ Choosing a name that clarifies the primary use case—<wbr>namely, access to mem
 and favors clarity, familiarity, and consistency across the web platform.</p>
    </ul>
    <h3 class="heading settled" data-level="9.3" id="DefinitionOfScheme"><span class="secno">9.3. </span><span class="content"> The Blob URL</span><a class="self-link" href="#DefinitionOfScheme"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="Blob URL" id="blob-url">Blob URL<span class="dfn-panel" data-deco=""><b><a href="#blob-url">#blob-url</a></b><b>Referenced in:</b><span><a href="#ref-for-blob-url-1">4.2. 
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="blob-url">Blob URL<span class="dfn-panel"><b><a href="#blob-url">#blob-url</a></b><b>Referenced in:</b><span><a href="#ref-for-blob-url-1">4.2. 
 Attributes</a></span><span><a href="#ref-for-blob-url-2">4.3.1. 
 The slice method</a></span><span><a href="#ref-for-blob-url-3">9.3. 
 The Blob URL</a></span><span><a href="#ref-for-blob-url-4">9.3.1. 
@@ -3489,7 +3496,7 @@ and are revoked using <code>URL.<code class="idl"><a data-link-type="idl" href="
 The <dfn data-dfn-type="dfn" data-lt="origin of a Blob URL|Blob URL’s origin" data-noexport="" id="origin-of-a-blob-url">origin of a Blob URL<a class="self-link" href="#origin-of-a-blob-url"></a></dfn> must be the same as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> specified by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> at the time the method that created it—<wbr>either <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-3">createObjectURL()</a></code></code> or <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-3">createFor()</a></code></code>—<wbr>was called.</p>
    <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of a Blob URL,
 when serialized as a string,
-must conform to the Web Origin Specification’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Unicode Serialization of an Origin algorithm" data-noexport="" id="unicode-serialization-of-an-origin-algorithm">Unicode Serialization of an Origin algorithm<span class="dfn-panel" data-deco=""><b><a href="#unicode-serialization-of-an-origin-algorithm">#unicode-serialization-of-an-origin-algorithm</a></b><b>Referenced in:</b><span><a href="#ref-for-unicode-serialization-of-an-origin-algorithm-1">9.3.2. 
+must conform to the Web Origin Specification’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unicode-serialization-of-an-origin-algorithm">Unicode Serialization of an Origin algorithm<span class="dfn-panel"><b><a href="#unicode-serialization-of-an-origin-algorithm">#unicode-serialization-of-an-origin-algorithm</a></b><b>Referenced in:</b><span><a href="#ref-for-unicode-serialization-of-an-origin-algorithm-1">9.3.2. 
 Unicode Serialization of a Blob URL</a> <a href="#ref-for-unicode-serialization-of-an-origin-algorithm-2">(2)</a> <a href="#ref-for-unicode-serialization-of-an-origin-algorithm-3">(3)</a></span></span></dfn> <a data-link-type="biblio" href="#biblio-rfc6454">[RFC6454]</a>. <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#http-cors-protocol">Cross-origin requests</a> on Blob URLs must return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
    <p class="note" role="note">Note: In practice this means that HTTP and HTTPS <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origins</a> are covered by this specification as valid origins for use with Blob URLs.
 This specification does not address the case of non-HTTP and non-HTTPS <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origins</a>.
@@ -3497,7 +3504,7 @@ For instance <code>blob:file:///Users/arunranga/702efefb-c234-4988-a73b-6104f1b6
 may have behavior that is undefined,
 even though user agents may treat such Blob URLs as valid.</p>
    <h4 class="heading settled" data-level="9.3.2" id="unicodeSerializationOfBlobURL"><span class="secno">9.3.2. </span><span class="content"> Unicode Serialization of a Blob URL</span><a class="self-link" href="#unicodeSerializationOfBlobURL"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Unicode Serialization of a Blob URL" data-noexport="" id="unicodeBlobURL">Unicode Serialization of a Blob URL<span class="dfn-panel" data-deco=""><b><a href="#unicodeBlobURL">#unicodeBlobURL</a></b><b>Referenced in:</b><span><a href="#ref-for-unicodeBlobURL-1">9.3. 
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unicodeBlobURL">Unicode Serialization of a Blob URL<span class="dfn-panel"><b><a href="#unicodeBlobURL">#unicodeBlobURL</a></b><b>Referenced in:</b><span><a href="#ref-for-unicodeBlobURL-1">9.3. 
 The Blob URL</a></span><span><a href="#ref-for-unicodeBlobURL-2">9.5.1. 
 Methods and Parameters</a> <a href="#ref-for-unicodeBlobURL-3">(2)</a> <a href="#ref-for-unicodeBlobURL-4">(3)</a> <a href="#ref-for-unicodeBlobURL-5">(4)</a></span></span></dfn> is the value returned by the following algorithm,
 which is invoked by <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-4">createObjectURL()</a></code></code> and/or <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-4">createFor()</a></code></code>:</p>
@@ -3537,7 +3544,7 @@ nor the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor
    <h3 class="heading settled" data-level="9.4" id="requestResponseModel"><span class="secno">9.4. </span><span class="content"> Dereferencing Model for Blob URLs</span><a class="self-link" href="#requestResponseModel"></a></h3>
    <p><em>This section is informative.</em></p>
    <p class="note" role="note">Note: The <a data-link-type="biblio" href="#biblio-whatwg-url">[URL]</a> and <a data-link-type="biblio" href="#biblio-fetch">[Fetch]</a> specifications should be considered normative for parsing and fetching <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-6">Blob URLs</a>.</p>
-   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-7">Blob URLs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="dereference" data-noexport="" id="dereference">dereferenced<span class="dfn-panel" data-deco=""><b><a href="#dereference">#dereference</a></b><b>Referenced in:</b><span><a href="#ref-for-dereference-1">4.2. 
+   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-7">Blob URLs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="dereference" data-noexport="" id="dereference">dereferenced<span class="dfn-panel"><b><a href="#dereference">#dereference</a></b><b>Referenced in:</b><span><a href="#ref-for-dereference-1">4.2. 
 Attributes</a></span><span><a href="#ref-for-dereference-2">9.3.3. 
 Discussion of Fragment Identifier</a></span><span><a href="#ref-for-dereference-3">9.5.1. 
 Methods and Parameters</a> <a href="#ref-for-dereference-4">(2)</a></span><span><a href="#ref-for-dereference-5">9.5.2. 
@@ -3585,7 +3592,7 @@ this also results in the <a data-link-type="dfn" href="#blob-url" id="ref-for-bl
    <h4 class="heading settled" data-level="9.4.4" id="ProtocolExamples"><span class="secno">9.4.4. </span><span class="content"> Sample Request and Response Headers</span><a class="self-link" href="#ProtocolExamples"></a></h4>
    <p><em>This section is informative.</em></p>
    <p>This section provides sample exchanges between web applications and user agents using <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-12">Blob URLs</a>.
-A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> can be triggered using HTML markup of the sort <code class="lang-markup highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"blob:http://example.org:8080/550e8400-e29b-41d4-a716-446655440000"</span><span class="nt">></span></code>.
+A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> can be triggered using HTML markup of the sort <code class="lang-markup highlight"><span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"blob:http://example.org:8080/550e8400-e29b-41d4-a716-446655440000"</span><span class="p">></span></code>.
 These examples merely illustrate the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>;
 web developers are not likely to interact with all the headers,
 but the <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-xmlhttprequest-getallresponseheaders">getAllResponseHeaders()</a></code> method of <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest">XMLHttpRequest</a></code>, if used,
@@ -3614,9 +3621,10 @@ Revocation of a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-14
 and if it is dereferenced after it is revoked,
 user agents must act as if a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> has occurred.
 This section describes a supplemental interface to the URL specification <a data-link-type="biblio" href="#biblio-whatwg-url">[URL]</a> and presents methods for <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-16">Blob URL</a> creation and revocation.</p>
-<pre class="idl def">partial interface <a class="idl-code" data-link-type="interface" href="https://url.spec.whatwg.org/#url">URL</a> {
-  static DOMString <a class="idl-code" data-link-type="method" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-6">createObjectURL</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-94">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-7">blob</a>);
-  static DOMString <a class="idl-code" data-link-type="method" href="#dfn-createFor" id="ref-for-dfn-createFor-6">createFor</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-95">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-8">blob</a>);
+<pre class="idl def">[Exposed=Window,DedicatedWorker,SharedWorker]
+partial interface <a class="idl-code" data-link-type="interface" href="https://url.spec.whatwg.org/#url">URL</a> {
+  static DOMString <a class="idl-code" data-link-type="method" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-6">createObjectURL</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-94">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-8">blob</a>);
+  static DOMString <a class="idl-code" data-link-type="method" href="#dfn-createFor" id="ref-for-dfn-createFor-6">createFor</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-95">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-9">blob</a>);
   static void <a class="idl-code" data-link-type="method" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-2">revokeObjectURL</a>(DOMString <a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-1">url</a>);
 };
 </pre>
@@ -3627,7 +3635,7 @@ In other words, <code>URL.prototype</code> must evaluate to true if the user age
 and must NOT evaluate to true otherwise.</p>
    <h4 class="heading settled" data-level="9.5.1" id="createRevokeMethodsParams"><span class="secno">9.5.1. </span><span class="content"> Methods and Parameters</span><a class="self-link" href="#createRevokeMethodsParams"></a></h4>
    <dl>
-    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" data-lt="createObjectURL(blob)" id="dfn-createObjectURL">createObjectURL(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-createObjectURL">#dfn-createObjectURL</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-createObjectURL-1">7.3.4.7. 
+    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" id="dfn-createObjectURL">createObjectURL(blob)<span class="dfn-panel"><b><a href="#dfn-createObjectURL">#dfn-createObjectURL</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-createObjectURL-1">7.3.4.7. 
 Blob Parameters</a></span><span><a href="#ref-for-dfn-createObjectURL-2">9.3.1. 
 Origin of Blob URLs</a> <a href="#ref-for-dfn-createObjectURL-3">(2)</a></span><span><a href="#ref-for-dfn-createObjectURL-4">9.3.2. 
 Unicode Serialization of a Blob URL</a></span><span><a href="#ref-for-dfn-createObjectURL-5">9.3.3. 
@@ -3657,7 +3665,7 @@ a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-e
          <p>Return <var>url</var>.</p>
        </ol>
      </ol>
-    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" data-lt="createFor(blob)" id="dfn-createFor">createFor(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-createFor">#dfn-createFor</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-createFor-1">7.3.4.7. 
+    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" id="dfn-createFor">createFor(blob)<span class="dfn-panel"><b><a href="#dfn-createFor">#dfn-createFor</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-createFor-1">7.3.4.7. 
 Blob Parameters</a></span><span><a href="#ref-for-dfn-createFor-2">9.3.1. 
 Origin of Blob URLs</a> <a href="#ref-for-dfn-createFor-3">(2)</a></span><span><a href="#ref-for-dfn-createFor-4">9.3.2. 
 Unicode Serialization of a Blob URL</a></span><span><a href="#ref-for-dfn-createFor-5">9.3.3. 
@@ -3666,7 +3674,7 @@ Creating and Revoking a Blob URL</a></span><span><a href="#ref-for-dfn-createFor
 Examples of Blob URL Creation and Revocation</a> <a href="#ref-for-dfn-createFor-8">(2)</a> <a href="#ref-for-dfn-createFor-9">(3)</a></span><span><a href="#ref-for-dfn-createFor-10">9.6. 
 Lifetime of Blob URLs</a> <a href="#ref-for-dfn-createFor-11">(2)</a> <a href="#ref-for-dfn-createFor-12">(3)</a> <a href="#ref-for-dfn-createFor-13">(4)</a></span></span></dfn> static method 
     <dd>
-     Returns a unique <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-19">Blob URL</a>. <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-20">Blob URLs</a> created with this method are said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="auto-revoking" data-noexport="" id="autoRevoking">auto-revoking<span class="dfn-panel" data-deco=""><b><a href="#autoRevoking">#autoRevoking</a></b><b>Referenced in:</b><span><a href="#ref-for-autoRevoking-1">9.6. 
+     Returns a unique <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-19">Blob URL</a>. <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-20">Blob URLs</a> created with this method are said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="autoRevoking">auto-revoking<span class="dfn-panel"><b><a href="#autoRevoking">#autoRevoking</a></b><b>Referenced in:</b><span><a href="#ref-for-autoRevoking-1">9.6. 
 Lifetime of Blob URLs</a></span></span></dfn> since user-agents are responsible for the revocation of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-21">Blob URL</a>s created with this method,
     subject to the <a data-link-type="dfn" href="#lifeTime" id="ref-for-lifeTime-2">lifetime stipulation</a> for <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-22">Blob URL</a>s.
     This method must act as follows: 
@@ -3704,7 +3712,7 @@ a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-e
 
 <span class="p">}</span></pre>
      </div>
-    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" data-lt="revokeObjectURL(url)" id="dfn-revokeObjectURL">revokeObjectURL(url)<span class="dfn-panel" data-deco=""><b><a href="#dfn-revokeObjectURL">#dfn-revokeObjectURL</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-revokeObjectURL-1">9.3.1. 
+    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" id="dfn-revokeObjectURL">revokeObjectURL(url)<span class="dfn-panel"><b><a href="#dfn-revokeObjectURL">#dfn-revokeObjectURL</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-revokeObjectURL-1">9.3.1. 
 Origin of Blob URLs</a></span><span><a href="#ref-for-dfn-revokeObjectURL-2">9.5. 
 Creating and Revoking a Blob URL</a></span><span><a href="#ref-for-dfn-revokeObjectURL-3">9.5.1. 
 Methods and Parameters</a> <a href="#ref-for-dfn-revokeObjectURL-4">(2)</a></span><span><a href="#ref-for-dfn-revokeObjectURL-5">9.5.2. 
@@ -3723,7 +3731,7 @@ User agents may display a message on the error console.</p>
        <p class="note" role="note">Note: Subsequent attemps to dereference <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-7">url</a></code> result in a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>,
 since the entry has been removed from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-9">Blob URL Store</a>.</p>
      </ol>
-     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL/revokeObjectURL(url)" data-dfn-type="argument" data-export="" data-lt="url" id="dfn-urlarg">url<span class="dfn-panel" data-deco=""><b><a href="#dfn-urlarg">#dfn-urlarg</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-urlarg-1">9.5. 
+     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL/revokeObjectURL(url)" data-dfn-type="argument" data-export="" id="dfn-urlarg">url<span class="dfn-panel"><b><a href="#dfn-urlarg">#dfn-urlarg</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-urlarg-1">9.5. 
 Creating and Revoking a Blob URL</a></span><span><a href="#ref-for-dfn-urlarg-2">9.5.1. 
 Methods and Parameters</a> <a href="#ref-for-dfn-urlarg-3">(2)</a> <a href="#ref-for-dfn-urlarg-4">(3)</a> <a href="#ref-for-dfn-urlarg-5">(4)</a> <a href="#ref-for-dfn-urlarg-6">(5)</a> <a href="#ref-for-dfn-urlarg-7">(6)</a></span></span></dfn> argument to the <code class="idl"><a data-link-type="idl" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-3">revokeObjectURL()</a></code> method
     is a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-26">Blob URL</a> string.</p>
@@ -3798,27 +3806,27 @@ developers should pair it with a corresponding call to <code>URL.<code class="id
 
 <span class="p">....</span></pre>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-for="blob url" data-dfn-type="dfn" data-export="" data-level="9.6" data-lt="lifetime|lifetime stipulation" id="lifeTime"><span class="secno">9.6. </span><span class="content"> Lifetime of Blob URLs</span><span class="dfn-panel" data-deco=""><b><a href="#lifeTime">#lifeTime</a></b><b>Referenced in:</b><span><a href="#ref-for-lifeTime-1">9.1. 
+   <h3 class="heading settled dfn-paneled" data-dfn-for="blob url" data-dfn-type="dfn" data-export="" data-level="9.6" data-lt="lifetime|lifetime stipulation" id="lifeTime"><span class="secno">9.6. </span><span class="content"> Lifetime of Blob URLs</span><span class="dfn-panel"><b><a href="#lifeTime">#lifeTime</a></b><b>Referenced in:</b><span><a href="#ref-for-lifeTime-1">9.1. 
 Requirements for a New Scheme</a></span><span><a href="#ref-for-lifeTime-2">9.5.1. 
 Methods and Parameters</a></span><span><a href="#ref-for-lifeTime-3">9.5.2. 
 Examples of Blob URL Creation and Revocation</a></span></span></h3>
-   <p>A global object which exposes <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-9">createObjectURL()</a></code></code> or <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-10">createFor()</a></code></code> must maintain a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Blob URL Store" data-noexport="" id="BlobURLStore">Blob URL Store<span class="dfn-panel" data-deco=""><b><a href="#BlobURLStore">#BlobURLStore</a></b><b>Referenced in:</b><span><a href="#ref-for-BlobURLStore-1">4.3.2. 
+   <p>A global object which exposes <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-9">createObjectURL()</a></code></code> or <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-10">createFor()</a></code></code> must maintain a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="BlobURLStore">Blob URL Store<span class="dfn-panel"><b><a href="#BlobURLStore">#BlobURLStore</a></b><b>Referenced in:</b><span><a href="#ref-for-BlobURLStore-1">4.3.2. 
 The close method</a></span><span><a href="#ref-for-BlobURLStore-2">9.4.3. 
 Network Errors</a> <a href="#ref-for-BlobURLStore-3">(2)</a></span><span><a href="#ref-for-BlobURLStore-4">9.5.1. 
 Methods and Parameters</a> <a href="#ref-for-BlobURLStore-5">(2)</a> <a href="#ref-for-BlobURLStore-6">(3)</a> <a href="#ref-for-BlobURLStore-7">(4)</a> <a href="#ref-for-BlobURLStore-8">(5)</a> <a href="#ref-for-BlobURLStore-9">(6)</a> <a href="#ref-for-BlobURLStore-10">(7)</a></span><span><a href="#ref-for-BlobURLStore-11">9.6. 
 Lifetime of Blob URLs</a> <a href="#ref-for-BlobURLStore-12">(2)</a> <a href="#ref-for-BlobURLStore-13">(3)</a> <a href="#ref-for-BlobURLStore-14">(4)</a> <a href="#ref-for-BlobURLStore-15">(5)</a> <a href="#ref-for-BlobURLStore-16">(6)</a></span></span></dfn> which is a list of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-34">Blob URLs</a> created by the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-10">createObjectURL()</a></code></code> method
 or the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-11">createFor()</a></code></code> method,
 and the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-102">Blob</a></code> resource that each refers to.</p>
-   <p>A global object which exposes <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-12">createFor()</a></code></code> must maintain a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Revocation List" data-noexport="" id="revokeList">Revocation List<span class="dfn-panel" data-deco=""><b><a href="#revokeList">#revokeList</a></b><b>Referenced in:</b><span><a href="#ref-for-revokeList-1">9.6. 
+   <p>A global object which exposes <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-12">createFor()</a></code></code> must maintain a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="revokeList">Revocation List<span class="dfn-panel"><b><a href="#revokeList">#revokeList</a></b><b>Referenced in:</b><span><a href="#ref-for-revokeList-1">9.6. 
 Lifetime of Blob URLs</a> <a href="#ref-for-revokeList-2">(2)</a> <a href="#ref-for-revokeList-3">(3)</a> <a href="#ref-for-revokeList-4">(4)</a> <a href="#ref-for-revokeList-5">(5)</a></span></span></dfn> which is a list of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-35">Blob URLs</a> created with the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-13">createFor()</a></code></code> method.</p>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="add an entry|add the entry|add an entry to the Blob URL Store|add the entry to the Blob URL Store" data-noexport="" id="add-an-entry">add an entry to the Blob URL Store<span class="dfn-panel" data-deco=""><b><a href="#add-an-entry">#add-an-entry</a></b><b>Referenced in:</b><span><a href="#ref-for-add-an-entry-1">9.5.1. 
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="add an entry|add the entry|add an entry to the Blob URL Store|add the entry to the Blob URL Store" data-noexport="" id="add-an-entry">add an entry to the Blob URL Store<span class="dfn-panel"><b><a href="#add-an-entry">#add-an-entry</a></b><b>Referenced in:</b><span><a href="#ref-for-add-an-entry-1">9.5.1. 
 Methods and Parameters</a> <a href="#ref-for-add-an-entry-2">(2)</a></span></span></dfn> for a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-36">Blob URL</a> and a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-103">Blob</a></code> input,
 the user-agent must add the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-37">Blob URL</a> and a reference to the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-104">Blob</a></code> it refers to to the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-11">Blob URL Store</a>.</p>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob revocation list" data-dfn-type="dfn" data-lt="add an entry|add the entry|add an entry to the Revocation List|add the entry to the Revocation List" data-noexport="" id="add-an-entry-revoke">add an entry to the Revocation List<span class="dfn-panel" data-deco=""><b><a href="#add-an-entry-revoke">#add-an-entry-revoke</a></b><b>Referenced in:</b><span><a href="#ref-for-add-an-entry-revoke-1">9.5.1. 
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob revocation list" data-dfn-type="dfn" data-lt="add an entry|add the entry|add an entry to the Revocation List|add the entry to the Revocation List" data-noexport="" id="add-an-entry-revoke">add an entry to the Revocation List<span class="dfn-panel"><b><a href="#add-an-entry-revoke">#add-an-entry-revoke</a></b><b>Referenced in:</b><span><a href="#ref-for-add-an-entry-revoke-1">9.5.1. 
 Methods and Parameters</a></span></span></dfn> for a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-38">Blob URL</a>,
 user agents must add the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-39">Blob URL</a> to the <a data-link-type="dfn" href="#revokeList" id="ref-for-revokeList-1">Revocation List</a>.
 This is only for <a data-link-type="dfn" href="#autoRevoking" id="ref-for-autoRevoking-1">auto-revoking</a> <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-40">Blob URL</a>s.</p>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="remove an entry|remove the entry|remove an entry from the Blob URL Store|remove the entry from the Blob URL Store" data-noexport="" id="removeTheEntry">remove an entry from the Blob URL Store<span class="dfn-panel" data-deco=""><b><a href="#removeTheEntry">#removeTheEntry</a></b><b>Referenced in:</b><span><a href="#ref-for-removeTheEntry-1">4.3.2. 
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="remove an entry|remove the entry|remove an entry from the Blob URL Store|remove the entry from the Blob URL Store" data-noexport="" id="removeTheEntry">remove an entry from the Blob URL Store<span class="dfn-panel"><b><a href="#removeTheEntry">#removeTheEntry</a></b><b>Referenced in:</b><span><a href="#ref-for-removeTheEntry-1">4.3.2. 
 The close method</a></span><span><a href="#ref-for-removeTheEntry-2">9.5.1. 
 Methods and Parameters</a></span><span><a href="#ref-for-removeTheEntry-3">9.6. 
 Lifetime of Blob URLs</a></span></span></dfn> for a given <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-41">Blob URL</a> or for a given <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-105">Blob</a></code>,
@@ -3967,6 +3975,37 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <p>Special thanks to Olli Pettay, Nikunj Mehta, Garrett Smith, Aaron Boodman, Michael Nordman, Jian Li, Dmitry Titov, Ian Hickson, Darin Fisher, Sam Weinig, Adrian Bateman and Julian Reschke.</p>
    <p>Thanks to the W3C WebApps WG, and to participants on the public-webapps@w3.org listserv</p>
   </main>
+  <h2 class="no-ref no-num heading settled" id="conformance0"><span class="content">Conformance</span><a class="self-link" href="#conformance0"></a></h2>
+  <h3 class="no-ref no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h3>
+  <p>Conformance requirements are expressed with a combination of
+    descriptive assertions and RFC 2119 terminology. The key words “MUST”,
+    “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”,
+    “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative parts of this
+    document are to be interpreted as described in RFC 2119.
+    However, for readability, these words do not appear in all uppercase
+    letters in this specification. </p>
+  <p>All of the text of this specification is normative except sections
+    explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
+  <p>Examples in this specification are introduced with the words “for example”
+    or are set apart from the normative text with <code>class="example"</code>,
+    like this: </p>
+  <div class="example" id="example-f839f6c8">
+   <a class="self-link" href="#example-f839f6c8"></a> 
+   <p>This is an example of an informative example.</p>
+  </div>
+  <p>Informative notes begin with the word “Note” and are set apart from the
+    normative text with <code>class="note"</code>, like this: </p>
+  <p class="note" role="note">Note, this is an informative note.</p>
+  <h3 class="no-ref no-num heading settled" id="conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#conformant-algorithms"></a></h3>
+  <p>Requirements phrased in the imperative as part of algorithms (such as
+    "strip any leading space characters" or "return false and abort these
+    steps") are to be interpreted with the meaning of the key word ("must",
+    "should", "may", etc) used in introducing the algorithm.</p>
+  <p>Conformance requirements phrased as algorithms or specific steps can be
+    implemented in any manner, so long as the end result is <dfn data-dfn-type="dfn" data-lt="processing equivalence" data-noexport="" id="dfn-processing-equivalence">equivalent<a class="self-link" href="#dfn-processing-equivalence"></a></dfn>. In
+    particular, the algorithms defined in this specification are intended to
+    be easy to understand and are not intended to be performant. Implementers
+    are encouraged to optimize.</p>
 <script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
@@ -3994,7 +4033,6 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <li><a href="#autoRevoking">auto-revoking</a><span>, in §9.5.1</span>
    <li><a href="#dom-blob-blob">Blob()</a><span>, in §4</span>
    <li><a href="#dfn-Blob">Blob</a><span>, in §4</span>
-   <li><a href="#dom-blob-blob-blobparts-options">Blob(blobParts)</a><span>, in §4</span>
    <li><a href="#dom-blob-blob-blobparts-options">Blob(blobParts, options)</a><span>, in §4</span>
    <li><a href="#typedefdef-blobpart">BlobPart</a><span>, in §4</span>
    <li><a href="#dfn-BlobPropertyBag">BlobPropertyBag</a><span>, in §4</span>
@@ -4019,7 +4057,6 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
     </ul>
    <li><a href="#failureReason">failure reason</a><span>, in §8.1</span>
    <li><a href="#dfn-file">File</a><span>, in §5</span>
-   <li><a href="#dom-file-file">File(fileBits, fileName)</a><span>, in §5</span>
    <li><a href="#dom-file-file">File(fileBits, fileName, options)</a><span>, in §5</span>
    <li><a href="#dfn-filelist">FileList</a><span>, in §6</span>
    <li><a href="#FileLockFR">FileLock</a><span>, in §8.1</span>
@@ -4060,6 +4097,7 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <li><a href="#dfn-openState">OPENED</a><span>, in §4</span>
    <li><a href="#origin-of-a-blob-url">origin of a Blob URL</a><span>, in §9.3.1</span>
    <li><a href="#selection-looping">Preventing selection looping</a><span>, in §10</span>
+   <li><a href="#dfn-processing-equivalence">processing equivalence</a><span>, in §Unnumbered section</span>
    <li><a href="#process-read">process read</a><span>, in §7.1</span>
    <li><a href="#process-read-data">process read data</a><span>, in §7.1</span>
    <li><a href="#process-read-EOF">process read EOF</a><span>, in §7.1</span>
@@ -4218,7 +4256,7 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <li>
     <a data-link-type="biblio" href="#biblio-webidl">[WebIDL]</a> defines the following terms:
     <ul>
-     <li><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
+     <li><a href="http://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
      <li><a href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-supported-property-indices">supported property indices</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-throw">throw</a>
@@ -4234,62 +4272,62 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
-   <dt id="biblio-ecma-262">[ECMA-262]
+   <dt id="biblio-ecma-262"><a class="self-link" href="#biblio-ecma-262"></a>[ECMA-262]
    <dd><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.github.io/ecma262/">https://tc39.github.io/ecma262/</a>
-   <dt id="biblio-fetch">[FETCH]
+   <dt id="biblio-fetch"><a class="self-link" href="#biblio-fetch"></a>[FETCH]
    <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
-   <dt id="biblio-html">[HTML]
+   <dt id="biblio-html"><a class="self-link" href="#biblio-html"></a>[HTML]
    <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
-   <dt id="biblio-mimesniff">[MIMESNIFF]
+   <dt id="biblio-mimesniff"><a class="self-link" href="#biblio-mimesniff"></a>[MIMESNIFF]
    <dd>Gordon P. Hemsley. <a href="https://mimesniff.spec.whatwg.org/">MIME Sniffing Standard</a>. Living Standard. URL: <a href="https://mimesniff.spec.whatwg.org/">https://mimesniff.spec.whatwg.org/</a>
-   <dt id="biblio-progress-events">[PROGRESS-EVENTS]
-   <dd>Anne van Kesteren; Charles McCathie Nevile; Jungkee Song. <a href="http://www.w3.org/TR/progress-events/">Progress Events</a>. 11 February 2014. REC. URL: <a href="http://www.w3.org/TR/progress-events/">http://www.w3.org/TR/progress-events/</a>
-   <dt id="biblio-rfc2046">[RFC2046]
-   <dd>N. Freed; N. Borenstein. <a href="https://tools.ietf.org/html/rfc2046">Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types</a>. November 1996. Draft Standard. URL: <a href="https://tools.ietf.org/html/rfc2046">https://tools.ietf.org/html/rfc2046</a>
-   <dt id="biblio-rfc2119">[RFC2119]
-   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
-   <dt id="biblio-rfc2397">[RFC2397]
-   <dd>L. Masinter. <a href="https://tools.ietf.org/html/rfc2397">The "data" URL scheme</a>. August 1998. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc2397">https://tools.ietf.org/html/rfc2397</a>
-   <dt id="biblio-rfc5234">[RFC5234]
-   <dd>D. Crocker, Ed.; P. Overell. <a href="https://tools.ietf.org/html/rfc5234">Augmented BNF for Syntax Specifications: ABNF</a>. January 2008. Internet Standard. URL: <a href="https://tools.ietf.org/html/rfc5234">https://tools.ietf.org/html/rfc5234</a>
-   <dt id="biblio-rfc6266">[RFC6266]
-   <dd>J. Reschke. <a href="https://tools.ietf.org/html/rfc6266">Use of the Content-Disposition Header Field in the Hypertext Transfer Protocol (HTTP)</a>. June 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6266">https://tools.ietf.org/html/rfc6266</a>
-   <dt id="biblio-rfc6454">[RFC6454]
-   <dd>A. Barth. <a href="https://tools.ietf.org/html/rfc6454">The Web Origin Concept</a>. December 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6454">https://tools.ietf.org/html/rfc6454</a>
-   <dt id="biblio-rfc7230">[RFC7230]
-   <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://tools.ietf.org/html/rfc7230">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7230">https://tools.ietf.org/html/rfc7230</a>
-   <dt id="biblio-rfc7231">[RFC7231]
-   <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7231">https://tools.ietf.org/html/rfc7231</a>
-   <dt id="biblio-streams">[STREAMS]
+   <dt id="biblio-streams"><a class="self-link" href="#biblio-streams"></a>[STREAMS]
    <dd>Domenic Denicola. <a href="https://streams.spec.whatwg.org/">Streams Standard</a>. Living Standard. URL: <a href="https://streams.spec.whatwg.org/">https://streams.spec.whatwg.org/</a>
-   <dt id="biblio-typedarray">[TYPEDARRAY]
-   <dd>David Herman; Kenneth Russell. <a href="https://www.khronos.org/registry/typedarray/specs/latest/">Typed Array Specification</a>. 26 June 2013. Khronos Working Draft. URL: <a href="https://www.khronos.org/registry/typedarray/specs/latest/">https://www.khronos.org/registry/typedarray/specs/latest/</a>
-   <dt id="biblio-unicode">[UNICODE]
+   <dt id="biblio-unicode"><a class="self-link" href="#biblio-unicode"></a>[UNICODE]
    <dd><a href="http://www.unicode.org/versions/latest/">The Unicode Standard</a>. URL: <a href="http://www.unicode.org/versions/latest/">http://www.unicode.org/versions/latest/</a>
-   <dt id="biblio-webidl">[WebIDL]
-   <dd>Cameron McCormack; Boris Zbarsky. <a href="https://heycam.github.io/webidl/">WebIDL Level 1</a>. 8 March 2016. CR. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
-   <dt id="biblio-whatwg-dom">[WHATWG-DOM]
+   <dt id="biblio-whatwg-dom"><a class="self-link" href="#biblio-whatwg-dom"></a>[WHATWG-DOM]
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
-   <dt id="biblio-whatwg-encoding">[WHATWG-ENCODING]
+   <dt id="biblio-whatwg-encoding"><a class="self-link" href="#biblio-whatwg-encoding"></a>[WHATWG-ENCODING]
    <dd>Anne van Kesteren. <a href="https://encoding.spec.whatwg.org/">Encoding Standard</a>. Living Standard. URL: <a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>
-   <dt id="biblio-whatwg-url">[WHATWG-URL]
+   <dt id="biblio-whatwg-url"><a class="self-link" href="#biblio-whatwg-url"></a>[WHATWG-URL]
    <dd>Anne van Kesteren; Sam Ruby. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
-   <dt id="biblio-workers">[WORKERS]
-   <dd>Ian Hickson. <a href="http://www.w3.org/TR/workers/">Web Workers</a>. 24 September 2015. WD. URL: <a href="http://www.w3.org/TR/workers/">http://www.w3.org/TR/workers/</a>
-   <dt id="biblio-xhr">[XHR]
+   <dt id="biblio-webidl"><a class="self-link" href="#biblio-webidl"></a>[WebIDL]
+   <dd>Cameron McCormack; Boris Zbarsky. <a href="https://heycam.github.io/webidl/">WebIDL Level 1</a>. 4 August 2015. WD. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dt id="biblio-xhr"><a class="self-link" href="#biblio-xhr"></a>[XHR]
    <dd>Anne van Kesteren. <a href="https://xhr.spec.whatwg.org/">XMLHttpRequest Standard</a>. Living Standard. URL: <a href="https://xhr.spec.whatwg.org/">https://xhr.spec.whatwg.org/</a>
+   <dt id="biblio-progress-events"><a class="self-link" href="#biblio-progress-events"></a>[PROGRESS-EVENTS]
+   <dd>Anne van Kesteren; Charles McCathie Nevile; Jungkee Song. <a href="http://www.w3.org/TR/progress-events/">Progress Events</a>. 11 February 2014. REC. URL: <a href="http://www.w3.org/TR/progress-events/">http://www.w3.org/TR/progress-events/</a>
+   <dt id="biblio-rfc2046"><a class="self-link" href="#biblio-rfc2046"></a>[RFC2046]
+   <dd>N. Freed; N. Borenstein. <a href="https://tools.ietf.org/html/rfc2046">Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types</a>. November 1996. Draft Standard. URL: <a href="https://tools.ietf.org/html/rfc2046">https://tools.ietf.org/html/rfc2046</a>
+   <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[RFC2119]
+   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-rfc2397"><a class="self-link" href="#biblio-rfc2397"></a>[RFC2397]
+   <dd>L. Masinter. <a href="https://tools.ietf.org/html/rfc2397">The "data" URL scheme</a>. August 1998. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc2397">https://tools.ietf.org/html/rfc2397</a>
+   <dt id="biblio-rfc5234"><a class="self-link" href="#biblio-rfc5234"></a>[RFC5234]
+   <dd>D. Crocker, Ed.; P. Overell. <a href="https://tools.ietf.org/html/rfc5234">Augmented BNF for Syntax Specifications: ABNF</a>. January 2008. Internet Standard. URL: <a href="https://tools.ietf.org/html/rfc5234">https://tools.ietf.org/html/rfc5234</a>
+   <dt id="biblio-rfc6266"><a class="self-link" href="#biblio-rfc6266"></a>[RFC6266]
+   <dd>J. Reschke. <a href="https://tools.ietf.org/html/rfc6266">Use of the Content-Disposition Header Field in the Hypertext Transfer Protocol (HTTP)</a>. June 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6266">https://tools.ietf.org/html/rfc6266</a>
+   <dt id="biblio-rfc6454"><a class="self-link" href="#biblio-rfc6454"></a>[RFC6454]
+   <dd>A. Barth. <a href="https://tools.ietf.org/html/rfc6454">The Web Origin Concept</a>. December 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6454">https://tools.ietf.org/html/rfc6454</a>
+   <dt id="biblio-rfc7230"><a class="self-link" href="#biblio-rfc7230"></a>[RFC7230]
+   <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://tools.ietf.org/html/rfc7230">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7230">https://tools.ietf.org/html/rfc7230</a>
+   <dt id="biblio-rfc7231"><a class="self-link" href="#biblio-rfc7231"></a>[RFC7231]
+   <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7231">https://tools.ietf.org/html/rfc7231</a>
+   <dt id="biblio-typedarray"><a class="self-link" href="#biblio-typedarray"></a>[TYPEDARRAY]
+   <dd>David Herman; Kenneth Russell. <a href="https://www.khronos.org/registry/typedarray/specs/latest/">Typed Array Specification</a>. 26 June 2013. Khronos Working Draft. URL: <a href="https://www.khronos.org/registry/typedarray/specs/latest/">https://www.khronos.org/registry/typedarray/specs/latest/</a>
+   <dt id="biblio-workers"><a class="self-link" href="#biblio-workers"></a>[WORKERS]
+   <dd>Ian Hickson. <a href="http://www.w3.org/TR/workers/">Web Workers</a>. 24 September 2015. WD. URL: <a href="http://www.w3.org/TR/workers/">http://www.w3.org/TR/workers/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
-   <dt id="biblio-rfc1630">[RFC1630]
+   <dt id="biblio-rfc1630"><a class="self-link" href="#biblio-rfc1630"></a>[RFC1630]
    <dd>T. Berners-Lee. <a href="https://tools.ietf.org/html/rfc1630">Universal Resource Identifiers in WWW: A Unifying Syntax for the Expression of Names and Addresses of Objects on the Network as used in the World-Wide Web</a>. June 1994. Informational. URL: <a href="https://tools.ietf.org/html/rfc1630">https://tools.ietf.org/html/rfc1630</a>
-   <dt id="biblio-rfc1738">[RFC1738]
+   <dt id="biblio-rfc1738"><a class="self-link" href="#biblio-rfc1738"></a>[RFC1738]
    <dd>T. Berners-Lee; L. Masinter; M. McCahill. <a href="https://tools.ietf.org/html/rfc1738">Uniform Resource Locators (URL)</a>. December 1994. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc1738">https://tools.ietf.org/html/rfc1738</a>
-   <dt id="biblio-rfc3986">[RFC3986]
+   <dt id="biblio-rfc3986"><a class="self-link" href="#biblio-rfc3986"></a>[RFC3986]
    <dd>T. Berners-Lee; R. Fielding; L. Masinter. <a href="https://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>. January 2005. Internet Standard. URL: <a href="https://tools.ietf.org/html/rfc3986">https://tools.ietf.org/html/rfc3986</a>
-   <dt id="biblio-rfc4122">[RFC4122]
+   <dt id="biblio-rfc4122"><a class="self-link" href="#biblio-rfc4122"></a>[RFC4122]
    <dd>P. Leach; M. Mealling; R. Salz. <a href="https://tools.ietf.org/html/rfc4122">A Universally Unique IDentifier (UUID) URN Namespace</a>. July 2005. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc4122">https://tools.ietf.org/html/rfc4122</a>
-   <dt id="biblio-webrtc">[WEBRTC]
+   <dt id="biblio-webrtc"><a class="self-link" href="#biblio-webrtc"></a>[WEBRTC]
    <dd>Adam Bergkvist; et al. <a href="http://www.w3.org/TR/webrtc/">WebRTC 1.0: Real-time Communication Between Browsers</a>. 28 January 2016. WD. URL: <a href="http://www.w3.org/TR/webrtc/">http://www.w3.org/TR/webrtc/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
@@ -4378,6 +4416,7 @@ interface <a href="#dfn-FileReaderSync">FileReaderSync</a> {
   DOMString <a class="idl-code" data-link-type="method" href="#dfn-readAsDataURLSync">readAsDataURL</a>(<a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
 };
 
+[Exposed=Window,DedicatedWorker,SharedWorker]
 partial interface <a class="idl-code" data-link-type="interface" href="https://url.spec.whatwg.org/#url">URL</a> {
   static DOMString <a class="idl-code" data-link-type="method" href="#dfn-createObjectURL">createObjectURL</a>(<a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
   static DOMString <a class="idl-code" data-link-type="method" href="#dfn-createFor">createFor</a>(<a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);


### PR DESCRIPTION
…vice worker global.

There has been a discussion around what the lifetime of a blob URL created in a service worker would be: https://github.com/slightlyoff/ServiceWorker/issues/688

During the f2f discussion last week, the service worker folks reached a consensus that the methods creating/revoking a blob URL should not be exposed on the service worker global. The rationale is the lifetime of a servic worker global hinges on the UAs decision and designed to be short unless needed. It can be exposed in the future when devs request with compelling use cases.