### PR TITLE
Re-add readAsBinaryString()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1013,6 +1013,7 @@ interface FileReader: EventTarget {
 
   // async read methods
   void readAsArrayBuffer(Blob blob);
+  void readAsBinaryString(Blob blob);
   void readAsText(Blob blob, optional DOMString label);
   void readAsDataURL(Blob blob);
 
@@ -1116,14 +1117,14 @@ which must be one of the following values:
 <h4 id="reading-a-file">
 Reading a File or Blob</h4>
 
-The {{FileReader}} interface makes available three <dfn id="asynchronous-read-methods" lt="asynchronous read method">asynchronous read methods</dfn>--
-{{FileReader/readAsArrayBuffer()}}, {{FileReader/readAsText()}}, and {{FileReader/readAsDataURL()}},
+The {{FileReader}} interface makes available several <dfn id="asynchronous-read-methods" lt="asynchronous read method">asynchronous read methods</dfn>--
+{{FileReader/readAsArrayBuffer()}}, {{FileReader/readAsBinaryString()}}, {{FileReader/readAsText()}} and {{FileReader/readAsDataURL()}},
 which read files into memory.
 If multiple concurrent read methods are called on the same {{FileReader}} object,
 user agents must throw an {{InvalidStateError}} on any of the read methods that occur
 when {{FileReader/readyState}} = {{FileReader/LOADING}}.
 
-({{FileReaderSync}} makes available three <a>synchronous read methods</a>.
+({{FileReaderSync}} makes available several <a>synchronous read methods</a>.
   Collectively, the sync and async read methods of {{FileReader}} and {{FileReaderSync}}
   are referred to as just <dfn lt="read method">read methods</dfn>.)
 
@@ -1149,6 +1150,11 @@ and is the conformance criteria for this attribute:
 * On getting, if the {{FileReader/readAsDataURL()}} <a>read method</a> is used,
   the {{FileReader/result}} attribute must return a {{DOMString}}
   that is a Data URL [[!RFC2397]] encoding of the {{File}} or {{Blob}}'s data.
+* On getting, if the {{FileReader/readAsBinaryString()}} <a>read method</a> is called
+  and no error in reading the {{File}} or {{Blob}} has occurred,
+  then the {{FileReader/result}} attribute must return a {{DOMString}}
+  representing the {{File}} or {{Blob}}'s data as a <dfn>binary string</dfn>,
+  in which every byte is represented by a code unit of equal value [0...255].
 * On getting, if the {{FileReader/readAsText()}} <a>read method</a> is called
   and no error in reading the {{File}} or {{Blob}} has occurred,
   then the {{FileReader/result}} attribute must return a string
@@ -1258,6 +1264,41 @@ the user agent must run the steps below.
     do NOT fire {{loadend}} at the <a>context object</a>.
 9. <a>Terminate this algorithm</a>.
 
+<h5 id="readAsBinaryString">
+The {{FileReader/readAsBinaryString()}} method</h5>
+
+When the <dfn method for=FileReader id="dfn-readAsBinaryString">readAsBinaryString(blob)</dfn> method is called,
+the user agent must run the steps below.
+
+1. If {{FileReader/readyState}} = {{FileReader/LOADING}} throw an {{InvalidStateError}} exception and <a>terminate this algorithm</a>.
+2. If the <code>blob</code> is in the <a for="Blob/readability state">CLOSED</a> <a>readability state</a>,
+  set the {{error!!attribute}} attribute of the <a>context object</a>
+  to return an {{InvalidStateError}} exception
+  and <a>fire a progress event</a> called {{error!!event}} at the <a>context object</a>.
+  <a>Terminate this algorithm</a>.
+3. Otherwise set {{FileReader/readyState}} to {{FileReader/LOADING}}.
+4. Initiate an <a>annotated task read operation</a> using the <code>blob</code> argument as <var>input</var>
+  and handle <a lt="queue a task">tasks queued</a> on the <a>file reading task source</a> per below.
+5. To <a>process read error</a> with a <a>failure reason</a>,
+  proceed to the [[#dfn-error-steps]].
+6. To <a>process read</a> <a>fire a progress event</a> called {{loadstart}} at the <a>context object</a>.
+7. To <a>process read data</a> <a>fire a progress event</a> called {{progress}} at the <a>context object</a>.
+8. To <a>process read EOF</a> run these substeps:
+  1. Set {{FileReader/readyState}} to {{FileReader/DONE}}
+  2. Set the {{FileReader/result}} attribute to the <a>body</a> returned by the <a>read operation</a> as a <a>binary string</a>.
+  3. <a>Fire a progress event</a> called {{load}} at the <a>context object</a>.
+  4. Unless {{FileReader/readyState}} is {{FileReader/LOADING}}
+    <a>fire a progress event</a> called {{loadend}} at the <a>context object</a>.
+    If {{FileReader/readyState}} is {{FileReader/LOADING}}
+    do NOT fire {{loadend}} at the <a>context object</a>.
+9. <a>Terminate this algorithm</a>.
+
+<div class=note>
+  The use of {{FileReader/readAsArrayBuffer()}} is preferred over
+  {{FileReader/readAsBinaryString()}}, which is provided for backwards
+  compatibility.
+</div>
+
 <h5 id="dfn-error-steps">
 Error Steps</h5>
 
@@ -1298,15 +1339,15 @@ the user agent must run the steps below:
 <h5 id="blobAndFileParams">
 Blob Parameters</h5>
 
-The three <a>asynchronous read methods</a>,
-the three <a>synchronous read methods</a>,
+The <a>asynchronous read methods</a>,
+the <a>synchronous read methods</a>,
 <code>URL.{{URL/createObjectURL()}}</code>
 and <code>URL.{{URL/createFor()}}</code>
 take a {{Blob}} parameter.
 This section defines this parameter.
 
 <dl>
-  <dt><dfn id="dfn-fileBlob" argument for="FileReader/readAsArrayBuffer(blob), FileReader/readAsText(blob, label), FileReader/readAsDataURL(blob), URL/createObjectURL(blob), URL/createFor(blob), FileReaderSync/readAsArrayBuffer(blob), FileReaderSync/readAsText(blob, label), FileReaderSync/readAsDataURL(blob)">blob</dfn>
+  <dt><dfn id="dfn-fileBlob" argument for="FileReader/readAsArrayBuffer(blob), FileReader/readAsBinaryString(blob), FileReader/readAsText(blob, label), FileReader/readAsDataURL(blob), URL/createObjectURL(blob), URL/createFor(blob), FileReaderSync/readAsArrayBuffer(blob), FileReaderSync/readAsBinaryString(blob), FileReaderSync/readAsText(blob, label), FileReaderSync/readAsDataURL(blob)">blob</dfn>
   <dd>This is a {{Blob}} argument
     and must be a reference to a single {{File}} in a {{FileList}}
     or a {{Blob}} argument not obtained from the underlying OS file system.
@@ -1464,6 +1505,7 @@ interface FileReaderSync {
   // Synchronously return strings
 
   ArrayBuffer readAsArrayBuffer(Blob blob);
+  DOMString readAsBinaryString(Blob blob);
   DOMString readAsText(Blob blob, optional DOMString label);
   DOMString readAsDataURL(Blob blob);
 };
@@ -1542,6 +1584,32 @@ the following steps must be followed:
   throw the appropriate exception as defined in [[#dfn-error-codes]].
   <a>Terminate this algorithm</a>.
 4. If no error has occurred, return the <var>result</var> of the <a>read operation</a> as an {{ArrayBuffer}}.
+
+<h5 id="readAsBinaryStringSyncSection">
+The {{FileReaderSync/readAsBinaryString()}} method</h5>
+
+When the <dfn method for=FileReaderSync id="dfn-readAsBinaryStringSync">readAsBinaryString(blob)</dfn> method is called,
+the following steps must be followed:
+
+1. If {{FileReader/readyState}} = {{FileReader/LOADING}}
+  throw an {{InvalidStateError}} exception
+  and <a>terminate this algorithm</a>.
+2. If the <code>blob</code> has been closed through the {{Blob/close()}} method,
+  throw an {{InvalidStateError}} exception
+  and <a>terminate this algorithm</a>.
+3. Otherwise, initiate a <a>read operation</a> using the <code>blob</code> argument,
+  and with the <a>synchronous flag</a> <em>set</em>.
+  If the <a>read operation</a> returns failure,
+  throw the appropriate exception as defined in [[#dfn-error-codes]].
+  <a>Terminate this algorithm</a>.
+4. If no error has occurred, return the <var>result</var> of the
+  <a>read operation</a> as an <a>binary string</a>.
+
+<div class=note>
+  The use of {{FileReaderSync/readAsArrayBuffer()}} is preferred over
+  {{FileReaderSync/readAsBinaryString()}}, which is provided for
+  backwards compatibility.
+</div>
 
 <h2 id="ErrorAndException">
 Errors and Exceptions</h2>

--- a/index.html
+++ b/index.html
@@ -409,15 +409,18 @@
 	}
 
 	/* Style for algorithms */
-	ol.algorithm ol:not(.algorithm) {
+	ol.algorithm ol:not(.algorithm),
+	.algorithm > ol ol:not(.algorithm) {
 	 border-left: 0.5em solid #DEF;
 	}
 
 	/* Style for switch/case <dl>s */
-	dl.switch > dd > ol.only {
+	dl.switch > dd > ol.only,
+	dl.switch > dd > .only > ol {
 	 margin-left: 0;
 	}
-	dl.switch > dd > ol.algorithm {
+	dl.switch > dd > ol.algorithm,
+	dl.switch > dd > .algorithm > ol {
 	 margin-left: -2em;
 	}
 	dl.switch {
@@ -963,10 +966,9 @@ Possible extra rowspan handling
 	/* ToC not indented until third level, but font style & margins show hierarchy */
 	.toc > li             { font-weight: bold;   }
 	.toc > li li          { font-weight: normal; }
-	.toc > li li li       { font-style:  italic; }
-	.toc > li li li li    { font-style:  normal; }
-	.toc > li li li li li { font-style:  italic;
-	                        font-size:   85%;    }
+	.toc > li li li       { font-size:   95%;    }
+	.toc > li li li li    { font-size:   90%;    }
+	.toc > li li li li li { font-size:   85%;    }
 
 	.toc > li             { margin: 1.5rem 0;    }
 	.toc > li li          { margin: 0.3rem 0;    }
@@ -1149,171 +1151,163 @@ Possible extra rowspan handling
 			*/
 		}
 	}
-
-/******************************************************************************/
-/*                                  Bikeshed                                  */
-/******************************************************************************/
-
-	/* Style for paragraphs I know are in MD-genned lists */
-	/* This is a weird hack for me not yet following the commonmark spec
-	   regarding paragraph and lists. */
-	[data-md] > :first-child {
-		margin-top: 0;
-	}
-	[data-md] > :last-child {
-		margin-bottom: 0;
-	}
-
-/** Inline CSS fragments ******************************************************/
-
-	.css.css, .property.property, .descriptor.descriptor {
-		color: #005a9c;
-		font-size: inherit;
-		font-family: inherit;
-	}
-	.css::before, .property::before, .descriptor::before {
-		content: "‘";
-	}
-	.css::after, .property::after, .descriptor::after {
-		content: "’";
-	}
-	.property, .descriptor {
-		/* Don't wrap property and descriptor names */
-		white-space: nowrap;
-	}
-	.type { /* CSS value <type> */
-		font-style: italic;
-	}
-	pre .property::before, pre .property::after {
-		content: "";
-	}
-
-/** Autolinks produced using Bikeshed *****************************************/
-
-	[data-link-type]:not([data-link-type="dfn"]),
-	[data-dfn-type]:not([data-dfn-type="dfn"]) {
-		hyphens: none;
-	}
-
-	[data-link-type="property"]::before,
-	[data-link-type="propdesc"]::before,
-	[data-link-type="descriptor"]::before,
-	[data-link-type="value"]::before,
-	[data-link-type="function"]::before,
-	[data-link-type="at-rule"]::before,
-	[data-link-type="selector"]::before,
-	[data-link-type="maybe"]::before {
-		content: "‘";
-	}
-	[data-link-type="property"]::after,
-	[data-link-type="propdesc"]::after,
-	[data-link-type="descriptor"]::after,
-	[data-link-type="value"]::after,
-	[data-link-type="function"]::after,
-	[data-link-type="at-rule"]::after,
-	[data-link-type="selector"]::after,
-	[data-link-type="maybe"]::after {
-		content: "’";
-	}
-
-	[data-link-type].production::before,
-	[data-link-type].production::after,
-	.prod [data-link-type]::before,
-	.prod [data-link-type]::after {
-		content: "";
-	}
-
-	[data-link-type=element],
-	[data-link-type=element-attr] {
-		font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
-		font-size: .9em;
-	}
-	[data-link-type=element]::before { content: "<" }
-	[data-link-type=element]::after  { content: ">" }
-
-	[data-link-type=biblio] {
-		white-space: pre;
-	}
-
-/** Self-Links ****************************************************************/
-/* Auto-generated links from an element to its own anchor, for usability */
-
-	.heading, .issue, .note, .example, li, dt {
-		position: relative;
-	}
-	a.self-link {
-		position: absolute;
-		top: 0;
-		left: calc(-1 * (3.5rem - 26px));
-		width: calc(3.5rem - 26px);
-		height: 2em;
-		text-align: center;
-		border: none;
-		transition: opacity .2s;
-		opacity: .5;
-	}
-	a.self-link:hover {
-		opacity: 1;
-	}
-	.heading > a.self-link {
-		font-size: 83%;
-	}
-	li > a.self-link {
-		left: calc(-1 * (3.5rem - 26px) - 2em);
-	}
-	dfn > a.self-link {
-		top: auto;
-		left: auto;
-		opacity: 0;
-		width: 1.5em;
-		height: 1.5em;
-		background: gray;
-		color: white;
-		font-style: normal;
-		transition: opacity .2s, background-color .2s, color .2s;
-	}
-	dfn:hover > a.self-link {
-		opacity: 1;
-	}
-	dfn > a.self-link:hover {
-		color: black;
-	}
-
-	a.self-link::before            { content: "¶"; }
-	.heading > a.self-link::before { content: "§"; }
-	dfn > a.self-link::before      { content: "#"; }
-
-/** Counters ******************************************************************/
-/* Adds the auto-genned issue/example counters,
-   until Bikeshed fills in manual ones. */
-	.issue:not(.no-marker)::before {
-		content: "Issue " counter(issue);
-	}
-
-	.example:not(.no-marker)::before {
-		content: "Example";
-		content: "Example " counter(example);
-	}
-	.invalid.example:not(.no-marker)::before,
-	.illegal.example:not(.no-marker)::before {
-		content: "Invalid Example";
-		content: "Invalid Example" counter(example);
-	}
-
-
-
-/********************************************
- Remember to fix the logo section when copypasting freshly.
- */
 </style>
   <meta content="Bikeshed 1.0.0" name="generator">
-<style>
+<style>/* style-md-lists */
+
+            /* This is a weird hack for me not yet following the commonmark spec
+               regarding paragraph and lists. */
+            [data-md] > :first-child {
+                margin-top: 0;
+            }
+            [data-md] > :last-child {
+                margin-bottom: 0;
+            }</style>
+<style>/* style-selflinks */
+
+            .heading, .issue, .note, .example, li, dt {
+                position: relative;
+            }
+            a.self-link {
+                position: absolute;
+                top: 0;
+                left: calc(-1 * (3.5rem - 26px));
+                width: calc(3.5rem - 26px);
+                height: 2em;
+                text-align: center;
+                border: none;
+                transition: opacity .2s;
+                opacity: .5;
+            }
+            a.self-link:hover {
+                opacity: 1;
+            }
+            .heading > a.self-link {
+                font-size: 83%;
+            }
+            li > a.self-link {
+                left: calc(-1 * (3.5rem - 26px) - 2em);
+            }
+            dfn > a.self-link {
+                top: auto;
+                left: auto;
+                opacity: 0;
+                width: 1.5em;
+                height: 1.5em;
+                background: gray;
+                color: white;
+                font-style: normal;
+                transition: opacity .2s, background-color .2s, color .2s;
+            }
+            dfn:hover > a.self-link {
+                opacity: 1;
+            }
+            dfn > a.self-link:hover {
+                color: black;
+            }
+
+            a.self-link::before            { content: "¶"; }
+            .heading > a.self-link::before { content: "§"; }
+            dfn > a.self-link::before      { content: "#"; }</style>
+<style>/* style-counters */
+
+            body {
+                counter-reset: example figure issue;
+            }
+            .issue {
+                counter-increment: issue;
+            }
+            .issue:not(.no-marker)::before {
+                content: "Issue " counter(issue);
+            }
+
+            .example {
+                counter-increment: example;
+            }
+            .example:not(.no-marker)::before {
+                content: "Example " counter(example);
+            }
+            .invalid.example:not(.no-marker)::before,
+            .illegal.example:not(.no-marker)::before {
+                content: "Invalid Example" counter(example);
+            }
+
+            figcaption {
+                counter-increment: figure;
+            }
+            figcaption:not(.no-marker)::before {
+                content: "Figure " counter(figure);
+            }</style>
+<style>/* style-autolinks */
+
+            .css.css, .property.property, .descriptor.descriptor {
+                color: #005a9c;
+                font-size: inherit;
+                font-family: inherit;
+            }
+            .css::before, .property::before, .descriptor::before {
+                content: "‘";
+            }
+            .css::after, .property::after, .descriptor::after {
+                content: "’";
+            }
+            .property, .descriptor {
+                /* Don't wrap property and descriptor names */
+                white-space: nowrap;
+            }
+            .type { /* CSS value <type> */
+                font-style: italic;
+            }
+            pre .property::before, pre .property::after {
+                content: "";
+            }
+            [data-link-type="property"]::before,
+            [data-link-type="propdesc"]::before,
+            [data-link-type="descriptor"]::before,
+            [data-link-type="value"]::before,
+            [data-link-type="function"]::before,
+            [data-link-type="at-rule"]::before,
+            [data-link-type="selector"]::before,
+            [data-link-type="maybe"]::before {
+                content: "‘";
+            }
+            [data-link-type="property"]::after,
+            [data-link-type="propdesc"]::after,
+            [data-link-type="descriptor"]::after,
+            [data-link-type="value"]::after,
+            [data-link-type="function"]::after,
+            [data-link-type="at-rule"]::after,
+            [data-link-type="selector"]::after,
+            [data-link-type="maybe"]::after {
+                content: "’";
+            }
+
+            [data-link-type].production::before,
+            [data-link-type].production::after,
+            .prod [data-link-type]::before,
+            .prod [data-link-type]::after {
+                content: "";
+            }
+
+            [data-link-type=element],
+            [data-link-type=element-attr] {
+                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+                font-size: .9em;
+            }
+            [data-link-type=element]::before { content: "<" }
+            [data-link-type=element]::after  { content: ">" }
+
+            [data-link-type=biblio] {
+                white-space: pre;
+            }</style>
+<style>/* style-dfn-panel */
+
         .dfn-panel {
-            display: inline-block;
             position: absolute;
             z-index: 35;
             height: auto;
             width: -webkit-fit-content;
+            width: fit-content;
             max-width: 300px;
             max-height: 500px;
             overflow: auto;
@@ -1329,12 +1323,13 @@ Possible extra rowspan handling
         .dfn-panel a { color: black; }
         .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
         .dfn-panel > b + b { margin-top: 0.25em; }
-        .dfn-panel > span { display: list-item; list-style: inside; }
+        .dfn-panel ul { padding: 0; }
+        .dfn-panel li { list-style: inside; }
         .dfn-panel.activated {
             display: inline-block;
             position: fixed;
             left: .5em;
-            bottom: .5em;
+            bottom: 2em;
             margin: 0 auto;
             max-width: calc(100vw - 1.5em - .4em - .5em);
             max-height: 30vh;
@@ -1342,74 +1337,74 @@ Possible extra rowspan handling
 
         .dfn-paneled { cursor: pointer; }
         </style>
-<style>.highlight .hll { background-color: #ffffcc }
-.highlight  { background: #ffffff; }
-.highlight .c { color: #708090 } /* Comment */
-.highlight .k { color: #990055 } /* Keyword */
-.highlight .l { color: #000000 } /* Literal */
-.highlight .n { color: #0077aa } /* Name */
-.highlight .o { color: #999999 } /* Operator */
-.highlight .p { color: #999999 } /* Punctuation */
-.highlight .cm { color: #708090 } /* Comment.Multiline */
-.highlight .cp { color: #708090 } /* Comment.Preproc */
-.highlight .c1 { color: #708090 } /* Comment.Single */
-.highlight .cs { color: #708090 } /* Comment.Special */
-.highlight .kc { color: #990055 } /* Keyword.Constant */
-.highlight .kd { color: #990055 } /* Keyword.Declaration */
-.highlight .kn { color: #990055 } /* Keyword.Namespace */
-.highlight .kp { color: #990055 } /* Keyword.Pseudo */
-.highlight .kr { color: #990055 } /* Keyword.Reserved */
-.highlight .kt { color: #990055 } /* Keyword.Type */
-.highlight .ld { color: #000000 } /* Literal.Date */
-.highlight .m { color: #000000 } /* Literal.Number */
-.highlight .s { color: #a67f59 } /* Literal.String */
-.highlight .na { color: #0077aa } /* Name.Attribute */
-.highlight .nc { color: #0077aa } /* Name.Class */
-.highlight .no { color: #0077aa } /* Name.Constant */
-.highlight .nd { color: #0077aa } /* Name.Decorator */
-.highlight .ni { color: #0077aa } /* Name.Entity */
-.highlight .ne { color: #0077aa } /* Name.Exception */
-.highlight .nf { color: #0077aa } /* Name.Function */
-.highlight .nl { color: #0077aa } /* Name.Label */
-.highlight .nn { color: #0077aa } /* Name.Namespace */
-.highlight .py { color: #0077aa } /* Name.Property */
-.highlight .nt { color: #669900 } /* Name.Tag */
-.highlight .nv { color: #0077aa } /* Name.Variable */
-.highlight .ow { color: #999999 } /* Operator.Word */
-.highlight .mb { color: #000000 } /* Literal.Number.Bin */
-.highlight .mf { color: #000000 } /* Literal.Number.Float */
-.highlight .mh { color: #000000 } /* Literal.Number.Hex */
-.highlight .mi { color: #000000 } /* Literal.Number.Integer */
-.highlight .mo { color: #000000 } /* Literal.Number.Oct */
-.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-.highlight .sc { color: #a67f59 } /* Literal.String.Char */
-.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-.highlight .se { color: #a67f59 } /* Literal.String.Escape */
-.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-.highlight .sx { color: #a67f59 } /* Literal.String.Other */
-.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-.highlight .vc { color: #0077aa } /* Name.Variable.Class */
-.highlight .vg { color: #0077aa } /* Name.Variable.Global */
-.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
-        .highlight { background: hsl(24, 20%, 95%); }
+<style>/* style-syntax-highlighting */
+pre.idl.highlight { color: #708090; }
+        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
         code.highlight { padding: .1em; border-radius: .3em; }
         pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+        .highlight .c { color: #708090 } /* Comment */
+        .highlight .k { color: #990055 } /* Keyword */
+        .highlight .l { color: #000000 } /* Literal */
+        .highlight .n { color: #0077aa } /* Name */
+        .highlight .o { color: #999999 } /* Operator */
+        .highlight .p { color: #999999 } /* Punctuation */
+        .highlight .cm { color: #708090 } /* Comment.Multiline */
+        .highlight .cp { color: #708090 } /* Comment.Preproc */
+        .highlight .c1 { color: #708090 } /* Comment.Single */
+        .highlight .cs { color: #708090 } /* Comment.Special */
+        .highlight .kc { color: #990055 } /* Keyword.Constant */
+        .highlight .kd { color: #990055 } /* Keyword.Declaration */
+        .highlight .kn { color: #990055 } /* Keyword.Namespace */
+        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
+        .highlight .kr { color: #990055 } /* Keyword.Reserved */
+        .highlight .kt { color: #990055 } /* Keyword.Type */
+        .highlight .ld { color: #000000 } /* Literal.Date */
+        .highlight .m { color: #000000 } /* Literal.Number */
+        .highlight .s { color: #a67f59 } /* Literal.String */
+        .highlight .na { color: #0077aa } /* Name.Attribute */
+        .highlight .nc { color: #0077aa } /* Name.Class */
+        .highlight .no { color: #0077aa } /* Name.Constant */
+        .highlight .nd { color: #0077aa } /* Name.Decorator */
+        .highlight .ni { color: #0077aa } /* Name.Entity */
+        .highlight .ne { color: #0077aa } /* Name.Exception */
+        .highlight .nf { color: #0077aa } /* Name.Function */
+        .highlight .nl { color: #0077aa } /* Name.Label */
+        .highlight .nn { color: #0077aa } /* Name.Namespace */
+        .highlight .py { color: #0077aa } /* Name.Property */
+        .highlight .nt { color: #669900 } /* Name.Tag */
+        .highlight .nv { color: #222222 } /* Name.Variable */
+        .highlight .ow { color: #999999 } /* Operator.Word */
+        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
+        .highlight .mf { color: #000000 } /* Literal.Number.Float */
+        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
+        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
+        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
+        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
+        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
+        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
+        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
+        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
+        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
         </style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">File API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-04-19">19 April 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-07-14">14 July 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://w3c.github.io/FileAPI/">https://w3c.github.io/FileAPI/</a>
-     <dt>Latest version:
+     <dt>Latest published version:
      <dd><a href="http://www.w3.org/TR/FileAPI/">http://www.w3.org/TR/FileAPI/</a>
      <dt>Previous Versions:
      <dd><a href="http://www.w3.org/TR/2012/WD-FileAPI-20121025/" rel="previous">http://www.w3.org/TR/2012/WD-FileAPI-20121025/</a>
@@ -1435,19 +1430,19 @@ Possible extra rowspan handling
 as well as programmatically selecting them and accessing their data. This includes:</p>
    <ul>
     <li data-md="">
-     <p>A <code class="idl"><a data-link-type="idl" href="#dfn-filelist">FileList</a></code> interface, which represents an array of individually selected files from the underlying system. The user interface for selection can be invoked via <code>&lt;input type="file"></code>, i.e. when the input element is in the <code>File Upload</code> state <a data-link-type="biblio" href="#biblio-html">[HTML]</a> .</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#d1">FileList</a></code> interface, which represents an array of individually selected files from the underlying system. The user interface for selection can be invoked via <code>&lt;input type="file"></code>, i.e. when the input element is in the <code>File Upload</code> state <a data-link-type="biblio" href="#biblio-html">[HTML]</a> .</p>
     <li data-md="">
-     <p>A <code class="idl"><a data-link-type="idl" href="#dfn-Blob">Blob</a></code> interface, which represents immutable raw binary data, and allows access to ranges of bytes within the <code class="idl"><a data-link-type="idl" href="#dfn-Blob">Blob</a></code> object as a separate <code class="idl"><a data-link-type="idl" href="#dfn-Blob">Blob</a></code>.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#d">Blob</a></code> interface, which represents immutable raw binary data, and allows access to ranges of bytes within the <code class="idl"><a data-link-type="idl" href="#d">Blob</a></code> object as a separate <code class="idl"><a data-link-type="idl" href="#d">Blob</a></code>.</p>
     <li data-md="">
-     <p>A <code class="idl"><a data-link-type="idl" href="#dfn-file">File</a></code> interface, which includes readonly informational attributes about a file such as its name and the date of the last modification (on disk) of the file.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#d0">File</a></code> interface, which includes readonly informational attributes about a file such as its name and the date of the last modification (on disk) of the file.</p>
     <li data-md="">
-     <p>A <code class="idl"><a data-link-type="idl" href="#dfn-filereader">FileReader</a></code> interface, which provides methods to read a <code class="idl"><a data-link-type="idl" href="#dfn-file">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob">Blob</a></code>, and an event model to obtain the results of these reads.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#d2">FileReader</a></code> interface, which provides methods to read a <code class="idl"><a data-link-type="idl" href="#d0">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#d">Blob</a></code>, and an event model to obtain the results of these reads.</p>
     <li data-md="">
      <p>A <a href="#url">URL scheme</a> for use with binary data such as files, so that they can be referenced within web applications.</p>
    </ul>
    <p>Additionally, this specification defines objects to be used within threaded web applications for the synchronous reading of files.</p>
    <p><a href="#requirements">§11 Requirements and Use Cases</a> covers the motivation behind this specification.</p>
-   <p>This API is designed to be used in conjunction with other APIs and elements on the web platform, notably: <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest">XMLHttpRequest</a></code> (e.g. with an overloaded <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send">send()</a></code> method for <code class="idl"><a data-link-type="idl" href="#dfn-file">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob">Blob</a></code> arguments), <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage">postMessage()</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/interaction.html#datatransfer">DataTransfer</a></code> (part of the drag and drop API defined in <a data-link-type="biblio" href="#biblio-html">[HTML]</a>)
+   <p>This API is designed to be used in conjunction with other APIs and elements on the web platform, notably: <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest">XMLHttpRequest</a></code> (e.g. with an overloaded <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send">send()</a></code> method for <code class="idl"><a data-link-type="idl" href="#d0">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d">Blob</a></code> arguments), <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage">postMessage()</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/interaction.html#datatransfer">DataTransfer</a></code> (part of the drag and drop API defined in <a data-link-type="biblio" href="#biblio-html">[HTML]</a>)
 and Web Workers.
 Additionally, it should be possible to programmatically obtain a list of files from the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-input-element">input</a></code> element
 when it is in the <code>File Upload</code> state <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.
@@ -1455,24 +1450,6 @@ These kinds of behaviors are defined in the appropriate affiliated specification
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
-   <p> This is a public copy of the editors’ draft.
-  It is provided for discussion only and may change at any moment.
-  Its publication here does not imply endorsement of its contents by W3C.
-  Don’t cite this document other than as work in progress. </p>
-   <p> <strong>Changes to this document may be tracked at <a href="https://github.com/w3c/FileAPI">https://github.com/w3c/FileAPI</a>.</strong> </p>
-   <p> The (<a href="http://lists.w3.org/Archives/Public/public-webapps/">archived</a>) public mailing list <a href="mailto:public-webapps@w3.org?Subject=%5Bfileapi%5D%20PUT%20SUBJECT%20HERE">public-webapps@w3.org</a> (see <a href="http://www.w3.org/Mail/Request">instructions</a>)
-  is preferred for discussion of this specification.
-  When sending e-mail,
-  please put the text “fileapi” in the subject,
-  preferably like this:
-  “[fileapi] <em>…summary of comment…</em>” </p>
-   <p> This document was produced by the <a href="https://www.w3.org/WebPlatform/WG/">Web Platform Working Group</a>. </p>
-   <p> This document was produced by a group operating under
-  the <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
-  W3C maintains a <a href="http://www.w3.org/2004/01/pp-impl/83482/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
-  that page also includes instructions for disclosing a patent.
-  An individual who has actual knowledge of a patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="http://www.w3.org/2015/Process-20150901/" id="w3c_process_revision">1 September 2015 W3C Process Document</a>. </p>
    <p></p>
    <p>Previous discussion of this specification has taken place on two other mailing lists: <a href="mailto:public-webapps@w3.org">public-webapps@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-webapps/">archive</a>) and <a href="mailto:public-webapi@w3.org">public-webapi@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-webapi/">archive</a>). Ongoing discussion will be on the <a href="mailto:public-webapps@w3.org">public-webapps@w3.org</a> mailing list.</p>
    <p>This draft consists of changes made to the previous Last Call Working Draft. Please send comments to the <a href="mailto:public-webapi@w3.org">public-webapi@w3.org</a> as described above. You can see Last Call Feedback on the W3C Wiki: <a href="http://www.w3.org/wiki/Webapps/LCWD-FileAPI-20130912">http://www.w3.org/wiki/Webapps/LCWD-FileAPI-20130912</a></p>
@@ -1489,7 +1466,7 @@ These kinds of behaviors are defined in the appropriate affiliated specification
      </ol>
     <li><a href="#terminology"><span class="secno">3</span> <span class="content"> Terminology and Algorithms</span></a>
     <li>
-     <a href="#blob"><span class="secno">4</span> <span class="content"> The Blob Interface and Binary Data</span></a>
+     <a href="#b"><span class="secno">4</span> <span class="content"> The Blob Interface and Binary Data</span></a>
      <ol class="toc">
       <li>
        <a href="#constructorBlob"><span class="secno">4.1</span> <span class="content"> Constructors</span></a>
@@ -1505,7 +1482,7 @@ These kinds of behaviors are defined in the appropriate affiliated specification
        </ol>
      </ol>
     <li>
-     <a href="#file"><span class="secno">5</span> <span class="content"> The File Interface</span></a>
+     <a href="#f"><span class="secno">5</span> <span class="content"> The File Interface</span></a>
      <ol class="toc">
       <li>
        <a href="#file-constructor"><span class="secno">5.1</span> <span class="content"> Constructor</span></a>
@@ -1538,9 +1515,10 @@ These kinds of behaviors are defined in the appropriate affiliated specification
           <li><a href="#readAsDataURL"><span class="secno">7.3.4.2</span> <span class="content"> The <code class="idl"><span>readAsDataURL()</span></code> method</span></a>
           <li><a href="#readAsDataText"><span class="secno">7.3.4.3</span> <span class="content"> The <code class="idl"><span>readAsText()</span></code> method</span></a>
           <li><a href="#readAsArrayBuffer"><span class="secno">7.3.4.4</span> <span class="content"> The <code class="idl"><span>readAsArrayBuffer()</span></code> method</span></a>
-          <li><a href="#dfn-error-steps"><span class="secno">7.3.4.5</span> <span class="content"> Error Steps</span></a>
-          <li><a href="#abort"><span class="secno">7.3.4.6</span> <span class="content"> The abort() method</span></a>
-          <li><a href="#blobAndFileParams"><span class="secno">7.3.4.7</span> <span class="content"> Blob Parameters</span></a>
+          <li><a href="#readAsBinaryString"><span class="secno">7.3.4.5</span> <span class="content"> The <code class="idl"><span>readAsBinaryString()</span></code> method</span></a>
+          <li><a href="#dfn-error-steps"><span class="secno">7.3.4.6</span> <span class="content"> Error Steps</span></a>
+          <li><a href="#abort"><span class="secno">7.3.4.7</span> <span class="content"> The abort() method</span></a>
+          <li><a href="#blobAndFileParams"><span class="secno">7.3.4.8</span> <span class="content"> Blob Parameters</span></a>
          </ol>
        </ol>
       <li><a href="#enctype"><span class="secno">7.4</span> <span class="content"> Determining Encoding</span></a>
@@ -1560,6 +1538,7 @@ These kinds of behaviors are defined in the appropriate affiliated specification
           <li><a href="#readAsTextSync"><span class="secno">7.6.1.2</span> <span class="content"> The <code class="idl"><span>readAsText()</span></code> method</span></a>
           <li><a href="#readAsDataURLSync-section"><span class="secno">7.6.1.3</span> <span class="content"> The <code class="idl"><span>readAsDataURL()</span></code> method</span></a>
           <li><a href="#readAsArrayBufferSyncSection"><span class="secno">7.6.1.4</span> <span class="content"> The <code class="idl"><span>readAsArrayBuffer()</span></code> method</span></a>
+          <li><a href="#readAsBinaryStringSyncSection"><span class="secno">7.6.1.5</span> <span class="content"> The <code class="idl"><span>readAsBinaryString()</span></code> method</span></a>
          </ol>
        </ol>
      </ol>
@@ -1633,14 +1612,14 @@ and programmatic ways to read files.
 Additionally, this specification also defines an interface that represents "raw data"
 which can be asynchronously processed on the main thread of conforming user agents.
 The interfaces and API defined in this specification can be used with other interfaces and APIs exposed to the web platform.</p>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-1">File</a></code> interface represents file data typically obtained from the underlying file system,
-and the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-1">Blob</a></code> interface
+   <p>The <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-1">File</a></code> interface represents file data typically obtained from the underlying file system,
+and the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-1">Blob</a></code> interface
 ("Binary Large Object" - a name originally introduced to web APIs in <a href="https://developers.google.com/gears/?csw=1">Google Gears</a>)
-represents immutable raw data. <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-2">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-2">Blob</a></code> reads should happen asynchronously on the main thread,
+represents immutable raw data. <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-2">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-2">Blob</a></code> reads should happen asynchronously on the main thread,
 with an optional synchronous API used within threaded web applications.
 An asynchronous API for reading files prevents blocking and UI "freezing" on a user agent’s main thread.
-This specification defines an asynchronous API based on an <em>event model</em> to read and access a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-3">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-3">Blob</a></code>’s data.
-A <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-1">FileReader</a></code> object provides asynchronous read methods to access that file’s data
+This specification defines an asynchronous API based on an <em>event model</em> to read and access a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-3">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-3">Blob</a></code>’s data.
+A <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-1">FileReader</a></code> object provides asynchronous read methods to access that file’s data
 through event handler content attributes and the firing of events.
 The use of events and event handlers allows separate code blocks the ability
 to monitor the <em>progress of the read</em> (which is particularly useful for remote drives or mounted drives,
@@ -1649,7 +1628,7 @@ and error conditions that may arise during reading of a file.
 An example will be illustrative.</p>
    <div class="example" id="example-6004b6cf">
     <a class="self-link" href="#example-6004b6cf"></a> In the example below, different code blocks handle progress, error, and success conditions. 
-<pre class="lang-javascript highlight"><span class="kd">function</span> <span class="nx">startRead</span><span class="p">()</span> <span class="p">{</span>
+<pre class="lang-javascript highlight"><span></span><span class="kd">function</span> <span class="nx">startRead</span><span class="p">()</span> <span class="p">{</span>
   <span class="c1">// obtain input element through DOM</span>
 
   <span class="kd">var</span> <span class="nx">file</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s1">'file'</span><span class="p">).</span><span class="nx">files</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>
@@ -1699,7 +1678,8 @@ An example will be illustrative.</p>
   <span class="k">if</span><span class="p">(</span><span class="nx">evt</span><span class="p">.</span><span class="nx">target</span><span class="p">.</span><span class="nx">error</span><span class="p">.</span><span class="nx">name</span> <span class="o">==</span> <span class="s2">"NotReadableError"</span><span class="p">)</span> <span class="p">{</span>
     <span class="c1">// The file could not be read</span>
   <span class="p">}</span>
-<span class="p">}</span></pre>
+<span class="p">}</span>
+</pre>
    </div>
    <h2 class="heading settled" data-level="2" id="conformance"><span class="secno">2. </span><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
    <p>Everything in this specification is normative except for
@@ -1715,9 +1695,7 @@ examples and sections marked as being informative.</p>
 interpreted as described in <cite><a href="http://www.ietf.org/rfc/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite> <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a>.</p>
    <p>The following conformance classes are defined by this specification:</p>
    <dl>
-    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="conforming user agent" data-noexport="" id="dfn-conforming-implementation">conforming user agent<span class="dfn-panel" data-deco=""><b><a href="#dfn-conforming-implementation">#dfn-conforming-implementation</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-conforming-implementation-1">2. 
-Conformance</a></span><span><a href="#ref-for-dfn-conforming-implementation-2">2.1. 
-Dependencies</a> <a href="#ref-for-dfn-conforming-implementation-3">(2)</a> <a href="#ref-for-dfn-conforming-implementation-4">(3)</a> <a href="#ref-for-dfn-conforming-implementation-5">(4)</a> <a href="#ref-for-dfn-conforming-implementation-6">(5)</a></span></span></dfn> 
+    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-conforming-implementation">conforming user agent</dfn> 
     <dd>
       A user agent is considered to be a <a data-link-type="dfn" href="#dfn-conforming-implementation" id="ref-for-dfn-conforming-implementation-1">conforming user agent</a> if it satisfies all of the <span class="rfc2119">MUST</span>-, <span class="rfc2119">REQUIRED</span>-,
     and <span class="rfc2119">SHALL</span>-level criteria in this specification that apply to implementations.
@@ -1750,17 +1728,7 @@ defined in the Web IDL specification <a data-link-type="biblio" href="#biblio-we
    <p>Parts of this specification rely on the Web Workers specification;
 for those parts of this specification, the Web Workers specification is a normative dependency. <a data-link-type="biblio" href="#biblio-workers">[Workers]</a></p>
    <h2 class="heading settled" data-level="3" id="terminology"><span class="secno">3. </span><span class="content"> Terminology and Algorithms</span><a class="self-link" href="#terminology"></a></h2>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="terminate an algorithm|terminate this algorithm" data-noexport="" id="terminate-an-algorithm">terminate an algorithm<span class="dfn-panel" data-deco=""><b><a href="#terminate-an-algorithm">#terminate-an-algorithm</a></b><b>Referenced in:</b><span><a href="#ref-for-terminate-an-algorithm-1">4.3.2. 
-The close method</a></span><span><a href="#ref-for-terminate-an-algorithm-2">7.1. 
-The Read Operation</a> <a href="#ref-for-terminate-an-algorithm-3">(2)</a> <a href="#ref-for-terminate-an-algorithm-4">(3)</a></span><span><a href="#ref-for-terminate-an-algorithm-5">7.3.4.2. 
-The readAsDataURL() method</a> <a href="#ref-for-terminate-an-algorithm-6">(2)</a> <a href="#ref-for-terminate-an-algorithm-7">(3)</a></span><span><a href="#ref-for-terminate-an-algorithm-8">7.3.4.3. 
-The readAsText() method</a> <a href="#ref-for-terminate-an-algorithm-9">(2)</a> <a href="#ref-for-terminate-an-algorithm-10">(3)</a></span><span><a href="#ref-for-terminate-an-algorithm-11">7.3.4.4. 
-The readAsArrayBuffer() method</a> <a href="#ref-for-terminate-an-algorithm-12">(2)</a> <a href="#ref-for-terminate-an-algorithm-13">(3)</a></span><span><a href="#ref-for-terminate-an-algorithm-14">7.3.4.5. 
-Error Steps</a></span><span><a href="#ref-for-terminate-an-algorithm-15">7.3.4.6. 
-The abort() method</a> <a href="#ref-for-terminate-an-algorithm-16">(2)</a></span><span><a href="#ref-for-terminate-an-algorithm-17">7.6.1.2. 
-The readAsText() method</a> <a href="#ref-for-terminate-an-algorithm-18">(2)</a> <a href="#ref-for-terminate-an-algorithm-19">(3)</a></span><span><a href="#ref-for-terminate-an-algorithm-20">7.6.1.3. 
-The readAsDataURL() method</a> <a href="#ref-for-terminate-an-algorithm-21">(2)</a> <a href="#ref-for-terminate-an-algorithm-22">(3)</a></span><span><a href="#ref-for-terminate-an-algorithm-23">7.6.1.4. 
-The readAsArrayBuffer() method</a> <a href="#ref-for-terminate-an-algorithm-24">(2)</a> <a href="#ref-for-terminate-an-algorithm-25">(3)</a></span></span></dfn> the user agent must terminate the algorithm after finishing the step it is on.
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="terminate an algorithm|terminate this algorithm" data-noexport="" id="terminate-an-algorithm">terminate an algorithm</dfn> the user agent must terminate the algorithm after finishing the step it is on.
 Asynchronous <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-1">read methods</a> defined in this specification may return before the algorithm in question is terminated,
 and can be terminated by an <code class="idl"><a data-link-type="idl" href="#dfn-abort" id="ref-for-dfn-abort-1">abort()</a></code> call.</p>
    <p>The algorithms and steps in this specification use the following mathematical operations:</p>
@@ -1778,129 +1746,57 @@ This operation is also defined in ECMAScript <a data-link-type="biblio" href="#b
     <li data-md="">
      <p>Mathematical comparisons such as &lt; (less than), ≤ (less than or equal to), and > (greater than) are as in ECMAScript <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a>.</p>
    </ul>
-   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Unix Epoch" data-noexport="" id="UnixEpoch">Unix Epoch<span class="dfn-panel" data-deco=""><b><a href="#UnixEpoch">#UnixEpoch</a></b><b>Referenced in:</b><span><a href="#ref-for-UnixEpoch-1">5.1. 
-Constructor</a> <a href="#ref-for-UnixEpoch-2">(2)</a></span><span><a href="#ref-for-UnixEpoch-3">5.2. 
-Attributes</a> <a href="#ref-for-UnixEpoch-4">(2)</a></span></span></dfn> is used in this specification to refer to the time 00:00:00 UTC on January 1 1970
+   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="UnixEpoch">Unix Epoch</dfn> is used in this specification to refer to the time 00:00:00 UTC on January 1 1970
 (or 1970-01-01T00:00:00Z ISO 8601);
 this is the same time that is conceptually "<code>0</code>" in ECMA-262 <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a>.</p>
-   <h2 class="heading settled" data-level="4" id="blob"><span class="secno">4. </span><span class="content"> The Blob Interface and Binary Data</span><a class="self-link" href="#blob"></a></h2>
-   <p>A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-4">Blob</a></code> object refers to a <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence,
+   <h2 class="heading settled" data-level="4" id="b"><span class="secno">4. </span><span class="content"> The Blob Interface and Binary Data</span><a class="self-link" href="#b"></a></h2>
+   <p>A <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-4">Blob</a></code> object refers to a <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence,
 and has a <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-1">size</a></code> attribute which is the total number of bytes in the byte sequence,
 and a <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-1">type</a></code> attribute,
 which is an ASCII-encoded string in lower case representing the media type of the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence.</p>
-   <p>A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-5">Blob</a></code> must have a <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-lt="readability state" data-noexport="" id="readabilityState">readability state<span class="dfn-panel" data-deco=""><b><a href="#readabilityState">#readabilityState</a></b><b>Referenced in:</b><span><a href="#ref-for-readabilityState-1">4. 
-The Blob Interface and Binary Data</a> <a href="#ref-for-readabilityState-2">(2)</a></span><span><a href="#ref-for-readabilityState-3">4.1. 
-Constructors</a> <a href="#ref-for-readabilityState-4">(2)</a></span><span><a href="#ref-for-readabilityState-5">4.2. 
-Attributes</a> <a href="#ref-for-readabilityState-6">(2)</a> <a href="#ref-for-readabilityState-7">(3)</a></span><span><a href="#ref-for-readabilityState-8">4.3.1. 
-The slice method</a> <a href="#ref-for-readabilityState-9">(2)</a> <a href="#ref-for-readabilityState-10">(3)</a></span><span><a href="#ref-for-readabilityState-11">4.3.2. 
-The close method</a> <a href="#ref-for-readabilityState-12">(2)</a></span><span><a href="#ref-for-readabilityState-13">5.1. 
-Constructor</a></span><span><a href="#ref-for-readabilityState-14">7.1. 
-The Read Operation</a></span><span><a href="#ref-for-readabilityState-15">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-readabilityState-16">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-readabilityState-17">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-readabilityState-18">9.5.1. 
-Methods and Parameters</a> <a href="#ref-for-readabilityState-19">(2)</a> <a href="#ref-for-readabilityState-20">(3)</a></span></span></dfn>,
+   <p>A <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-5">Blob</a></code> must have a <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-noexport="" id="readabilityState">readability state</dfn>,
 which is one of <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-1"><code>OPENED</code></a> or <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-1"><code>CLOSED</code></a>.
-A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-6">Blob</a></code> that refers to a <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence,
+A <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-6">Blob</a></code> that refers to a <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence,
 including one of 0 bytes,
-is said to be in the <dfn class="dfn-paneled" data-dfn-for="Blob/readability state" data-dfn-type="dfn" data-lt="OPENED" data-noexport="" id="dfn-openState"><code>OPENED</code><span class="dfn-panel" data-deco=""><b><a href="#dfn-openState">#dfn-openState</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-openState-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-openState-2">4.1. 
-Constructors</a> <a href="#ref-for-dfn-openState-3">(2)</a></span><span><a href="#ref-for-dfn-openState-4">4.2. 
-Attributes</a></span><span><a href="#ref-for-dfn-openState-5">5.1. 
-Constructor</a></span></span></dfn> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-1">readability state</a>.
-A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-7">Blob</a></code> is said to be <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-lt="closed" data-noexport="" id="closed">closed<span class="dfn-panel" data-deco=""><b><a href="#closed">#closed</a></b><b>Referenced in:</b><span><a href="#ref-for-closed-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-closed-2">4.3.2. 
-The close method</a></span><span><a href="#ref-for-closed-3">9.4.3. 
-Network Errors</a></span></span></dfn> if its <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-1">close()</a></code> method has been called.
-A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-8">Blob</a></code> that is <a data-link-type="dfn" href="#closed" id="ref-for-closed-1">closed</a> is said to be in the <dfn class="dfn-paneled" data-dfn-for="Blob/readability state" data-dfn-type="dfn" data-lt="CLOSED" data-noexport="" id="dfn-closedState"><code>CLOSED</code><span class="dfn-panel" data-deco=""><b><a href="#dfn-closedState">#dfn-closedState</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-closedState-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-closedState-2">4.2. 
-Attributes</a> <a href="#ref-for-dfn-closedState-3">(2)</a> <a href="#ref-for-dfn-closedState-4">(3)</a></span><span><a href="#ref-for-dfn-closedState-5">4.3.2. 
-The close method</a> <a href="#ref-for-dfn-closedState-6">(2)</a></span><span><a href="#ref-for-dfn-closedState-7">7.1. 
-The Read Operation</a></span><span><a href="#ref-for-dfn-closedState-8">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-closedState-9">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-dfn-closedState-10">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-dfn-closedState-11">9.5.1. 
-Methods and Parameters</a> <a href="#ref-for-dfn-closedState-12">(2)</a> <a href="#ref-for-dfn-closedState-13">(3)</a></span></span></dfn> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-2">readability state</a>.</p>
-   <p>Each <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-9">Blob</a></code> must have an internal <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-lt="snapshot state" data-noexport="" id="snapshot-state">snapshot state<span class="dfn-panel" data-deco=""><b><a href="#snapshot-state">#snapshot-state</a></b><b>Referenced in:</b><span><a href="#ref-for-snapshot-state-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-snapshot-state-2">5. 
-The File Interface</a> <a href="#ref-for-snapshot-state-3">(2)</a> <a href="#ref-for-snapshot-state-4">(3)</a> <a href="#ref-for-snapshot-state-5">(4)</a></span><span><a href="#ref-for-snapshot-state-6">8. 
-Errors and Exceptions</a></span><span><a href="#ref-for-snapshot-state-7">8.1. 
-Throwing an Exception or Returning an Error</a> <a href="#ref-for-snapshot-state-8">(2)</a></span></span></dfn>,
+is said to be in the <dfn class="dfn-paneled" data-dfn-for="Blob/readability state" data-dfn-type="dfn" data-noexport="" id="dfn-openState"><code>OPENED</code></dfn> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-1">readability state</a>.
+A <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-7">Blob</a></code> is said to be <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-noexport="" id="closed">closed</dfn> if its <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-1">close()</a></code> method has been called.
+A <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-8">Blob</a></code> that is <a data-link-type="dfn" href="#closed" id="ref-for-closed-1">closed</a> is said to be in the <dfn class="dfn-paneled" data-dfn-for="Blob/readability state" data-dfn-type="dfn" data-noexport="" id="dfn-closedState"><code>CLOSED</code></dfn> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-2">readability state</a>.</p>
+   <p>Each <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-9">Blob</a></code> must have an internal <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-noexport="" id="snapshot-state">snapshot state</dfn>,
 which must be initially set to the state of the underlying storage,
 if any such underlying storage exists,
 and must be preserved through <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#structured-clone">structured clone</a>.
-Further normative definition of <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-1">snapshot state</a> can be found for <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-4">File</a></code>s.</p>
-<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="constructor" data-export="" data-lt="Blob(blobParts, options)|Blob(blobParts)|Blob()" id="dom-blob-blob">Constructor<span class="dfn-panel" data-deco=""><b><a href="#dom-blob-blob">#dom-blob-blob</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-blob-blob-1">4.1. 
-Constructors</a> <a href="#ref-for-dom-blob-blob-2">(2)</a></span><span><a href="#ref-for-dom-blob-blob-3">4.1.1. 
-Constructor Parameters</a></span></span></dfn>(optional sequence&lt;<a data-link-type="idl-name" href="#typedefdef-blobpart" id="ref-for-typedefdef-blobpart-1">BlobPart</a>> <a class="idl-code" data-link-type="argument" href="#dfn-blobParts" id="ref-for-dfn-blobParts-1">blobParts</a>, optional <a data-link-type="idl-name" href="#dfn-BlobPropertyBag" id="ref-for-dfn-BlobPropertyBag-1">BlobPropertyBag</a> <dfn class="idl-code" data-dfn-for="Blob/Blob(blobParts, options)" data-dfn-type="argument" data-export="" id="dom-blob-blob-blobparts-options-options">options<a class="self-link" href="#dom-blob-blob-blobparts-options-options"></a></dfn>),
-Exposed=(Window,Worker)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-lt="Blob" id="dfn-Blob">Blob<span class="dfn-panel" data-deco=""><b><a href="#dfn-Blob">#dfn-Blob</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-Blob-1">1. 
-Introduction</a> <a href="#ref-for-dfn-Blob-2">(2)</a> <a href="#ref-for-dfn-Blob-3">(3)</a></span><span><a href="#ref-for-dfn-Blob-4">4. 
-The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-Blob-5">(2)</a> <a href="#ref-for-dfn-Blob-6">(3)</a> <a href="#ref-for-dfn-Blob-7">(4)</a> <a href="#ref-for-dfn-Blob-8">(5)</a> <a href="#ref-for-dfn-Blob-9">(6)</a> <a href="#ref-for-dfn-Blob-10">(7)</a> <a href="#ref-for-dfn-Blob-11">(8)</a></span><span><a href="#ref-for-dfn-Blob-12">4.1. 
-Constructors</a> <a href="#ref-for-dfn-Blob-13">(2)</a> <a href="#ref-for-dfn-Blob-14">(3)</a> <a href="#ref-for-dfn-Blob-15">(4)</a> <a href="#ref-for-dfn-Blob-16">(5)</a> <a href="#ref-for-dfn-Blob-17">(6)</a></span><span><a href="#ref-for-dfn-Blob-18">4.1.1. 
-Constructor Parameters</a> <a href="#ref-for-dfn-Blob-19">(2)</a></span><span><a href="#ref-for-dfn-Blob-20">4.2. 
-Attributes</a> <a href="#ref-for-dfn-Blob-21">(2)</a> <a href="#ref-for-dfn-Blob-22">(3)</a> <a href="#ref-for-dfn-Blob-23">(4)</a> <a href="#ref-for-dfn-Blob-24">(5)</a> <a href="#ref-for-dfn-Blob-25">(6)</a> <a href="#ref-for-dfn-Blob-26">(7)</a> <a href="#ref-for-dfn-Blob-27">(8)</a></span><span><a href="#ref-for-dfn-Blob-28">4.3.1. 
-The slice method</a> <a href="#ref-for-dfn-Blob-29">(2)</a> <a href="#ref-for-dfn-Blob-30">(3)</a> <a href="#ref-for-dfn-Blob-31">(4)</a> <a href="#ref-for-dfn-Blob-32">(5)</a> <a href="#ref-for-dfn-Blob-33">(6)</a> <a href="#ref-for-dfn-Blob-34">(7)</a></span><span><a href="#ref-for-dfn-Blob-35">4.3.2. 
-The close method</a> <a href="#ref-for-dfn-Blob-36">(2)</a></span><span><a href="#ref-for-dfn-Blob-37">5. 
-The File Interface</a> <a href="#ref-for-dfn-Blob-38">(2)</a></span><span><a href="#ref-for-dfn-Blob-39">5.1. 
-Constructor</a> <a href="#ref-for-dfn-Blob-40">(2)</a> <a href="#ref-for-dfn-Blob-41">(3)</a></span><span><a href="#ref-for-dfn-Blob-42">5.1.1. 
-Constructor Parameters</a></span><span><a href="#ref-for-dfn-Blob-43">5.2. 
-Attributes</a></span><span><a href="#ref-for-dfn-Blob-44">7.1. 
-The Read Operation</a> <a href="#ref-for-dfn-Blob-45">(2)</a> <a href="#ref-for-dfn-Blob-46">(3)</a> <a href="#ref-for-dfn-Blob-47">(4)</a> <a href="#ref-for-dfn-Blob-48">(5)</a></span><span><a href="#ref-for-dfn-Blob-49">7.2. 
-The File Reading Task Source</a></span><span><a href="#ref-for-dfn-Blob-50">7.3. 
-The FileReader API</a> <a href="#ref-for-dfn-Blob-51">(2)</a> <a href="#ref-for-dfn-Blob-52">(3)</a></span><span><a href="#ref-for-dfn-Blob-53">7.3.3. 
-FileReader States</a> <a href="#ref-for-dfn-Blob-54">(2)</a> <a href="#ref-for-dfn-Blob-55">(3)</a></span><span><a href="#ref-for-dfn-Blob-56">7.3.4.1. 
-The result attribute</a> <a href="#ref-for-dfn-Blob-57">(2)</a> <a href="#ref-for-dfn-Blob-58">(3)</a> <a href="#ref-for-dfn-Blob-59">(4)</a> <a href="#ref-for-dfn-Blob-60">(5)</a> <a href="#ref-for-dfn-Blob-61">(6)</a></span><span><a href="#ref-for-dfn-Blob-62">7.3.4.7. 
-Blob Parameters</a> <a href="#ref-for-dfn-Blob-63">(2)</a> <a href="#ref-for-dfn-Blob-64">(3)</a></span><span><a href="#ref-for-dfn-Blob-65">7.4. 
-Determining Encoding</a></span><span><a href="#ref-for-dfn-Blob-66">7.6. 
-Reading on Threads</a></span><span><a href="#ref-for-dfn-Blob-67">7.6.1. 
-The FileReaderSync API</a> <a href="#ref-for-dfn-Blob-68">(2)</a> <a href="#ref-for-dfn-Blob-69">(3)</a> <a href="#ref-for-dfn-Blob-70">(4)</a></span><span><a href="#ref-for-dfn-Blob-71">8. 
-Errors and Exceptions</a> <a href="#ref-for-dfn-Blob-72">(2)</a> <a href="#ref-for-dfn-Blob-73">(3)</a></span><span><a href="#ref-for-dfn-Blob-74">8.1. 
-Throwing an Exception or Returning an Error</a> <a href="#ref-for-dfn-Blob-75">(2)</a> <a href="#ref-for-dfn-Blob-76">(3)</a> <a href="#ref-for-dfn-Blob-77">(4)</a> <a href="#ref-for-dfn-Blob-78">(5)</a> <a href="#ref-for-dfn-Blob-79">(6)</a></span><span><a href="#ref-for-dfn-Blob-80">9. 
-A URL for Blob and File reference</a></span><span><a href="#ref-for-dfn-Blob-81">9.1. 
-Requirements for a New Scheme</a> <a href="#ref-for-dfn-Blob-82">(2)</a> <a href="#ref-for-dfn-Blob-83">(3)</a> <a href="#ref-for-dfn-Blob-84">(4)</a> <a href="#ref-for-dfn-Blob-85">(5)</a></span><span><a href="#ref-for-dfn-Blob-86">9.2. 
-Discussion of Existing Schemes</a> <a href="#ref-for-dfn-Blob-87">(2)</a></span><span><a href="#ref-for-dfn-Blob-88">9.3. 
-The Blob URL</a> <a href="#ref-for-dfn-Blob-89">(2)</a></span><span><a href="#ref-for-dfn-Blob-90">9.4.2. 
-Response Headers</a> <a href="#ref-for-dfn-Blob-91">(2)</a></span><span><a href="#ref-for-dfn-Blob-92">9.4.4. 
-Sample Request and Response Headers</a> <a href="#ref-for-dfn-Blob-93">(2)</a></span><span><a href="#ref-for-dfn-Blob-94">9.5. 
-Creating and Revoking a Blob URL</a> <a href="#ref-for-dfn-Blob-95">(2)</a></span><span><a href="#ref-for-dfn-Blob-96">9.5.1. 
-Methods and Parameters</a> <a href="#ref-for-dfn-Blob-97">(2)</a> <a href="#ref-for-dfn-Blob-98">(3)</a> <a href="#ref-for-dfn-Blob-99">(4)</a> <a href="#ref-for-dfn-Blob-100">(5)</a></span><span><a href="#ref-for-dfn-Blob-101">9.5.2. 
-Examples of Blob URL Creation and Revocation</a></span><span><a href="#ref-for-dfn-Blob-102">9.6. 
-Lifetime of Blob URLs</a> <a href="#ref-for-dfn-Blob-103">(2)</a> <a href="#ref-for-dfn-Blob-104">(3)</a> <a href="#ref-for-dfn-Blob-105">(4)</a> <a href="#ref-for-dfn-Blob-106">(5)</a></span></span></dfn> {
+Further normative definition of <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-1">snapshot state</a> can be found for <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-4">File</a></code>s.</p>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="https://w3c.github.io/FileAPI/#dom-blob-blob">Constructor</a>(<span class="kt">optional</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#typedefdef-blobpart">BlobPart</a>> <a class="nv idl-code" data-link-type="argument" href="#dfn-blobParts" id="ref-for-dfn-blobParts-1">blobParts</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-BlobPropertyBag">BlobPropertyBag</a> <a class="nv idl-code" data-link-type="argument" href="https://w3c.github.io/FileAPI/#dom-blob-blob-blobparts-options-options">options</a>),
+<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="d">Blob</dfn> {
 
-  readonly attribute unsigned long long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long " href="#dfn-size" id="ref-for-dfn-size-2">size</a>;
-  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString " href="#dfn-type" id="ref-for-dfn-type-2">type</a>;
-  readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dfn-isClosed" id="ref-for-dfn-isClosed-1">isClosed</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long" href="#dfn-size" id="ref-for-dfn-size-2">size</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dfn-type" id="ref-for-dfn-type-2">type</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dfn-isClosed" id="ref-for-dfn-isClosed-1">isClosed</a>;
 
   //slice Blob into byte-ranged chunks
 
-  <a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-10">Blob</a> <a class="idl-code" data-link-type="method" href="#dfn-slice" id="ref-for-dfn-slice-1">slice</a>([Clamp] optional long long <a class="idl-code" data-link-type="argument" href="#dfn-start" id="ref-for-dfn-start-1">start</a>,
-            [Clamp] optional long long <a class="idl-code" data-link-type="argument" href="#dfn-end" id="ref-for-dfn-end-1">end</a>,
-            optional DOMString <a class="idl-code" data-link-type="argument" href="#dfn-contentTypeBlob" id="ref-for-dfn-contentTypeBlob-1">contentType</a>);
-  void <a class="idl-code" data-link-type="method" href="#dfn-close" id="ref-for-dfn-close-2">close</a>();
+  <a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-10">Blob</a> <a class="nv idl-code" data-link-type="method" href="https://w3c.github.io/FileAPI/#dfn-slice">slice</a>([<a class="nv idl-code" data-link-type="extended-attribute">Clamp</a>] <span class="kt">optional</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-start" id="ref-for-dfn-start-1">start</a>,
+            [<a class="nv idl-code" data-link-type="extended-attribute">Clamp</a>] <span class="kt">optional</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-end" id="ref-for-dfn-end-1">end</a>,
+            <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-contentTypeBlob" id="ref-for-dfn-contentTypeBlob-1">contentType</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-close" id="ref-for-dfn-close-2">close</a>();
 
 };
 
-dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" data-lt="BlobPropertyBag" id="dfn-BlobPropertyBag">BlobPropertyBag<span class="dfn-panel" data-deco=""><b><a href="#dfn-BlobPropertyBag">#dfn-BlobPropertyBag</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-BlobPropertyBag-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-BlobPropertyBag-2">4.1.1. 
-Constructor Parameters</a></span><span><a href="#ref-for-dfn-BlobPropertyBag-3">5. 
-The File Interface</a></span><span><a href="#ref-for-dfn-BlobPropertyBag-4">5.1.1. 
-Constructor Parameters</a></span></span></dfn> {
-  DOMString <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dfn-BPtype" id="ref-for-dfn-BPtype-1">type</a> = "";
+<span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="https://w3c.github.io/FileAPI/#dfn-BlobPropertyBag">BlobPropertyBag</a> {
+  <span class="kt">DOMString</span> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dfn-BPtype" id="ref-for-dfn-BPtype-1">type</a> = "";
 };
 
-typedef (ArrayBuffer or <a data-link-type="idl-name" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBufferView">ArrayBufferView</a> or <a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-11">Blob</a> or USVString) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export="" data-lt="BlobPart" id="typedefdef-blobpart">BlobPart<span class="dfn-panel" data-deco=""><b><a href="#typedefdef-blobpart">#typedefdef-blobpart</a></b><b>Referenced in:</b><span><a href="#ref-for-typedefdef-blobpart-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-typedefdef-blobpart-2">5. 
-The File Interface</a></span></span></dfn>;
+<span class="kt">typedef</span> (<span class="kt">ArrayBuffer</span> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBufferView">ArrayBufferView</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-11">Blob</a> <span class="kt">or</span> <span class="kt">USVString</span>) <a class="nv idl-code" data-link-type="typedef" href="https://w3c.github.io/FileAPI/#typedefdef-blobpart">BlobPart</a>;
 </pre>
    <h3 class="heading settled" data-level="4.1" id="constructorBlob"><span class="secno">4.1. </span><span class="content"> Constructors</span><a class="self-link" href="#constructorBlob"></a></h3>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dom-blob-blob" id="ref-for-dom-blob-blob-1">Blob()</a></code> constructor can be invoked with zero or more parameters.
-When the <code class="idl"><a data-link-type="idl" href="#dom-blob-blob" id="ref-for-dom-blob-blob-2">Blob()</a></code> constructor is invoked,
+   <p>The <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dom-blob-blob">Blob()</a></code> constructor can be invoked with zero or more parameters.
+When the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dom-blob-blob">Blob()</a></code> constructor is invoked,
 user agents must run the following steps:</p>
    <ol>
     <li data-md="">
      <p>If invoked with zero parameters,
-return a new <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-12">Blob</a></code> object with its <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-3">readability state</a> set to <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-2"><code>OPENED</code></a>,
+return a new <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-12">Blob</a></code> object with its <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-3">readability state</a> set to <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-2"><code>OPENED</code></a>,
 consisting of 0 bytes,
 with <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-3">size</a></code> set to 0,
 and with <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-3">type</a></code> set to the empty string.</p>
@@ -1915,13 +1811,13 @@ For 0 ≤ <var>i</var> &lt; <var>length</var>, repeat the following steps:</p>
       <li data-md="">
        <p>Let <var>element</var> be the <var>i</var>th element of <var>a</var>.</p>
       <li data-md="">
-       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl">USVString</a></code>, run the following substeps:</p>
+       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dom-USVString">USVString</a></code>, run the following substeps:</p>
        <ol>
         <li data-md="">
          <p>Encode <var>s</var> as <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8">utf-8</a> and append the resulting bytes to <var>bytes</var>.</p>
          <p class="note" role="note">Note: The algorithm from WebIDL <a data-link-type="biblio" href="#biblio-webidl">[WebIDL]</a> replaces unmatched surrogates in an invalid <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-16">utf-16</a> string
 with U+FFFD replacement characters.
-Scenarios exist when the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-13">Blob</a></code> constructor may result in some data loss
+Scenarios exist when the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-13">Blob</a></code> constructor may result in some data loss
 due to lost or scrambled character sequences.</p>
        </ol>
       <li data-md="">
@@ -1935,9 +1831,9 @@ and append those bytes to <var>bytes</var>.</p>
 convert it to a sequence of <code>byteLength</code> bytes,
 and append those bytes to <var>bytes</var>.</p>
       <li data-md="">
-       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-14">Blob</a></code>,
+       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-14">Blob</a></code>,
 append the bytes it represents to <var>bytes</var>.
-The <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-4">type</a></code> of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-15">Blob</a></code> array element is ignored.</p>
+The <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-4">type</a></code> of the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-15">Blob</a></code> array element is ignored.</p>
      </ol>
     <li data-md="">
      <p>If the <code class="idl"><a data-link-type="idl" href="#dfn-BPtype" id="ref-for-dfn-BPtype-2">type</a></code> member of the optional <code>options</code> argument is provided
@@ -1953,20 +1849,18 @@ then set <var>t</var> to the empty string and return from these substeps.</p>
 using the "<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#converted-to-ascii-lowercase">converting a string to ASCII lowercase</a>" algorithm.</p>
      </ol>
     <li data-md="">
-     <p>Return a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-16">Blob</a></code> object with its <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-4">readability state</a> set to <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-3"><code>OPENED</code></a>,
+     <p>Return a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-16">Blob</a></code> object with its <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-4">readability state</a> set to <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-3"><code>OPENED</code></a>,
 referring to <var>bytes</var> as its associated <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence,
 with its <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-4">size</a></code> set to the length of <var>bytes</var>,
 and its <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-5">type</a></code> set to the value of <var>t</var> from the substeps above.</p>
-     <p class="note" role="note">Note: The type t of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-17">Blob</a></code> is considered a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">parsable MIME type</a> if the ASCII-encoded string representing the Blob object’s type,
+     <p class="note" role="note">Note: The type t of a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-17">Blob</a></code> is considered a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">parsable MIME type</a> if the ASCII-encoded string representing the Blob object’s type,
 when converted to a byte sequence,
 does not return undefined for the <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">parse a MIME type</a> algorithm.</p>
    </ol>
    <h4 class="heading settled" data-level="4.1.1" id="constructorParams"><span class="secno">4.1.1. </span><span class="content"> Constructor Parameters</span><a class="self-link" href="#constructorParams"></a></h4>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dom-blob-blob" id="ref-for-dom-blob-blob-3">Blob()</a></code> constructor can be invoked with the parameters below:</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dom-blob-blob">Blob()</a></code> constructor can be invoked with the parameters below:</p>
    <dl>
-    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/Blob(blobParts, options)" data-dfn-type="argument" data-export="" data-lt="blobParts" id="dfn-blobParts"><code>blobParts</code><span class="dfn-panel" data-deco=""><b><a href="#dfn-blobParts">#dfn-blobParts</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-blobParts-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-blobParts-2">4.1. 
-Constructors</a></span></span></dfn> <code>sequence</code> 
+    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/Blob(blobParts, options)" data-dfn-type="argument" data-export="" id="dfn-blobParts"><code>blobParts</code></dfn> <code>sequence</code> 
     <dd>
      which takes any number of the following types of elements, and in any order: 
      <ul>
@@ -1975,26 +1869,23 @@ Constructors</a></span></span></dfn> <code>sequence</code>
       <li data-md="">
        <p><code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBufferView">ArrayBufferView</a></code> elements.</p>
       <li data-md="">
-       <p><code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-18">Blob</a></code> elements.</p>
+       <p><code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-18">Blob</a></code> elements.</p>
       <li data-md="">
        <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> elements.</p>
      </ul>
-    <dt id="dfn-BlobPropertyBagMembers"><a class="self-link" href="#dfn-BlobPropertyBagMembers"></a>An <em>optional</em> <code class="idl"><a data-link-type="idl" href="#dfn-BlobPropertyBag" id="ref-for-dfn-BlobPropertyBag-2">BlobPropertyBag</a></code> 
+    <dt id="dfn-BlobPropertyBagMembers"><a class="self-link" href="#dfn-BlobPropertyBagMembers"></a>An <em>optional</em> <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-BlobPropertyBag">BlobPropertyBag</a></code> 
     <dd>
      which takes one member: 
      <ul>
       <li data-md="">
-       <p><dfn class="dfn-paneled idl-code" data-dfn-for="BlobPropertyBag" data-dfn-type="dict-member" data-export="" data-lt="type" id="dfn-BPtype">type<span class="dfn-panel" data-deco=""><b><a href="#dfn-BPtype">#dfn-BPtype</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-BPtype-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-BPtype-2">4.1. 
-Constructors</a> <a href="#ref-for-dfn-BPtype-3">(2)</a></span><span><a href="#ref-for-dfn-BPtype-4">5.1. 
-Constructor</a> <a href="#ref-for-dfn-BPtype-5">(2)</a></span></span></dfn>,
-the ASCII-encoded string in lower case representing the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-19">Blob</a></code>.
+       <p><dfn class="dfn-paneled idl-code" data-dfn-for="BlobPropertyBag" data-dfn-type="dict-member" data-export="" id="dfn-BPtype">type</dfn>,
+the ASCII-encoded string in lower case representing the media type of the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-19">Blob</a></code>.
 Normative conditions for this member are provided in the <a href="#constructorBlob">§4.1 Constructors</a>.</p>
      </ul>
    </dl>
    <div class="example" id="example-b4f2f2b4">
     <a class="self-link" href="#example-b4f2f2b4"></a> Examples of constructor usage follow. 
-<pre class="lang-javascript highlight"><span class="c1">// Create a new Blob object</span>
+<pre class="lang-javascript highlight"><span></span><span class="c1">// Create a new Blob object</span>
 
 <span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Blob</span><span class="p">();</span>
 
@@ -2014,98 +1905,71 @@ Normative conditions for this member are provided in the <a href="#constructorBl
 
 <span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Blob</span><span class="p">([</span><span class="nx">b</span><span class="p">,</span> <span class="nx">c</span><span class="p">,</span> <span class="nx">bytes</span><span class="p">]);</span>
 
-<span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Blob</span><span class="p">([</span><span class="nx">buffer</span><span class="p">,</span> <span class="nx">b</span><span class="p">,</span> <span class="nx">c</span><span class="p">,</span> <span class="nx">bytes</span><span class="p">]);</span></pre>
+<span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Blob</span><span class="p">([</span><span class="nx">buffer</span><span class="p">,</span> <span class="nx">b</span><span class="p">,</span> <span class="nx">c</span><span class="p">,</span> <span class="nx">bytes</span><span class="p">]);</span>
+</pre>
    </div>
    <h3 class="heading settled" data-level="4.2" id="attributes-blob"><span class="secno">4.2. </span><span class="content"> Attributes</span><a class="self-link" href="#attributes-blob"></a></h3>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" data-lt="size" id="dfn-size">size<span class="dfn-panel" data-deco=""><b><a href="#dfn-size">#dfn-size</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-size-1">4. 
-The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-size-2">(2)</a></span><span><a href="#ref-for-dfn-size-3">4.1. 
-Constructors</a> <a href="#ref-for-dfn-size-4">(2)</a></span><span><a href="#ref-for-dfn-size-5">4.2. 
-Attributes</a></span><span><a href="#ref-for-dfn-size-6">4.3.1. 
-The slice method</a> <a href="#ref-for-dfn-size-7">(2)</a> <a href="#ref-for-dfn-size-8">(3)</a></span><span><a href="#ref-for-dfn-size-9">5.1. 
-Constructor</a></span><span><a href="#ref-for-dfn-size-10">7.1. 
-The Read Operation</a></span><span><a href="#ref-for-dfn-size-11">9.4.2. 
-Response Headers</a></span></span></dfn> , <span> of type <a data-link-type="idl-name">unsigned long long</a>, readonly</span>
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" id="dfn-size">size</dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#dom-unsignedlonglong">unsigned long long</a>, readonly</span>
     <dd>Returns the size of the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence in number of bytes.
-    On getting, conforming user agents must return the total number of bytes that can be read by a <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-2">FileReader</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-1">FileReaderSync</a></code> object,
-    or 0 if the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-20">Blob</a></code> has no bytes to be read.
-    If the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-21">Blob</a></code> has a readability state of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-2"><code>CLOSED</code></a> then <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-5">size</a></code> must return 0. 
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" data-lt="type" id="dfn-type">type<span class="dfn-panel" data-deco=""><b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-type-1">4. 
-The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-type-2">(2)</a></span><span><a href="#ref-for-dfn-type-3">4.1. 
-Constructors</a> <a href="#ref-for-dfn-type-4">(2)</a> <a href="#ref-for-dfn-type-5">(3)</a></span><span><a href="#ref-for-dfn-type-6">4.2. 
-Attributes</a> <a href="#ref-for-dfn-type-7">(2)</a> <a href="#ref-for-dfn-type-8">(3)</a></span><span><a href="#ref-for-dfn-type-9">4.3.1. 
-The slice method</a> <a href="#ref-for-dfn-type-10">(2)</a></span><span><a href="#ref-for-dfn-type-11">5. 
-The File Interface</a> <a href="#ref-for-dfn-type-12">(2)</a></span><span><a href="#ref-for-dfn-type-13">5.1. 
-Constructor</a> <a href="#ref-for-dfn-type-14">(2)</a></span><span><a href="#ref-for-dfn-type-15">7.3.4.2. 
-The readAsDataURL() method</a> <a href="#ref-for-dfn-type-16">(2)</a></span><span><a href="#ref-for-dfn-type-17">7.4. 
-Determining Encoding</a> <a href="#ref-for-dfn-type-18">(2)</a></span><span><a href="#ref-for-dfn-type-19">7.6.1.3. 
-The readAsDataURL() method</a> <a href="#ref-for-dfn-type-20">(2)</a></span><span><a href="#ref-for-dfn-type-21">9.4.2. 
-Response Headers</a></span><span><a href="#ref-for-dfn-type-22">9.4.4. 
-Sample Request and Response Headers</a></span></span></dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
+    On getting, conforming user agents must return the total number of bytes that can be read by a <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-2">FileReader</a></code> or <code class="idl"><a data-link-type="idl" href="#d3" id="ref-for-d3-1">FileReaderSync</a></code> object,
+    or 0 if the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-20">Blob</a></code> has no bytes to be read.
+    If the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-21">Blob</a></code> has a readability state of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-2"><code>CLOSED</code></a> then <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-5">size</a></code> must return 0. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" id="dfn-type">type</dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
     <dd>
-     The ASCII-encoded string in lower case representing the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-22">Blob</a></code>.
-    On getting, user agents must return the type of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-23">Blob</a></code> as an ASCII-encoded string in lower case,
+     The ASCII-encoded string in lower case representing the media type of the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-22">Blob</a></code>.
+    On getting, user agents must return the type of a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-23">Blob</a></code> as an ASCII-encoded string in lower case,
     such that when it is converted to a <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence,
     it is a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">parsable MIME type</a>,
     or the empty string – 0 bytes – if the type cannot be determined. 
      <p>The <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-6">type</a></code> attribute can be set by the web application itself through constructor invocation
-    and through the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-2">slice()</a></code> call;
+    and through the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-1">slice()</a></code> call;
     in these cases, further normative conditions for this attribute are in <a href="#constructorBlob">§4.1 Constructors</a>, <a href="#file-constructor">§5.1 Constructor</a>,
     and <a href="#slice-method-algo">§4.3.1 The slice method</a> respectively.
-    User agents can also determine the <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-7">type</a></code> of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-24">Blob</a></code>,
+    User agents can also determine the <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-7">type</a></code> of a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-24">Blob</a></code>,
     especially if the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence is from an on-disk file;
     in this case, further normative conditions are in the <a data-link-type="dfn" href="#file-type-guidelines" id="ref-for-file-type-guidelines-1">file type guidelines</a>.</p>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" data-lt="isClosed" id="dfn-isClosed">isClosed<span class="dfn-panel" data-deco=""><b><a href="#dfn-isClosed">#dfn-isClosed</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-isClosed-1">4. 
-The Blob Interface and Binary Data</a></span></span></dfn> , <span> of type <a data-link-type="idl-name">boolean</a>, readonly</span>
-    <dd>The boolean value that indicates whether the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-25">Blob</a></code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-3"><code>CLOSED</code></a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-5">readability state</a>.
-    On getting, user agents must return <code>false</code> if the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-26">Blob</a></code> is in the <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-4"><code>OPENED</code></a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-6">readability state</a>,
-    and <code>true</code> if the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-27">Blob</a></code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-4"><code>CLOSED</code></a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-7">readability state</a> as a result of the <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-3">close()</a></code> method being called. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" id="dfn-isClosed">isClosed</dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#dom-boolean">boolean</a>, readonly</span>
+    <dd>The boolean value that indicates whether the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-25">Blob</a></code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-3"><code>CLOSED</code></a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-5">readability state</a>.
+    On getting, user agents must return <code>false</code> if the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-26">Blob</a></code> is in the <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-4"><code>OPENED</code></a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-6">readability state</a>,
+    and <code>true</code> if the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-27">Blob</a></code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-4"><code>CLOSED</code></a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-7">readability state</a> as a result of the <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-3">close()</a></code> method being called. 
    </dl>
    <p class="note" role="note">Note: Use of the <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-8">type</a></code> attribute informs the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-1">encoding determination</a> and <a href="#processing-media-types">parsing the Content-Type header</a> when <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-1">dereferencing</a> <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-1">Blob URLs</a>.</p>
    <h3 class="heading settled" data-level="4.3" id="methodsandparams-blob"><span class="secno">4.3. </span><span class="content"> Methods and Parameters</span><a class="self-link" href="#methodsandparams-blob"></a></h3>
    <h4 class="heading settled" data-level="4.3.1" id="slice-method-algo"><span class="secno">4.3.1. </span><span class="content"> The slice method</span><a class="self-link" href="#slice-method-algo"></a></h4>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="method" data-export="" data-lt="slice(start, end, contentType), slice(start, end), slice(start), slice()" id="dfn-slice">slice()<span class="dfn-panel" data-deco=""><b><a href="#dfn-slice">#dfn-slice</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-slice-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-slice-2">4.2. 
-Attributes</a></span><span><a href="#ref-for-dfn-slice-3">4.3.1. 
-The slice method</a> <a href="#ref-for-dfn-slice-4">(2)</a> <a href="#ref-for-dfn-slice-5">(3)</a> <a href="#ref-for-dfn-slice-6">(4)</a> <a href="#ref-for-dfn-slice-7">(5)</a> <a href="#ref-for-dfn-slice-8">(6)</a> <a href="#ref-for-dfn-slice-9">(7)</a> <a href="#ref-for-dfn-slice-10">(8)</a></span></span></dfn> method
-returns a new <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-28">Blob</a></code> object with bytes ranging from
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="method" data-export="" data-lt="slice(start, end, contentType), slice(start, end), slice(start), slice()" id="dfn-slice">slice()</dfn> method
+returns a new <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-28">Blob</a></code> object with bytes ranging from
 the optional <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-2">start</a></code> parameter
 upto but not including the optional <code class="idl"><a data-link-type="idl" href="#dfn-end" id="ref-for-dfn-end-2">end</a></code> parameter,
 and with a <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-9">type</a></code> attribute that is the value of the optional <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-contentTypeBlob" id="ref-for-dfn-contentTypeBlob-2">contentType</a></code> parameter.
 It must act as follows:</p>
    <ol>
     <li data-md="">
-     <p>Let <var>O</var> be the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-29">Blob</a></code> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> on which the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-3">slice()</a></code> method is being called.</p>
+     <p>Let <var>O</var> be the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-29">Blob</a></code> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> on which the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-2">slice()</a></code> method is being called.</p>
     <li data-md="">
-     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" data-lt="start" id="dfn-start">start<span class="dfn-panel" data-deco=""><b><a href="#dfn-start">#dfn-start</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-start-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-start-2">4.3.1. 
-The slice method</a> <a href="#ref-for-dfn-start-3">(2)</a> <a href="#ref-for-dfn-start-4">(3)</a> <a href="#ref-for-dfn-start-5">(4)</a> <a href="#ref-for-dfn-start-6">(5)</a></span></span></dfn> parameter
-is a value for the start point of a <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-4">slice()</a></code> call,
+     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" id="dfn-start">start</dfn> parameter
+is a value for the start point of a <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-3">slice()</a></code> call,
 and must be treated as a byte-order position,
 with the zeroth position representing the first byte.
-User agents must process <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-5">slice()</a></code> with <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-3">start</a></code> normalized according to the following:</p>
+User agents must process <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-4">slice()</a></code> with <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-3">start</a></code> normalized according to the following:</p>
      <ol type="a">
       <li>If the optional <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-4">start</a></code> parameter is not used as a parameter when making this call, let <var>relativeStart</var> be 0. 
       <li>If <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-5">start</a></code> is negative, let <var>relativeStart</var> be <code>max((<code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-6">size</a></code> + <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-6">start</a></code>), 0)</code>. 
       <li>Else, let <var>relativeStart</var> be <code>min(start, size)</code>. 
      </ol>
     <li data-md="">
-     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" data-lt="end" id="dfn-end">end<span class="dfn-panel" data-deco=""><b><a href="#dfn-end">#dfn-end</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-end-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-end-2">4.3.1. 
-The slice method</a> <a href="#ref-for-dfn-end-3">(2)</a> <a href="#ref-for-dfn-end-4">(3)</a> <a href="#ref-for-dfn-end-5">(4)</a></span></span></dfn> parameter
-is a value for the end point of a <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-6">slice()</a></code> call.
-User agents must process <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-7">slice()</a></code> with <code class="idl"><a data-link-type="idl" href="#dfn-end" id="ref-for-dfn-end-3">end</a></code> normalized according to the following:</p>
+     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" id="dfn-end">end</dfn> parameter
+is a value for the end point of a <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-5">slice()</a></code> call.
+User agents must process <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-6">slice()</a></code> with <code class="idl"><a data-link-type="idl" href="#dfn-end" id="ref-for-dfn-end-3">end</a></code> normalized according to the following:</p>
      <ol type="a">
       <li>If the optional <code class="idl"><a data-link-type="idl" href="#dfn-end" id="ref-for-dfn-end-4">end</a></code> parameter is not used as a parameter when making this call, let <var>relativeEnd</var> be <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-7">size</a></code>. 
       <li>If <code class="idl"><a data-link-type="idl" href="#dfn-end" id="ref-for-dfn-end-5">end</a></code> is negative, let <var>relativeEnd</var> be <code>max((size + end), 0)</code> . 
       <li>Else, let <var>relativeEnd</var> be <code>min(end, size)</code>. 
      </ol>
     <li data-md="">
-     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" data-lt="contentType" id="dfn-contentTypeBlob">contentType<span class="dfn-panel" data-deco=""><b><a href="#dfn-contentTypeBlob">#dfn-contentTypeBlob</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-contentTypeBlob-1">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-contentTypeBlob-2">4.3.1. 
-The slice method</a> <a href="#ref-for-dfn-contentTypeBlob-3">(2)</a> <a href="#ref-for-dfn-contentTypeBlob-4">(3)</a> <a href="#ref-for-dfn-contentTypeBlob-5">(4)</a></span></span></dfn> parameter
+     <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" id="dfn-contentTypeBlob">contentType</dfn> parameter
 is used to set the ASCII-encoded string in lower case representing the media type of the Blob.
-User agents must process the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-8">slice()</a></code> with <code class="idl"><a data-link-type="idl" href="#dfn-contentTypeBlob" id="ref-for-dfn-contentTypeBlob-3">contentType</a></code> normalized according to the following:</p>
+User agents must process the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-7">slice()</a></code> with <code class="idl"><a data-link-type="idl" href="#dfn-contentTypeBlob" id="ref-for-dfn-contentTypeBlob-3">contentType</a></code> normalized according to the following:</p>
      <ol type="a">
       <li>If the <code class="idl"><a data-link-type="idl" href="#dfn-contentTypeBlob" id="ref-for-dfn-contentTypeBlob-4">contentType</a></code> parameter is not provided, let <var>relativeContentType</var> be set to the empty string . 
       <li>
@@ -2121,27 +1985,27 @@ then set <var>relativeContentType</var> to the empty string and return from thes
     <li data-md="">
      <p>Let <var>span</var> be <code>max((relativeEnd - relativeStart), 0)</code>.</p>
     <li data-md="">
-     <p>Return a new <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-30">Blob</a></code> object <var>S</var> with the following characteristics:</p>
+     <p>Return a new <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-30">Blob</a></code> object <var>S</var> with the following characteristics:</p>
      <ol type="a">
       <li>
        <var>S</var> has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-8">readability state</a> equal to that of <var>O</var>’s <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-9">readability state</a>. 
        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-10">readability state</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> is retained
-    by the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-31">Blob</a></code> object returned by the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-9">slice()</a></code> call;
-    this has implications on whether the returned <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-32">Blob</a></code> is actually usable
+    by the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-31">Blob</a></code> object returned by the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-8">slice()</a></code> call;
+    this has implications on whether the returned <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-32">Blob</a></code> is actually usable
     for <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-1">read operation</a>s or as a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-2">Blob URL</a>.</p>
       <li><var>S</var> refers to <var>span</var> consecutive <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a>s from <var>O</var>,
     beginning with the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> at byte-order position <var>relativeStart</var>. 
       <li><var>S</var>.<code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-8">size</a></code> = <var>span</var>. 
       <li>
        <var>S</var>.<code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-10">type</a></code> = <var>relativeContentType</var>. 
-       <p class="note" role="note">Note: The type t of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-33">Blob</a></code> is considered a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">parsable MIME type</a> if the ASCII-encoded string representing the Blob object’s type,
+       <p class="note" role="note">Note: The type t of a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-33">Blob</a></code> is considered a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">parsable MIME type</a> if the ASCII-encoded string representing the Blob object’s type,
     when converted to a byte sequence,
     does not return undefined for the <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">parse a MIME type</a> algorithm.</p>
      </ol>
    </ol>
    <div class="example" id="example-5fb7503c">
-    <a class="self-link" href="#example-5fb7503c"></a> The examples below illustrate the different types of <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-10">slice()</a></code> calls possible. Since the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-5">File</a></code> interface inherits from the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-34">Blob</a></code> interface, examples are based on the use of the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-6">File</a></code> interface. 
-<pre class="lang-javascript highlight"><span class="c1">// obtain input element through DOM</span>
+    <a class="self-link" href="#example-5fb7503c"></a> The examples below illustrate the different types of <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-9">slice()</a></code> calls possible. Since the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-5">File</a></code> interface inherits from the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-34">Blob</a></code> interface, examples are based on the use of the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-6">File</a></code> interface. 
+<pre class="lang-javascript highlight"><span></span><span class="c1">// obtain input element through DOM</span>
 
 <span class="kd">var</span> <span class="nx">file</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s1">'file'</span><span class="p">).</span><span class="nx">files</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>
 <span class="k">if</span><span class="p">(</span><span class="nx">file</span><span class="p">)</span>
@@ -2164,16 +2028,12 @@ then set <var>relativeContentType</var> to the empty string and return from thes
   <span class="c1">// slice file from beginning till 150 bytes before end</span>
 
   <span class="kd">var</span> <span class="nx">fileNoMetadata</span> <span class="o">=</span> <span class="nx">file</span><span class="p">.</span><span class="nx">slice</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="o">-</span><span class="mi">150</span><span class="p">,</span> <span class="s2">"application/experimental"</span><span class="p">);</span>
-<span class="p">}</span></pre>
+<span class="p">}</span>
+</pre>
    </div>
    <h4 class="heading settled" data-level="4.3.2" id="close-method"><span class="secno">4.3.2. </span><span class="content"> The close method</span><a class="self-link" href="#close-method"></a></h4>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="method" data-export="" data-lt="close()" id="dfn-close">close()<span class="dfn-panel" data-deco=""><b><a href="#dfn-close">#dfn-close</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-close-1">4. 
-The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-close-2">(2)</a></span><span><a href="#ref-for-dfn-close-3">4.2. 
-Attributes</a></span><span><a href="#ref-for-dfn-close-4">7.6.1.2. 
-The readAsText() method</a></span><span><a href="#ref-for-dfn-close-5">7.6.1.3. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-close-6">7.6.1.4. 
-The readAsArrayBuffer() method</a></span></span></dfn> method is said to <a data-link-type="dfn" href="#closed" id="ref-for-closed-2">close</a> a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-35">Blob</a></code>,
-and must act as follows on the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-36">Blob</a></code> on which the method has been called:</p>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="method" data-export="" id="dfn-close">close()</dfn> method is said to <a data-link-type="dfn" href="#closed" id="ref-for-closed-2">close</a> a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-35">Blob</a></code>,
+and must act as follows on the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-36">Blob</a></code> on which the method has been called:</p>
    <ol>
     <li data-md="">
      <p>If the <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-11">readability state</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> is <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-5"><code>CLOSED</code></a>, <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-1">terminate this algorithm</a>.</p>
@@ -2182,23 +2042,22 @@ and must act as follows on the <code class="idl"><a data-link-type="idl" href="#
     <li data-md="">
      <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> has an entry in the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-1">Blob URL Store</a>, <a data-link-type="dfn" href="#removeTheEntry" id="ref-for-removeTheEntry-1">remove the entry</a> that corresponds to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
    </ol>
-   <h2 class="heading settled" data-level="5" id="file"><span class="secno">5. </span><span class="content"> The File Interface</span><a class="self-link" href="#file"></a></h2>
-   <p>A <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-7">File</a></code> object is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-37">Blob</a></code> object with a <code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-1">name</a></code> attribute, which is a string;
+   <h2 class="heading settled" data-level="5" id="f"><span class="secno">5. </span><span class="content"> The File Interface</span><a class="self-link" href="#f"></a></h2>
+   <p>A <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-7">File</a></code> object is a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-37">Blob</a></code> object with a <code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-1">name</a></code> attribute, which is a string;
 it can be created within the web application via a constructor,
 or is a reference to a <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence from a file from the underlying (OS) file system.</p>
-   <p>If a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-8">File</a></code> object is a reference to a <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence originating from a file on disk,
-then its <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-2">snapshot state</a> should be set to the state of the file on disk at the time the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-9">File</a></code> object is created.</p>
+   <p>If a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-8">File</a></code> object is a reference to a <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequence originating from a file on disk,
+then its <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-2">snapshot state</a> should be set to the state of the file on disk at the time the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-9">File</a></code> object is created.</p>
    <p class="note" role="note">Note: This is a non-trivial requirement to implement for user agents,
 and is thus not a <em>must</em> but a <em>should</em> <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a>.
-User agents should endeavor to have a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-10">File</a></code> object’s <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-3">snapshot state</a> set to the state of the underlying storage on disk at the time the reference is taken.
+User agents should endeavor to have a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-10">File</a></code> object’s <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-3">snapshot state</a> set to the state of the underlying storage on disk at the time the reference is taken.
 If the file is modified on disk following the time a reference has been taken,
-the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-11">File</a></code>'s <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-4">snapshot state</a> will differ from the state of the underlying storage.
+the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-11">File</a></code>'s <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-4">snapshot state</a> will differ from the state of the underlying storage.
 User agents may use modification time stamps and other mechanisms to maintain <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-5">snapshot state</a>,
 but this is left as an implementation detail.</p>
-   <p>When a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-12">File</a></code> object refers to a file on disk,
+   <p>When a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-12">File</a></code> object refers to a file on disk,
 user agents must return the <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-11">type</a></code> of that file,
-and must follow the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="file type guidelines" id="file-type-guidelines">file type guidelines<span class="dfn-panel" data-deco=""><b><a href="#file-type-guidelines">#file-type-guidelines</a></b><b>Referenced in:</b><span><a href="#ref-for-file-type-guidelines-1">4.2. 
-Attributes</a></span></span></dfn> below:</p>
+and must follow the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="file-type-guidelines">file type guidelines</dfn> below:</p>
    <ul>
     <li data-md="">
      <p>User agents must return the <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-12">type</a></code> as an ASCII-encoded string in lower case,
@@ -2210,51 +2069,24 @@ or the empty string – 0 bytes – if the type cannot be determined.</p>
     <li data-md="">
      <p>User agents must not attempt heuristic determination of encoding,
 including statistical methods.</p>
-<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="File" data-dfn-type="constructor" data-export="" data-lt="File(fileBits, fileName, options)|File(fileBits, fileName)" id="dom-file-file">Constructor<span class="dfn-panel" data-deco=""><b><a href="#dom-file-file">#dom-file-file</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-file-file-1">5.1. 
-Constructor</a></span><span><a href="#ref-for-dom-file-file-2">5.1.1. 
-Constructor Parameters</a></span></span></dfn>(sequence&lt;<a data-link-type="idl-name" href="#typedefdef-blobpart" id="ref-for-typedefdef-blobpart-2">BlobPart</a>> <a class="idl-code" data-link-type="argument" href="#dfn-fileBits" id="ref-for-dfn-fileBits-1">fileBits</a>,
-            [EnsureUTF16] DOMString <a class="idl-code" data-link-type="argument" href="#dfn-fileName" id="ref-for-dfn-fileName-1">fileName</a>,
-            optional <a data-link-type="idl-name" href="#dfn-FilePropertyBag" id="ref-for-dfn-FilePropertyBag-1">FilePropertyBag</a> <dfn class="idl-code" data-dfn-for="File/File(fileBits, fileName, options)" data-dfn-type="argument" data-export="" id="dom-file-file-filebits-filename-options-options">options<a class="self-link" href="#dom-file-file-filebits-filename-options-options"></a></dfn>),
-Exposed=(Window,Worker)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-lt="File" id="dfn-file">File<span class="dfn-panel" data-deco=""><b><a href="#dfn-file">#dfn-file</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-file-1">1. 
-Introduction</a> <a href="#ref-for-dfn-file-2">(2)</a> <a href="#ref-for-dfn-file-3">(3)</a></span><span><a href="#ref-for-dfn-file-4">4. 
-The Blob Interface and Binary Data</a></span><span><a href="#ref-for-dfn-file-5">4.3.1. 
-The slice method</a> <a href="#ref-for-dfn-file-6">(2)</a></span><span><a href="#ref-for-dfn-file-7">5. 
-The File Interface</a> <a href="#ref-for-dfn-file-8">(2)</a> <a href="#ref-for-dfn-file-9">(3)</a> <a href="#ref-for-dfn-file-10">(4)</a> <a href="#ref-for-dfn-file-11">(5)</a> <a href="#ref-for-dfn-file-12">(6)</a></span><span><a href="#ref-for-dfn-file-13">5.1. 
-Constructor</a> <a href="#ref-for-dfn-file-14">(2)</a> <a href="#ref-for-dfn-file-15">(3)</a></span><span><a href="#ref-for-dfn-file-16">5.1.1. 
-Constructor Parameters</a></span><span><a href="#ref-for-dfn-file-17">5.2. 
-Attributes</a> <a href="#ref-for-dfn-file-18">(2)</a> <a href="#ref-for-dfn-file-19">(3)</a> <a href="#ref-for-dfn-file-20">(4)</a></span><span><a href="#ref-for-dfn-file-21">6. 
-The FileList Interface</a> <a href="#ref-for-dfn-file-22">(2)</a></span><span><a href="#ref-for-dfn-file-23">6.2. 
-Methods and Parameters</a> <a href="#ref-for-dfn-file-24">(2)</a> <a href="#ref-for-dfn-file-25">(3)</a> <a href="#ref-for-dfn-file-26">(4)</a> <a href="#ref-for-dfn-file-27">(5)</a></span><span><a href="#ref-for-dfn-file-28">7.2. 
-The File Reading Task Source</a></span><span><a href="#ref-for-dfn-file-29">7.3.3. 
-FileReader States</a> <a href="#ref-for-dfn-file-30">(2)</a> <a href="#ref-for-dfn-file-31">(3)</a></span><span><a href="#ref-for-dfn-file-32">7.3.4.1. 
-The result attribute</a> <a href="#ref-for-dfn-file-33">(2)</a> <a href="#ref-for-dfn-file-34">(3)</a> <a href="#ref-for-dfn-file-35">(4)</a> <a href="#ref-for-dfn-file-36">(5)</a></span><span><a href="#ref-for-dfn-file-37">7.3.4.7. 
-Blob Parameters</a></span><span><a href="#ref-for-dfn-file-38">7.6. 
-Reading on Threads</a></span><span><a href="#ref-for-dfn-file-39">7.6.1. 
-The FileReaderSync API</a></span><span><a href="#ref-for-dfn-file-40">8. 
-Errors and Exceptions</a> <a href="#ref-for-dfn-file-41">(2)</a> <a href="#ref-for-dfn-file-42">(3)</a></span><span><a href="#ref-for-dfn-file-43">8.1. 
-Throwing an Exception or Returning an Error</a> <a href="#ref-for-dfn-file-44">(2)</a> <a href="#ref-for-dfn-file-45">(3)</a> <a href="#ref-for-dfn-file-46">(4)</a> <a href="#ref-for-dfn-file-47">(5)</a> <a href="#ref-for-dfn-file-48">(6)</a></span><span><a href="#ref-for-dfn-file-49">9. 
-A URL for Blob and File reference</a></span><span><a href="#ref-for-dfn-file-50">9.3. 
-The Blob URL</a> <a href="#ref-for-dfn-file-51">(2)</a></span><span><a href="#ref-for-dfn-file-52">9.4.2. 
-Response Headers</a> <a href="#ref-for-dfn-file-53">(2)</a> <a href="#ref-for-dfn-file-54">(3)</a></span><span><a href="#ref-for-dfn-file-55">9.5.1. 
-Methods and Parameters</a></span><span><a href="#ref-for-dfn-file-56">11. 
-Requirements and Use Cases</a></span></span></dfn> : <a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-38">Blob</a> {
-  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString " href="#dfn-name" id="ref-for-dfn-name-2">name</a>;
-  readonly attribute long long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="long long " href="#dfn-lastModified" id="ref-for-dfn-lastModified-1">lastModified</a>;
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="https://w3c.github.io/FileAPI/#dom-file-file">Constructor</a>(<span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#typedefdef-blobpart">BlobPart</a>> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBits" id="ref-for-dfn-fileBits-1">fileBits</a>,
+            [<a class="nv idl-code" data-link-type="extended-attribute">EnsureUTF16</a>] <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileName" id="ref-for-dfn-fileName-1">fileName</a>,
+            <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-FilePropertyBag">FilePropertyBag</a> <a class="nv idl-code" data-link-type="argument" href="https://w3c.github.io/FileAPI/#dom-file-file-filebits-filename-options-options">options</a>),
+<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="d0">File</dfn> : <a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-38">Blob</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dfn-name" id="ref-for-dfn-name-2">name</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long long" href="#dfn-lastModified" id="ref-for-dfn-lastModified-1">lastModified</a>;
 };
 
-dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" data-lt="FilePropertyBag" id="dfn-FilePropertyBag">FilePropertyBag<span class="dfn-panel" data-deco=""><b><a href="#dfn-FilePropertyBag">#dfn-FilePropertyBag</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-FilePropertyBag-1">5. 
-The File Interface</a></span><span><a href="#ref-for-dfn-FilePropertyBag-2">5.1. 
-Constructor</a></span><span><a href="#ref-for-dfn-FilePropertyBag-3">5.1.1. 
-Constructor Parameters</a></span></span></dfn> : <a data-link-type="idl-name" href="#dfn-BlobPropertyBag" id="ref-for-dfn-BlobPropertyBag-3">BlobPropertyBag</a> {
-  long long <a class="idl-code" data-link-type="dict-member" data-type="long long " href="#dfn-FPdate" id="ref-for-dfn-FPdate-1">lastModified</a>;
+<span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="https://w3c.github.io/FileAPI/#dfn-FilePropertyBag">FilePropertyBag</a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-BlobPropertyBag">BlobPropertyBag</a> {
+  <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="dict-member" data-type="long long " href="#dfn-FPdate" id="ref-for-dfn-FPdate-1">lastModified</a>;
 };
 </pre>
    </ul>
    <h3 class="heading settled" data-level="5.1" id="file-constructor"><span class="secno">5.1. </span><span class="content"> Constructor</span><a class="self-link" href="#file-constructor"></a></h3>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-13">File</a></code> constructor is invoked with two or three parameters,
+   <p>The <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-13">File</a></code> constructor is invoked with two or three parameters,
 depending on whether the optional dictionary parameter is used.
-When the <code class="idl"><a data-link-type="idl" href="#dom-file-file" id="ref-for-dom-file-file-1">File()</a></code> constructor is invoked,
+When the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dom-file-file">File()</a></code> constructor is invoked,
 user agents must run the following steps:</p>
    <ol>
     <li data-md="">
@@ -2266,13 +2098,13 @@ For 0 ≤ i &lt; <var>length</var>, repeat the following steps:</p>
       <li data-md="">
        <p>Let <var>element</var> be the <var>i</var>’th element of <var>a</var>.</p>
       <li data-md="">
-       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl">USVString</a></code>, run the following substeps:</p>
+       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dom-USVString">USVString</a></code>, run the following substeps:</p>
        <ol>
         <li data-md="">
          <p>Encode <var>s</var> as <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8">utf-8</a> and append the resulting <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> to <var>bytes</var>.</p>
        </ol>
        <p class="note" role="note">Note: The algorithm from WebIDL <a data-link-type="biblio" href="#biblio-webidl">[WebIDL]</a> replaces unmatched surrogates in an invalid <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-16">utf-16</a> string with U+FFFD replacement characters.
-Scenarios exist when the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-39">Blob</a></code> constructor may result in some data loss due to lost or scrambled character sequences.</p>
+Scenarios exist when the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-39">Blob</a></code> constructor may result in some data loss due to lost or scrambled character sequences.</p>
       <li data-md="">
        <p>If <var>element</var> is an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBufferView">ArrayBufferView</a></code>,
 convert it to a sequence of <code>byteLength</code> bytes from the underlying <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code>,
@@ -2283,9 +2115,9 @@ and append those bytes to <var>bytes</var>.</p>
 convert it to a sequence of <code>byteLength</code> bytes,
 and append those bytes to <var>bytes</var>.</p>
       <li data-md="">
-       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-40">Blob</a></code>,
+       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-40">Blob</a></code>,
 append the bytes it represents to <var>bytes</var>.
-The <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-13">type</a></code> of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-41">Blob</a></code> argument must be ignored.</p>
+The <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-13">type</a></code> of the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-41">Blob</a></code> argument must be ignored.</p>
      </ol>
     <li data-md="">
      <p>Let <var>n</var> be a new string of the same size as the <code class="idl"><a data-link-type="idl" href="#dfn-fileName" id="ref-for-dfn-fileName-2">fileName</a></code> argument to the constructor.
@@ -2294,7 +2126,7 @@ replacing any "/" character (U+002F SOLIDUS) with a ":" (U+003A COLON).</p>
      <p class="note" role="note">Note: Underlying OS filesystems use differing conventions for file name;
 with constructed files, mandating UTF-16 lessens ambiquity when file names are converted to <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a> sequences.</p>
     <li data-md="">
-     <p>If the optional <code class="idl"><a data-link-type="idl" href="#dfn-FilePropertyBag" id="ref-for-dfn-FilePropertyBag-2">FilePropertyBag</a></code> dictionary argument is used,
+     <p>If the optional <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-FilePropertyBag">FilePropertyBag</a></code> dictionary argument is used,
 then run the following substeps:</p>
      <ol>
       <li data-md="">
@@ -2315,7 +2147,7 @@ representing the number of milliseconds since the <a data-link-type="dfn" href="
 the <code class="idl"><a data-link-type="idl" href="#dfn-FPdate" id="ref-for-dfn-FPdate-4">lastModified</a></code> member could be a <code class="idl"><a data-link-type="idl">Date</a></code> object <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a>.</p>
      </ol>
     <li data-md="">
-     <p>Return a new <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-14">File</a></code> object <var>F</var> such that:</p>
+     <p>Return a new <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-14">File</a></code> object <var>F</var> such that:</p>
      <ol>
       <li data-md="">
        <p><var>F</var> has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-13">readability state</a> of <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-5"><code>OPENED</code></a>.</p>
@@ -2327,7 +2159,7 @@ the <code class="idl"><a data-link-type="idl" href="#dfn-FPdate" id="ref-for-dfn
        <p><var>F</var>.<code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-3">name</a></code> is set to <var>n</var>.</p>
       <li data-md="">
        <p><var>F</var>.<code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-14">type</a></code> is set to <var>t</var>.</p>
-       <p class="note" role="note">Note: The type t of a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-15">File</a></code> is considered a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">parsable MIME type</a> if the ASCII-encoded string representing the File object’s type,
+       <p class="note" role="note">Note: The type t of a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-15">File</a></code> is considered a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">parsable MIME type</a> if the ASCII-encoded string representing the File object’s type,
 when converted to a byte sequence,
 does not return undefined for the <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">parse a MIME type</a> algorithm.</p>
       <li data-md="">
@@ -2335,11 +2167,9 @@ does not return undefined for the <a data-link-type="dfn" href="https://mimesnif
      </ol>
    </ol>
    <h4 class="heading settled" data-level="5.1.1" id="file-constructor-params"><span class="secno">5.1.1. </span><span class="content"> Constructor Parameters</span><a class="self-link" href="#file-constructor-params"></a></h4>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dom-file-file" id="ref-for-dom-file-file-2">File()</a></code> constructor can be invoked with the parameters below:</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dom-file-file">File()</a></code> constructor can be invoked with the parameters below:</p>
    <dl>
-    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="File/File(fileBits, fileName, options)" data-dfn-type="argument" data-export="" data-lt="fileBits" id="dfn-fileBits"><code>fileBits</code><span class="dfn-panel" data-deco=""><b><a href="#dfn-fileBits">#dfn-fileBits</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-fileBits-1">5. 
-The File Interface</a></span><span><a href="#ref-for-dfn-fileBits-2">5.1. 
-Constructor</a></span></span></dfn> <code>sequence</code> 
+    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="File/File(fileBits, fileName, options)" data-dfn-type="argument" data-export="" id="dfn-fileBits"><code>fileBits</code></dfn> <code>sequence</code> 
     <dd>
      which takes any number of the following elements, and in any order: 
      <ul>
@@ -2348,44 +2178,35 @@ Constructor</a></span></span></dfn> <code>sequence</code>
       <li data-md="">
        <p><code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBufferView">ArrayBufferView</a></code> elements.</p>
       <li data-md="">
-       <p><code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-42">Blob</a></code> elements, which includes <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-16">File</a></code> elements.</p>
+       <p><code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-42">Blob</a></code> elements, which includes <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-16">File</a></code> elements.</p>
       <li data-md="">
        <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> elements.</p>
      </ul>
-    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="File/File(fileBits, fileName, options)" data-dfn-type="argument" data-export="" data-lt="fileName" id="dfn-fileName"><code>fileName</code><span class="dfn-panel" data-deco=""><b><a href="#dfn-fileName">#dfn-fileName</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-fileName-1">5. 
-The File Interface</a></span><span><a href="#ref-for-dfn-fileName-2">5.1. 
-Constructor</a> <a href="#ref-for-dfn-fileName-3">(2)</a></span></span></dfn> parameter 
+    <dt>A <dfn class="dfn-paneled idl-code" data-dfn-for="File/File(fileBits, fileName, options)" data-dfn-type="argument" data-export="" id="dfn-fileName"><code>fileName</code></dfn> parameter 
     <dd>A <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> parameter representing the name of the file;
     normative conditions for this constructor parameter can be found in <a href="#file-constructor">§5.1 Constructor</a>. 
-    <dt id="def-Properties"><a class="self-link" href="#def-Properties"></a>An optional <code class="idl"><a data-link-type="idl" href="#dfn-FilePropertyBag" id="ref-for-dfn-FilePropertyBag-3">FilePropertyBag</a></code> dictionary 
+    <dt id="def-Properties"><a class="self-link" href="#def-Properties"></a>An optional <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-FilePropertyBag">FilePropertyBag</a></code> dictionary 
     <dd>
-     which in addition to the <a href="#dfn-BlobPropertyBagMembers">members</a> of <code class="idl"><a data-link-type="idl" href="#dfn-BlobPropertyBag" id="ref-for-dfn-BlobPropertyBag-4">BlobPropertyBag</a></code> takes one member: 
+     which in addition to the <a href="#dfn-BlobPropertyBagMembers">members</a> of <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-BlobPropertyBag">BlobPropertyBag</a></code> takes one member: 
      <ul>
       <li data-md="">
-       <p>An optional <dfn class="dfn-paneled idl-code" data-dfn-for="FilePropertyBag" data-dfn-type="dict-member" data-export="" data-lt="lastModified" id="dfn-FPdate">lastModified<span class="dfn-panel" data-deco=""><b><a href="#dfn-FPdate">#dfn-FPdate</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-FPdate-1">5. 
-The File Interface</a></span><span><a href="#ref-for-dfn-FPdate-2">5.1. 
-Constructor</a> <a href="#ref-for-dfn-FPdate-3">(2)</a> <a href="#ref-for-dfn-FPdate-4">(3)</a></span></span></dfn> member,
+       <p>An optional <dfn class="dfn-paneled idl-code" data-dfn-for="FilePropertyBag" data-dfn-type="dict-member" data-export="" id="dfn-FPdate">lastModified</dfn> member,
 which must be a <code>long long</code>;
 normative conditions for this member are provided in <a href="#file-constructor">§5.1 Constructor</a>.</p>
      </ul>
    </dl>
    <h3 class="heading settled" data-level="5.2" id="file-attrs"><span class="secno">5.2. </span><span class="content"> Attributes</span><a class="self-link" href="#file-attrs"></a></h3>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="File" data-dfn-type="attribute" data-export="" data-lt="name" id="dfn-name">name<span class="dfn-panel" data-deco=""><b><a href="#dfn-name">#dfn-name</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-name-1">5. 
-The File Interface</a> <a href="#ref-for-dfn-name-2">(2)</a></span><span><a href="#ref-for-dfn-name-3">5.1. 
-Constructor</a></span><span><a href="#ref-for-dfn-name-4">9.4.2. 
-Response Headers</a> <a href="#ref-for-dfn-name-5">(2)</a> <a href="#ref-for-dfn-name-6">(3)</a></span></span></dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="File" data-dfn-type="attribute" data-export="" id="dfn-name">name</dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
     <dd>The name of the file.
     On getting, this must return the name of the file as a string.
     There are numerous file name variations and conventions used by different underlying OS file systems;
     this is merely the name of the file, without path information.
     On getting, if user agents cannot make this information available,
     they must return the empty string.
-    If a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-17">File</a></code> object is created using a constructor,
+    If a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-17">File</a></code> object is created using a constructor,
     further normative conditions for this attribute are found in <a href="#file-constructor">§5.1 Constructor</a>. 
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="File" data-dfn-type="attribute" data-export="" data-lt="lastModified" id="dfn-lastModified">lastModified<span class="dfn-panel" data-deco=""><b><a href="#dfn-lastModified">#dfn-lastModified</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-lastModified-1">5. 
-The File Interface</a></span><span><a href="#ref-for-dfn-lastModified-2">5.1. 
-Constructor</a></span></span></dfn> , <span> of type <a data-link-type="idl-name">long long</a>, readonly</span>
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="File" data-dfn-type="attribute" data-export="" id="dfn-lastModified">lastModified</dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#dom-longlong">long long</a>, readonly</span>
     <dd>The last modified date of the file.
     On getting, if user agents can make this information available,
     this must return a <code>long long</code> set to the time the file was last modified
@@ -2393,21 +2214,21 @@ Constructor</a></span></span></dfn> , <span> of type <a data-link-type="idl-name
     If the last modification date and time are not known,
     the attribute must return the current date and time
     as a <code>long long</code> representing the number of milliseconds since the <a data-link-type="dfn" href="#UnixEpoch" id="ref-for-UnixEpoch-4">Unix Epoch</a>;
-    this is equivalent to <code class="lang-javascript highlight"><span class="nb">Date</span><span class="p">.</span><span class="nx">now</span><span class="p">()</span></code> <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a>.
-    If a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-18">File</a></code> object is created using a constructor,
+    this is equivalent to <code class="lang-javascript highlight"><span></span><span class="nb">Date</span><span class="p">.</span><span class="nx">now</span><span class="p">()</span> </code> <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a>.
+    If a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-18">File</a></code> object is created using a constructor,
     further normative conditions for this attribute are found in <a href="#file-constructor">§5.1 Constructor</a>. 
    </dl>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-19">File</a></code> interface is available on objects that expose an attribute of type <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-1">FileList</a></code>;
+   <p>The <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-19">File</a></code> interface is available on objects that expose an attribute of type <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-1">FileList</a></code>;
 these objects are defined in HTML <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.
-The <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-20">File</a></code> interface, which inherits from <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-43">Blob</a></code>, is immutable,
+The <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-20">File</a></code> interface, which inherits from <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-43">Blob</a></code>, is immutable,
 and thus represents file data that can be read into memory at the time a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-2">read operation</a> is initiated.
 User agents must process reads on files that no longer exist at the time of read as <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-1">errors</a>,
 throwing a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception
-if using a <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-2">FileReaderSync</a></code> on a Web Worker <a data-link-type="biblio" href="#biblio-workers">[Workers]</a> or firing an <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-1">error</a></code> event
+if using a <code class="idl"><a data-link-type="idl" href="#d3" id="ref-for-d3-2">FileReaderSync</a></code> on a Web Worker <a data-link-type="biblio" href="#biblio-workers">[Workers]</a> or firing an <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-1">error</a></code> event
 with the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-1">error</a></code> attribute returning a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#domerror">DOMError</a></code>.</p>
    <div class="example" id="example-b63bb870">
     <a class="self-link" href="#example-b63bb870"></a> In the examples below, metadata from a file object is displayed meaningfully, and a file object is created with a name and a last modified date. 
-<pre class="lang-javascript highlight"><span class="kd">var</span> <span class="nx">file</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"filePicker"</span><span class="p">).</span><span class="nx">files</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>
+<pre class="lang-javascript highlight"><span></span><span class="kd">var</span> <span class="nx">file</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"filePicker"</span><span class="p">).</span><span class="nx">files</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>
 <span class="kd">var</span> <span class="nx">date</span> <span class="o">=</span> <span class="k">new</span> <span class="nb">Date</span><span class="p">(</span><span class="nx">file</span><span class="p">.</span><span class="nx">lastModified</span><span class="p">);</span>
 <span class="nx">println</span><span class="p">(</span><span class="s2">"You selected the file "</span> <span class="o">+</span> <span class="nx">file</span><span class="p">.</span><span class="nx">name</span> <span class="o">+</span> <span class="s2">" which was modified on "</span> <span class="o">+</span> <span class="nx">date</span><span class="p">.</span><span class="nx">toDateString</span><span class="p">()</span> <span class="o">+</span> <span class="s2">" ."</span><span class="p">);</span>
 
@@ -2418,31 +2239,26 @@ with the <code class="idl"><a class="idl-code" data-link-type="attribute" href="
 <span class="kd">var</span> <span class="nx">d</span> <span class="o">=</span> <span class="k">new</span> <span class="nb">Date</span><span class="p">(</span><span class="mi">2013</span><span class="p">,</span> <span class="mi">12</span><span class="p">,</span> <span class="mi">5</span><span class="p">,</span> <span class="mi">16</span><span class="p">,</span> <span class="mi">23</span><span class="p">,</span> <span class="mi">45</span><span class="p">,</span> <span class="mi">600</span><span class="p">);</span>
 <span class="kd">var</span> <span class="nx">generatedFile</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">File</span><span class="p">([</span><span class="s2">"Rough Draft ...."</span><span class="p">],</span> <span class="s2">"Draft1.txt"</span><span class="p">,</span> <span class="p">{</span><span class="nx">type</span><span class="o">:</span> <span class="s2">"text/plain"</span><span class="p">,</span> <span class="nx">lastModified</span><span class="o">:</span> <span class="nx">d</span><span class="p">})</span>
 
-<span class="p">...</span></pre>
+<span class="p">...</span>
+</pre>
    </div>
    <h2 class="heading settled" data-level="6" id="filelist-section"><span class="secno">6. </span><span class="content"> The FileList Interface</span><a class="self-link" href="#filelist-section"></a></h2>
-   <p class="note" role="note">Note: The <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-2">FileList</a></code> interface should be considered "at risk"
+   <p class="note" role="note">Note: The <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-2">FileList</a></code> interface should be considered "at risk"
 since the general trend on the Web Platform is to replace such interfaces
 with the <code class="idl"><a data-link-type="idl">Array</a></code> platform object in ECMAScript <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a>.
-In particular, this means syntax of the sort <code class="lang-javascript highlight"><span class="nx">filelist</span><span class="p">.</span><span class="nx">item</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span></code> is at risk;
-most other programmatic use of <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-3">FileList</a></code> is unlikely to be affected by the eventual migration to an <code class="idl"><a data-link-type="idl">Array</a></code> type.</p>
-   <p>This interface is a list of <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-21">File</a></code> objects.</p>
-<pre class="idl def">[Exposed=(Window,Worker)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-lt="FileList" id="dfn-filelist">FileList<span class="dfn-panel" data-deco=""><b><a href="#dfn-filelist">#dfn-filelist</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-filelist-1">5.2. 
-Attributes</a></span><span><a href="#ref-for-dfn-filelist-2">6. 
-The FileList Interface</a> <a href="#ref-for-dfn-filelist-3">(2)</a></span><span><a href="#ref-for-dfn-filelist-4">6.1. 
-Attributes</a></span><span><a href="#ref-for-dfn-filelist-5">6.2. 
-Methods and Parameters</a> <a href="#ref-for-dfn-filelist-6">(2)</a> <a href="#ref-for-dfn-filelist-7">(3)</a> <a href="#ref-for-dfn-filelist-8">(4)</a> <a href="#ref-for-dfn-filelist-9">(5)</a> <a href="#ref-for-dfn-filelist-10">(6)</a></span><span><a href="#ref-for-dfn-filelist-11">7.3.4.7. 
-Blob Parameters</a></span><span><a href="#ref-for-dfn-filelist-12">10. 
-Security Considerations</a></span></span></dfn> {
-  getter <a data-link-type="idl-name" href="#dfn-file" id="ref-for-dfn-file-22">File</a>? <a class="idl-code" data-link-type="method" href="#dfn-item" id="ref-for-dfn-item-1">item</a>(unsigned long <a class="idl-code" data-link-type="argument" href="#dfn-index" id="ref-for-dfn-index-1">index</a>);
-  readonly attribute unsigned long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long " href="#dfn-length" id="ref-for-dfn-length-1">length</a>;
+In particular, this means syntax of the sort <code class="lang-javascript highlight"><span></span><span class="nx">filelist</span><span class="p">.</span><span class="nx">item</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span> </code> is at risk;
+most other programmatic use of <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-3">FileList</a></code> is unlikely to be affected by the eventual migration to an <code class="idl"><a data-link-type="idl">Array</a></code> type.</p>
+   <p>This interface is a list of <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-21">File</a></code> objects.</p>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="d1">FileList</dfn> {
+  <span class="kt">getter</span> <a class="n" data-link-type="idl-name" href="#d0" id="ref-for-d0-22">File</a>? <a class="nv idl-code" data-link-type="method" href="#dfn-item" id="ref-for-dfn-item-1">item</a>(<span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-index" id="ref-for-dfn-index-1">index</a>);
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dfn-length" id="ref-for-dfn-length-1">length</a>;
 };
 </pre>
    <div class="example" id="example-6cf5eb7d">
     <a class="self-link" href="#example-6cf5eb7d"></a> Sample usage typically involves DOM access to the <code>&lt;input type="file"></code> element within a form,
   and then accessing selected files. 
-<pre class="lang-javascript highlight"><span class="c1">// uploadData is a form element</span>
+<pre class="lang-javascript highlight"><span></span><span class="c1">// uploadData is a form element</span>
 <span class="c1">// fileChooser is input element of type 'file'</span>
 <span class="kd">var</span> <span class="nx">file</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">forms</span><span class="p">[</span><span class="s1">'uploadData'</span><span class="p">][</span><span class="s1">'fileChooser'</span><span class="p">].</span><span class="nx">files</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>
 
@@ -2452,73 +2268,57 @@ Security Considerations</a></span></span></dfn> {
 <span class="k">if</span><span class="p">(</span><span class="nx">file</span><span class="p">)</span>
 <span class="p">{</span>
   <span class="c1">// Perform file ops</span>
-<span class="p">}</span></pre>
+<span class="p">}</span>
+</pre>
    </div>
    <h3 class="heading settled" data-level="6.1" id="attributes-filelist"><span class="secno">6.1. </span><span class="content"> Attributes</span><a class="self-link" href="#attributes-filelist"></a></h3>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileList" data-dfn-type="attribute" data-export="" data-lt="length" id="dfn-length">length<span class="dfn-panel" data-deco=""><b><a href="#dfn-length">#dfn-length</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-length-1">6. 
-The FileList Interface</a></span></span></dfn> , <span> of type <a data-link-type="idl-name">unsigned long</a>, readonly</span>
-    <dd>must return the number of files in the <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-4">FileList</a></code> object.
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileList" data-dfn-type="attribute" data-export="" id="dfn-length">length</dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#dom-unsignedlong">unsigned long</a>, readonly</span>
+    <dd>must return the number of files in the <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-4">FileList</a></code> object.
       If there are no files, this attribute must return 0. 
    </dl>
    <h3 class="heading settled" data-level="6.2" id="filelist-methods-params"><span class="secno">6.2. </span><span class="content"> Methods and Parameters</span><a class="self-link" href="#filelist-methods-params"></a></h3>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileList" data-dfn-type="method" data-export="" data-lt="item(index)" id="dfn-item">item(index)<span class="dfn-panel" data-deco=""><b><a href="#dfn-item">#dfn-item</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-item-1">6. 
-The FileList Interface</a></span></span></dfn> 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileList" data-dfn-type="method" data-export="" id="dfn-item">item(index)</dfn> 
     <dd>
-     must return the <em>indexth</em> <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-23">File</a></code> object in the <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-5">FileList</a></code>.
-    If there is no <em>indexth</em> <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-24">File</a></code> object in the <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-6">FileList</a></code>,
+     must return the <em>indexth</em> <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-23">File</a></code> object in the <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-5">FileList</a></code>.
+    If there is no <em>indexth</em> <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-24">File</a></code> object in the <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-6">FileList</a></code>,
     then this method must return <code>null</code>. 
-     <p><dfn class="dfn-paneled idl-code" data-dfn-for="FileList/item(index)" data-dfn-type="argument" data-export="" data-lt="index" id="dfn-index">index<span class="dfn-panel" data-deco=""><b><a href="#dfn-index">#dfn-index</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-index-1">6. 
-The FileList Interface</a></span></span></dfn> must be treated by user agents
-    as value for the position of a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-25">File</a></code> object in the <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-7">FileList</a></code>,
+     <p><dfn class="dfn-paneled idl-code" data-dfn-for="FileList/item(index)" data-dfn-type="argument" data-export="" id="dfn-index">index</dfn> must be treated by user agents
+    as value for the position of a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-25">File</a></code> object in the <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-7">FileList</a></code>,
     with 0 representing the first file. <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-supported-property-indices">Supported property indices</a> are the numbers in the range zero
-    to one less than the number of <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-26">File</a></code> objects represented by the <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-8">FileList</a></code> object.
-    If there are no such <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-27">File</a></code> objects,
+    to one less than the number of <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-26">File</a></code> objects represented by the <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-8">FileList</a></code> object.
+    If there are no such <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-27">File</a></code> objects,
     then there are no supported property indices.</p>
    </dl>
-   <p class="note" role="note">Note: The <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlinputelement">HTMLInputElement</a></code> interface has a readonly attribute of type <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-9">FileList</a></code>,
+   <p class="note" role="note">Note: The <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlinputelement">HTMLInputElement</a></code> interface has a readonly attribute of type <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-9">FileList</a></code>,
 which is what is being accessed in the above example.
-Other interfaces with a readonly attribute of type <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-10">FileList</a></code> include the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/interaction.html#datatransfer">DataTransfer</a></code> interface.</p>
+Other interfaces with a readonly attribute of type <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-10">FileList</a></code> include the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/interaction.html#datatransfer">DataTransfer</a></code> interface.</p>
    <h2 class="heading settled" data-level="7" id="reading-data-section"><span class="secno">7. </span><span class="content"> Reading Data</span><a class="self-link" href="#reading-data-section"></a></h2>
    <h3 class="heading settled" data-level="7.1" id="readOperationSection"><span class="secno">7.1. </span><span class="content"> The Read Operation</span><a class="self-link" href="#readOperationSection"></a></h3>
    <p>The algorithm below defines a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-3">read operation</a>,
-which takes a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-44">Blob</a></code> and a <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-1">synchronous flag</a> as input,
+which takes a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-44">Blob</a></code> and a <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-1">synchronous flag</a> as input,
 and reads <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#byte">byte</a>s into a byte stream
 which is returned as the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-4">read operation</a>,
 or else fails along with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-1">failure reason</a>.
 Methods in this specification invoke the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-5">read operation</a> with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-2">synchronous flag</a> either set or unset.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="synchronous flag" data-noexport="" id="synchronousFlag">synchronous flag<span class="dfn-panel" data-deco=""><b><a href="#synchronousFlag">#synchronousFlag</a></b><b>Referenced in:</b><span><a href="#ref-for-synchronousFlag-1">7.1. 
-The Read Operation</a> <a href="#ref-for-synchronousFlag-2">(2)</a> <a href="#ref-for-synchronousFlag-3">(3)</a> <a href="#ref-for-synchronousFlag-4">(4)</a> <a href="#ref-for-synchronousFlag-5">(5)</a> <a href="#ref-for-synchronousFlag-6">(6)</a> <a href="#ref-for-synchronousFlag-7">(7)</a> <a href="#ref-for-synchronousFlag-8">(8)</a></span><span><a href="#ref-for-synchronousFlag-9">7.6.1.2. 
-The readAsText() method</a></span><span><a href="#ref-for-synchronousFlag-10">7.6.1.3. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-synchronousFlag-11">7.6.1.4. 
-The readAsArrayBuffer() method</a></span></span></dfn> determines if a read operation is synchronous or asynchronous,
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="synchronousFlag">synchronous flag</dfn> determines if a read operation is synchronous or asynchronous,
 and is <em>unset</em> by default.
 Methods may set it.
 If it is set,
 the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-6">read operation</a> takes place synchronously.
 Otherwise, it takes place asynchronously.</p>
-   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="read operation" data-noexport="" id="readOperation">read operation<span class="dfn-panel" data-deco=""><b><a href="#readOperation">#readOperation</a></b><b>Referenced in:</b><span><a href="#ref-for-readOperation-1">4.3.1. 
-The slice method</a></span><span><a href="#ref-for-readOperation-2">5.2. 
-Attributes</a></span><span><a href="#ref-for-readOperation-3">7.1. 
-The Read Operation</a> <a href="#ref-for-readOperation-4">(2)</a> <a href="#ref-for-readOperation-5">(3)</a> <a href="#ref-for-readOperation-6">(4)</a> <a href="#ref-for-readOperation-7">(5)</a> <a href="#ref-for-readOperation-8">(6)</a> <a href="#ref-for-readOperation-9">(7)</a> <a href="#ref-for-readOperation-10">(8)</a> <a href="#ref-for-readOperation-11">(9)</a> <a href="#ref-for-readOperation-12">(10)</a></span><span><a href="#ref-for-readOperation-13">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-readOperation-14">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-readOperation-15">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-readOperation-16">7.6.1.2. 
-The readAsText() method</a> <a href="#ref-for-readOperation-17">(2)</a></span><span><a href="#ref-for-readOperation-18">7.6.1.3. 
-The readAsDataURL() method</a> <a href="#ref-for-readOperation-19">(2)</a> <a href="#ref-for-readOperation-20">(3)</a></span><span><a href="#ref-for-readOperation-21">7.6.1.4. 
-The readAsArrayBuffer() method</a> <a href="#ref-for-readOperation-22">(2)</a> <a href="#ref-for-readOperation-23">(3)</a></span><span><a href="#ref-for-readOperation-24">8.1. 
-Throwing an Exception or Returning an Error</a></span></span></dfn> on a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-45">Blob</a></code> and the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-3">synchronous flag</a>,
+   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="readOperation">read operation</dfn> on a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-45">Blob</a></code> and the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-3">synchronous flag</a>,
 run the following steps:</p>
    <ol>
     <li data-md="">
-     <p>Let <var>s</var> be a a new <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a>, <var>b</var> be the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-46">Blob</a></code> to be read from,
+     <p>Let <var>s</var> be a a new <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a>, <var>b</var> be the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-46">Blob</a></code> to be read from,
 and <var>bytes</var> initially set to an empty byte sequence.
 Set the <var>length</var> on <var>s</var> to the <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-10">size</a></code> of <var>b</var>.
 While there are still bytes to be read in <var>b</var>,
 perform the following substeps:</p>
      <p class="note" role="note">Note: The algorithm assumes that invoking methods have checked for <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-14">readability state</a>.
-A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-47">Blob</a></code> in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-7"><code>CLOSED</code></a> state must not have a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-7">read operation</a> called on it.</p>
+A <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-47">Blob</a></code> in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-7"><code>CLOSED</code></a> state must not have a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-7">read operation</a> called on it.</p>
      <ol>
       <li data-md="">
        <p>If the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-4">synchronous flag</a> is set, follow the steps below:</p>
@@ -2561,109 +2361,73 @@ Reset <var>bytes</var> to the empty byte sequence
 and continue reading <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s as above.</p>
      </ol>
    </ol>
-   <p>To perform an <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="annotated task read operation" data-noexport="" id="task-read-operation">annotated task read operation<span class="dfn-panel" data-deco=""><b><a href="#task-read-operation">#task-read-operation</a></b><b>Referenced in:</b><span><a href="#ref-for-task-read-operation-1">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-task-read-operation-2">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-task-read-operation-3">7.3.4.4. 
-The readAsArrayBuffer() method</a></span></span></dfn> on a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-48">Blob</a></code> <var>b</var>,
+   <p>To perform an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="task-read-operation">annotated task read operation</dfn> on a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-48">Blob</a></code> <var>b</var>,
 perform the steps below:</p>
    <ol>
     <li data-md="">
      <p>Perform a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-8">read operation</a> on <var>b</var> with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-8">synchronous flag</a> unset,
 along with the additional steps below.</p>
     <li data-md="">
-     <p>If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-9">read operation</a> terminates with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-6">failure reason</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="process read error" data-noexport="" id="process-read-error">process read error<span class="dfn-panel" data-deco=""><b><a href="#process-read-error">#process-read-error</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-error-1">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-process-read-error-2">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-process-read-error-3">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-process-read-error-4">7.3.4.5. 
-Error Steps</a></span><span><a href="#ref-for-process-read-error-5">8.1. 
-Throwing an Exception or Returning an Error</a></span></span></dfn> with the <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-7">failure reason</a> and terminate this algorithm.</p>
+     <p>If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-9">read operation</a> terminates with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-6">failure reason</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read-error">process read error</dfn> with the <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-7">failure reason</a> and terminate this algorithm.</p>
     <li data-md="">
-     <p>When the first <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> is being pushed to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> during the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-10">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="process read" data-noexport="" id="process-read">process read<span class="dfn-panel" data-deco=""><b><a href="#process-read">#process-read</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-1">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-process-read-2">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-process-read-3">7.3.4.4. 
-The readAsArrayBuffer() method</a></span></span></dfn>.</p>
+     <p>When the first <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> is being pushed to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> during the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-10">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read">process read</dfn>.</p>
     <li data-md="">
      <p>Once the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> from the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-11">read operation</a> has at least one <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> read into it,
-or there are no <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s left to read from <var>b</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="process read data" data-noexport="" id="process-read-data">process read data<span class="dfn-panel" data-deco=""><b><a href="#process-read-data">#process-read-data</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-data-1">7.1. 
-The Read Operation</a></span><span><a href="#ref-for-process-read-data-2">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-process-read-data-3">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-process-read-data-4">7.3.4.4. 
-The readAsArrayBuffer() method</a></span></span></dfn>.
+or there are no <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s left to read from <var>b</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read-data">process read data</dfn>.
 Keep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queuing tasks</a> to <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-1">process read data</a> for every <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> read or every 50ms,
 whichever is <em>least frequent</em>.</p>
     <li data-md="">
-     <p>When all of the <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s from <var>b</var> are read into the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> from the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-12">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="process read EOF" data-noexport="" id="process-read-EOF">process read EOF<span class="dfn-panel" data-deco=""><b><a href="#process-read-EOF">#process-read-EOF</a></b><b>Referenced in:</b><span><a href="#ref-for-process-read-EOF-1">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-process-read-EOF-2">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-process-read-EOF-3">7.3.4.4. 
-The readAsArrayBuffer() method</a></span></span></dfn>.</p>
+     <p>When all of the <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s from <var>b</var> are read into the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> from the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-12">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read-EOF">process read EOF</dfn>.</p>
    </ol>
    <p>Use the <a data-link-type="dfn" href="#fileReadingTaskSource" id="ref-for-fileReadingTaskSource-1">file reading task source</a> for all these tasks.</p>
    <h3 class="heading settled" data-level="7.2" id="blobreader-task-source"><span class="secno">7.2. </span><span class="content"> The File Reading Task Source</span><a class="self-link" href="#blobreader-task-source"></a></h3>
-   <p>This specification defines a new generic <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="file reading task source" data-noexport="" id="fileReadingTaskSource">file reading task source<span class="dfn-panel" data-deco=""><b><a href="#fileReadingTaskSource">#fileReadingTaskSource</a></b><b>Referenced in:</b><span><a href="#ref-for-fileReadingTaskSource-1">7.1. 
-The Read Operation</a></span><span><a href="#ref-for-fileReadingTaskSource-2">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-fileReadingTaskSource-3">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-fileReadingTaskSource-4">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-fileReadingTaskSource-5">7.3.4.6. 
-The abort() method</a></span></span></dfn>,
+   <p>This specification defines a new generic <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fileReadingTaskSource">file reading task source</dfn>,
 which is used for all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">tasks that are queued</a> in this specification
-to read byte sequences associated with <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-49">Blob</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-28">File</a></code> objects.
+to read byte sequences associated with <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-49">Blob</a></code> and <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-28">File</a></code> objects.
 It is to be used for features that trigger in response to asynchronously reading binary data.</p>
    <h3 class="heading settled" data-level="7.3" id="APIASynch"><span class="secno">7.3. </span><span class="content"> The FileReader API</span><a class="self-link" href="#APIASynch"></a></h3>
-<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="constructor" data-export="" data-lt="FileReader()" id="dom-filereader-filereader">Constructor<span class="dfn-panel" data-deco=""><b><a href="#dom-filereader-filereader">#dom-filereader-filereader</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-filereader-filereader-1">7.3.1. 
-Constructor</a></span></span></dfn>, Exposed=(Window,Worker)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-lt="FileReader" id="dfn-filereader">FileReader<span class="dfn-panel" data-deco=""><b><a href="#dfn-filereader">#dfn-filereader</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-filereader-1">1. 
-Introduction</a></span><span><a href="#ref-for-dfn-filereader-2">4.2. 
-Attributes</a></span><span><a href="#ref-for-dfn-filereader-3">7.3.1. 
-Constructor</a> <a href="#ref-for-dfn-filereader-4">(2)</a></span><span><a href="#ref-for-dfn-filereader-5">7.3.2. 
-Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-filereader-6">7.3.3. 
-FileReader States</a> <a href="#ref-for-dfn-filereader-7">(2)</a> <a href="#ref-for-dfn-filereader-8">(3)</a> <a href="#ref-for-dfn-filereader-9">(4)</a> <a href="#ref-for-dfn-filereader-10">(5)</a></span><span><a href="#ref-for-dfn-filereader-11">7.3.4. 
-Reading a File or Blob</a> <a href="#ref-for-dfn-filereader-12">(2)</a> <a href="#ref-for-dfn-filereader-13">(3)</a></span><span><a href="#ref-for-dfn-filereader-14">7.3.4.1. 
-The result attribute</a></span><span><a href="#ref-for-dfn-filereader-15">7.4. 
-Determining Encoding</a></span><span><a href="#ref-for-dfn-filereader-16">7.5. 
-Events</a> <a href="#ref-for-dfn-filereader-17">(2)</a></span><span><a href="#ref-for-dfn-filereader-18">7.5.1. 
-Event Summary</a></span><span><a href="#ref-for-dfn-filereader-19">7.6. 
-Reading on Threads</a></span><span><a href="#ref-for-dfn-filereader-20">8.1. 
-Throwing an Exception or Returning an Error</a></span><span><a href="#ref-for-dfn-filereader-21">10. 
-Security Considerations</a></span></span></dfn>: <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="https://w3c.github.io/FileAPI/#dom-filereader-filereader">Constructor</a>, <a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="d2">FileReader</dfn>: <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
 
   // async read methods
-  void <a class="idl-code" data-link-type="method" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-1">readAsArrayBuffer</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-50">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-1">blob</a>);
-  void <a class="idl-code" data-link-type="method" href="#dfn-readAsText" id="ref-for-dfn-readAsText-1">readAsText</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-51">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-2">blob</a>, optional DOMString <a class="idl-code" data-link-type="argument" href="#dfn-label" id="ref-for-dfn-label-1">label</a>);
-  void <a class="idl-code" data-link-type="method" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-1">readAsDataURL</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-52">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-3">blob</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-1">readAsArrayBuffer</a>(<a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-50">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-1">blob</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsBinaryString" id="ref-for-dfn-readAsBinaryString-1">readAsBinaryString</a>(<a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-51">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-2">blob</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsText" id="ref-for-dfn-readAsText-1">readAsText</a>(<a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-52">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-3">blob</a>, <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-label" id="ref-for-dfn-label-1">label</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-1">readAsDataURL</a>(<a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-53">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-4">blob</a>);
 
-  void <a class="idl-code" data-link-type="method" href="#dfn-abort" id="ref-for-dfn-abort-2">abort</a>();
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-abort" id="ref-for-dfn-abort-2">abort</a>();
 
   // states
-  const unsigned short <a class="idl-code" data-link-type="const" href="#dfn-empty" id="ref-for-dfn-empty-1">EMPTY</a> = 0;
-  const unsigned short <a class="idl-code" data-link-type="const" href="#dfn-loading" id="ref-for-dfn-loading-1">LOADING</a> = 1;
-  const unsigned short <a class="idl-code" data-link-type="const" href="#dfn-done" id="ref-for-dfn-done-1">DONE</a> = 2;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dfn-empty" id="ref-for-dfn-empty-1">EMPTY</a> = 0;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dfn-loading" id="ref-for-dfn-loading-1">LOADING</a> = 1;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dfn-done" id="ref-for-dfn-done-1">DONE</a> = 2;
 
 
-  readonly attribute unsigned short <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned short " href="#dfn-readyState" id="ref-for-dfn-readyState-1">readyState</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned short" href="#dfn-readyState" id="ref-for-dfn-readyState-1">readyState</a>;
 
   // File or Blob data
-  readonly attribute (DOMString or ArrayBuffer)? <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="(DOMString or ArrayBuffer)? " href="#dfn-result" id="ref-for-dfn-result-1">result</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> (<span class="kt">DOMString</span> <span class="kt">or</span> <span class="kt">ArrayBuffer</span>)? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="(DOMString or ArrayBuffer)?" href="#dfn-result" id="ref-for-dfn-result-1">result</a>;
 
-  readonly attribute <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#domerror">DOMError</a>? <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMError? " href="#dfn-error" id="ref-for-dfn-error-2">error</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#domerror">DOMError</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMError?" href="#dfn-error" id="ref-for-dfn-error-2">error</a>;
 
   // event handler content attributes
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onloadstart" id="ref-for-dfn-onloadstart-1">onloadstart</a>;
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onprogress" id="ref-for-dfn-onprogress-1">onprogress</a>;
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onload" id="ref-for-dfn-onload-1">onload</a>;
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onabort" id="ref-for-dfn-onabort-1">onabort</a>;
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onerror" id="ref-for-dfn-onerror-1">onerror</a>;
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onloadend" id="ref-for-dfn-onloadend-1">onloadend</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onloadstart" id="ref-for-dfn-onloadstart-1">onloadstart</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onprogress" id="ref-for-dfn-onprogress-1">onprogress</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onload" id="ref-for-dfn-onload-1">onload</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onabort" id="ref-for-dfn-onabort-1">onabort</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onerror" id="ref-for-dfn-onerror-1">onerror</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onloadend" id="ref-for-dfn-onloadend-1">onloadend</a>;
 
 };
 </pre>
    <h4 class="heading settled" data-level="7.3.1" id="filereaderConstrctr"><span class="secno">7.3.1. </span><span class="content"> Constructor</span><a class="self-link" href="#filereaderConstrctr"></a></h4>
-   <p>When the <code class="idl"><a data-link-type="idl" href="#dom-filereader-filereader" id="ref-for-dom-filereader-filereader-1">FileReader()</a></code> constructor is invoked,
-the user agent must return a new <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-3">FileReader</a></code> object.</p>
+   <p>When the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dom-filereader-filereader">FileReader()</a></code> constructor is invoked,
+the user agent must return a new <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-3">FileReader</a></code> object.</p>
    <p>In environments where the global object is represented by a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> or a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> object,
-the <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-4">FileReader</a></code> constructor must be available.</p>
+the <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-4">FileReader</a></code> constructor must be available.</p>
    <h4 class="heading settled" data-level="7.3.2" id="event-handler-attributes-section"><span class="secno">7.3.2. </span><span class="content"> Event Handler Content Attributes</span><a class="self-link" href="#event-handler-attributes-section"></a></h4>
    <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attribute">event handler content attributes</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event types</a>)
-that user agents must support on <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-5">FileReader</a></code> as DOM attributes:</p>
+that user agents must support on <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-5">FileReader</a></code> as DOM attributes:</p>
    <table>
     <thead>
      <tr>
@@ -2671,115 +2435,60 @@ that user agents must support on <code class="idl"><a data-link-type="idl" href=
       <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event type</a> 
     <tbody>
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onloadstart" id="dfn-onloadstart">onloadstart<span class="dfn-panel" data-deco=""><b><a href="#dfn-onloadstart">#dfn-onloadstart</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onloadstart-1">7.3. 
-The FileReader API</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onloadstart">onloadstart</dfn> 
       <td><code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-1">loadstart</a></code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onprogress" id="dfn-onprogress">onprogress<span class="dfn-panel" data-deco=""><b><a href="#dfn-onprogress">#dfn-onprogress</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onprogress-1">7.3. 
-The FileReader API</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onprogress">onprogress</dfn> 
       <td><code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-1">progress</a></code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onabort" id="dfn-onabort">onabort<span class="dfn-panel" data-deco=""><b><a href="#dfn-onabort">#dfn-onabort</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onabort-1">7.3. 
-The FileReader API</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onabort">onabort</dfn> 
       <td><code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-1">abort</a></code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onerror" id="dfn-onerror">onerror<span class="dfn-panel" data-deco=""><b><a href="#dfn-onerror">#dfn-onerror</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onerror-1">7.3. 
-The FileReader API</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onerror">onerror</dfn> 
       <td><code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-2">error</a></code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onload" id="dfn-onload">onload<span class="dfn-panel" data-deco=""><b><a href="#dfn-onload">#dfn-onload</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onload-1">7.3. 
-The FileReader API</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onload">onload</dfn> 
       <td><code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-1">load</a></code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="onloadend" id="dfn-onloadend">onloadend<span class="dfn-panel" data-deco=""><b><a href="#dfn-onloadend">#dfn-onloadend</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-onloadend-1">7.3. 
-The FileReader API</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-onloadend">onloadend</dfn> 
       <td><code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-1">loadend</a></code> 
    </table>
    <h4 class="heading settled" data-level="7.3.3" id="blobreader-state"><span class="secno">7.3.3. </span><span class="content"> FileReader States</span><a class="self-link" href="#blobreader-state"></a></h4>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-6">FileReader</a></code> object can be in one of 3 states.
-The <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="readyState" id="dfn-readyState">readyState<span class="dfn-panel" data-deco=""><b><a href="#dfn-readyState">#dfn-readyState</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readyState-1">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-readyState-2">7.3.3. 
-FileReader States</a></span><span><a href="#ref-for-dfn-readyState-3">7.3.4. 
-Reading a File or Blob</a></span><span><a href="#ref-for-dfn-readyState-4">7.3.4.1. 
-The result attribute</a></span><span><a href="#ref-for-dfn-readyState-5">7.3.4.2. 
-The readAsDataURL() method</a> <a href="#ref-for-dfn-readyState-6">(2)</a> <a href="#ref-for-dfn-readyState-7">(3)</a> <a href="#ref-for-dfn-readyState-8">(4)</a> <a href="#ref-for-dfn-readyState-9">(5)</a></span><span><a href="#ref-for-dfn-readyState-10">7.3.4.3. 
-The readAsText() method</a> <a href="#ref-for-dfn-readyState-11">(2)</a> <a href="#ref-for-dfn-readyState-12">(3)</a> <a href="#ref-for-dfn-readyState-13">(4)</a> <a href="#ref-for-dfn-readyState-14">(5)</a></span><span><a href="#ref-for-dfn-readyState-15">7.3.4.4. 
-The readAsArrayBuffer() method</a> <a href="#ref-for-dfn-readyState-16">(2)</a> <a href="#ref-for-dfn-readyState-17">(3)</a> <a href="#ref-for-dfn-readyState-18">(4)</a> <a href="#ref-for-dfn-readyState-19">(5)</a></span><span><a href="#ref-for-dfn-readyState-20">7.3.4.5. 
-Error Steps</a> <a href="#ref-for-dfn-readyState-21">(2)</a> <a href="#ref-for-dfn-readyState-22">(3)</a></span><span><a href="#ref-for-dfn-readyState-23">7.3.4.6. 
-The abort() method</a> <a href="#ref-for-dfn-readyState-24">(2)</a> <a href="#ref-for-dfn-readyState-25">(3)</a> <a href="#ref-for-dfn-readyState-26">(4)</a></span><span><a href="#ref-for-dfn-readyState-27">7.6.1.2. 
-The readAsText() method</a></span><span><a href="#ref-for-dfn-readyState-28">7.6.1.3. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-readyState-29">7.6.1.4. 
-The readAsArrayBuffer() method</a></span></span></dfn> attribute,
+   <p>The <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-6">FileReader</a></code> object can be in one of 3 states.
+The <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-readyState">readyState</dfn> attribute,
 on getting,
 must return the current state,
 which must be one of the following values:</p>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" data-lt="EMPTY" id="dfn-empty">EMPTY<span class="dfn-panel" data-deco=""><b><a href="#dfn-empty">#dfn-empty</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-empty-1">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-empty-2">7.3.4.1. 
-The result attribute</a></span><span><a href="#ref-for-dfn-empty-3">7.3.4.6. 
-The abort() method</a></span></span></dfn> (numeric value 0) 
-    <dd>The <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-7">FileReader</a></code> object has been constructed,
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" id="dfn-empty">EMPTY</dfn> (numeric value 0) 
+    <dd>The <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-7">FileReader</a></code> object has been constructed,
     and there are no pending reads.
     None of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-2">read methods</a> have been called.
-    This is the default state of a newly minted <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-8">FileReader</a></code> object,
+    This is the default state of a newly minted <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-8">FileReader</a></code> object,
     until one of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-3">read methods</a> have been called on it. 
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" data-lt="LOADING" id="dfn-loading">LOADING<span class="dfn-panel" data-deco=""><b><a href="#dfn-loading">#dfn-loading</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-loading-1">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-loading-2">7.3.4. 
-Reading a File or Blob</a></span><span><a href="#ref-for-dfn-loading-3">7.3.4.2. 
-The readAsDataURL() method</a> <a href="#ref-for-dfn-loading-4">(2)</a> <a href="#ref-for-dfn-loading-5">(3)</a> <a href="#ref-for-dfn-loading-6">(4)</a></span><span><a href="#ref-for-dfn-loading-7">7.3.4.3. 
-The readAsText() method</a> <a href="#ref-for-dfn-loading-8">(2)</a> <a href="#ref-for-dfn-loading-9">(3)</a> <a href="#ref-for-dfn-loading-10">(4)</a></span><span><a href="#ref-for-dfn-loading-11">7.3.4.4. 
-The readAsArrayBuffer() method</a> <a href="#ref-for-dfn-loading-12">(2)</a> <a href="#ref-for-dfn-loading-13">(3)</a> <a href="#ref-for-dfn-loading-14">(4)</a></span><span><a href="#ref-for-dfn-loading-15">7.3.4.5. 
-Error Steps</a> <a href="#ref-for-dfn-loading-16">(2)</a></span><span><a href="#ref-for-dfn-loading-17">7.3.4.6. 
-The abort() method</a></span><span><a href="#ref-for-dfn-loading-18">7.6.1.2. 
-The readAsText() method</a></span><span><a href="#ref-for-dfn-loading-19">7.6.1.3. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-loading-20">7.6.1.4. 
-The readAsArrayBuffer() method</a></span></span></dfn> (numeric value 1) 
-    <dd>A <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-29">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-53">Blob</a></code> is being read.
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" id="dfn-loading">LOADING</dfn> (numeric value 1) 
+    <dd>A <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-29">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-54">Blob</a></code> is being read.
     One of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-4">read methods</a> is being processed,
     and no error has occurred during the read. 
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" data-lt="DONE" id="dfn-done">DONE<span class="dfn-panel" data-deco=""><b><a href="#dfn-done">#dfn-done</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-done-1">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-done-2">7.3.3. 
-FileReader States</a></span><span><a href="#ref-for-dfn-done-3">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-done-4">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-dfn-done-5">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-dfn-done-6">7.3.4.5. 
-Error Steps</a></span><span><a href="#ref-for-dfn-done-7">7.3.4.6. 
-The abort() method</a> <a href="#ref-for-dfn-done-8">(2)</a></span></span></dfn> (numeric value 2) 
-    <dd>The entire <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-30">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-54">Blob</a></code> has been read into memory,
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" id="dfn-done">DONE</dfn> (numeric value 2) 
+    <dd>The entire <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-30">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-55">Blob</a></code> has been read into memory,
     OR a <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-5">file read error</a> occurred,
     OR the read was aborted using <code class="idl"><a data-link-type="idl" href="#dfn-abort" id="ref-for-dfn-abort-3">abort()</a></code>.
-    The <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-9">FileReader</a></code> is no longer reading a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-31">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-55">Blob</a></code>.
-    If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-2">readyState</a></code> is set to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-2">DONE</a></code> it means at least one of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-5">read methods</a> have been called on this <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-10">FileReader</a></code>. 
+    The <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-9">FileReader</a></code> is no longer reading a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-31">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-56">Blob</a></code>.
+    If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-2">readyState</a></code> is set to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-2">DONE</a></code> it means at least one of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-5">read methods</a> have been called on this <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-10">FileReader</a></code>. 
    </dl>
    <h4 class="heading settled" data-level="7.3.4" id="reading-a-file"><span class="secno">7.3.4. </span><span class="content"> Reading a File or Blob</span><a class="self-link" href="#reading-a-file"></a></h4>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-11">FileReader</a></code> interface makes available three <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="asynchronous read method" data-noexport="" id="asynchronous-read-methods">asynchronous read methods<span class="dfn-panel" data-deco=""><b><a href="#asynchronous-read-methods">#asynchronous-read-methods</a></b><b>Referenced in:</b><span><a href="#ref-for-asynchronous-read-methods-1">7.3.4.7. 
-Blob Parameters</a></span><span><a href="#ref-for-asynchronous-read-methods-2">8. 
-Errors and Exceptions</a></span></span></dfn>—<wbr><code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-2">readAsArrayBuffer()</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-2">readAsText()</a></code>, and <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-2">readAsDataURL()</a></code>,
+   <p>The <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-11">FileReader</a></code> interface makes available several <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="asynchronous read method" data-noexport="" id="asynchronous-read-methods">asynchronous read methods</dfn>—<wbr><code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-2">readAsArrayBuffer()</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-readAsBinaryString" id="ref-for-dfn-readAsBinaryString-2">readAsBinaryString()</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-2">readAsText()</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-2">readAsDataURL()</a></code>,
 which read files into memory.
-If multiple concurrent read methods are called on the same <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-12">FileReader</a></code> object,
+If multiple concurrent read methods are called on the same <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-12">FileReader</a></code> object,
 user agents must throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> on any of the read methods that occur
 when <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-3">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-2">LOADING</a></code>.</p>
-   <p>(<code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-3">FileReaderSync</a></code> makes available three <a data-link-type="dfn" href="#read-method-sync" id="ref-for-read-method-sync-1">synchronous read methods</a>.
-  Collectively, the sync and async read methods of <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-13">FileReader</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-4">FileReaderSync</a></code> are referred to as just <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="read method" data-noexport="" id="read-method">read methods<span class="dfn-panel" data-deco=""><b><a href="#read-method">#read-method</a></b><b>Referenced in:</b><span><a href="#ref-for-read-method-1">3. 
-Terminology and Algorithms</a></span><span><a href="#ref-for-read-method-2">7.3.3. 
-FileReader States</a> <a href="#ref-for-read-method-3">(2)</a> <a href="#ref-for-read-method-4">(3)</a> <a href="#ref-for-read-method-5">(4)</a></span><span><a href="#ref-for-read-method-6">7.3.4.1. 
-The result attribute</a> <a href="#ref-for-read-method-7">(2)</a> <a href="#ref-for-read-method-8">(3)</a> <a href="#ref-for-read-method-9">(4)</a> <a href="#ref-for-read-method-10">(5)</a></span><span><a href="#ref-for-read-method-11">7.3.4.5. 
-Error Steps</a></span><span><a href="#ref-for-read-method-12">7.3.4.6. 
-The abort() method</a></span><span><a href="#ref-for-read-method-13">7.4. 
-Determining Encoding</a></span><span><a href="#ref-for-read-method-14">7.5.2. 
-Summary of Event Invariants</a> <a href="#ref-for-read-method-15">(2)</a> <a href="#ref-for-read-method-16">(3)</a></span></span></dfn>.)</p>
+   <p>(<code class="idl"><a data-link-type="idl" href="#d3" id="ref-for-d3-3">FileReaderSync</a></code> makes available several <a data-link-type="dfn" href="#read-method-sync" id="ref-for-read-method-sync-1">synchronous read methods</a>.
+  Collectively, the sync and async read methods of <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-13">FileReader</a></code> and <code class="idl"><a data-link-type="idl" href="#d3" id="ref-for-d3-4">FileReaderSync</a></code> are referred to as just <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="read method" data-noexport="" id="read-method">read methods</dfn>.)</p>
    <h5 class="heading settled" data-level="7.3.4.1" id="filedata-attr"><span class="secno">7.3.4.1. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-2">result</a></code> attribute</span><a class="self-link" href="#filedata-attr"></a></h5>
-   <p>On getting, the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="result" id="dfn-result">result<span class="dfn-panel" data-deco=""><b><a href="#dfn-result">#dfn-result</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-result-1">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-result-2">7.3.4.1. 
-The result attribute</a> <a href="#ref-for-dfn-result-3">(2)</a> <a href="#ref-for-dfn-result-4">(3)</a> <a href="#ref-for-dfn-result-5">(4)</a> <a href="#ref-for-dfn-result-6">(5)</a> <a href="#ref-for-dfn-result-7">(6)</a> <a href="#ref-for-dfn-result-8">(7)</a></span><span><a href="#ref-for-dfn-result-9">7.3.4.2. 
-The readAsDataURL() method</a> <a href="#ref-for-dfn-result-10">(2)</a></span><span><a href="#ref-for-dfn-result-11">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-dfn-result-12">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-dfn-result-13">7.3.4.5. 
-Error Steps</a></span><span><a href="#ref-for-dfn-result-14">7.3.4.6. 
-The abort() method</a> <a href="#ref-for-dfn-result-15">(2)</a></span><span><a href="#ref-for-dfn-result-16">7.4. 
-Determining Encoding</a></span></span></dfn> attribute returns a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-56">Blob</a></code>'s data
+   <p>On getting, the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-result">result</dfn> attribute returns a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-57">Blob</a></code>'s data
 as a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, or as an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code>, or <code>null</code>,
-depending on the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-6">read method</a> that has been called on the <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-14">FileReader</a></code>,
+depending on the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-6">read method</a> that has been called on the <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-14">FileReader</a></code>,
 and any errors that may have occurred.</p>
    <p>The list below is normative for the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-3">result</a></code> attribute
 and is the conformance criteria for this attribute:</p>
@@ -2790,29 +2499,30 @@ if the <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-
 then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-4">result</a></code> attribute must return <code>null</code>.</p>
     <li data-md="">
      <p>On getting,
-if an error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-32">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-57">Blob</a></code> has occurred
+if an error in reading the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-32">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-58">Blob</a></code> has occurred
 (using <em>any</em> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-7">read method</a>)
 then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-5">result</a></code> attribute must return <code>null</code>.</p>
     <li data-md="">
      <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-3">readAsDataURL()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-8">read method</a> is used,
-the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-6">result</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> that is a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a> encoding of the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-33">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-58">Blob</a></code>'s data.</p>
+the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-6">result</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> that is a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a> encoding of the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-33">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-59">Blob</a></code>'s data.</p>
     <li data-md="">
-     <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-3">readAsText()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-9">read method</a> is called
-and no error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-34">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-59">Blob</a></code> has occurred,
-then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-7">result</a></code> attribute must return a string
-representing the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-35">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-60">Blob</a></code>'s data as a text string,
+     <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsBinaryString" id="ref-for-dfn-readAsBinaryString-3">readAsBinaryString()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-9">read method</a> is called
+and no error in reading the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-34">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-60">Blob</a></code> has occurred,
+then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-7">result</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> representing the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-35">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-61">Blob</a></code>'s data as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="binary-string">binary string</dfn>,
+in which every byte is represented by a <a data-link-type="dfn">code unit</a> of equal value [0...255].</p>
+    <li data-md="">
+     <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-3">readAsText()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-10">read method</a> is called
+and no error in reading the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-36">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-62">Blob</a></code> has occurred,
+then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-8">result</a></code> attribute must return a string
+representing the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-37">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-63">Blob</a></code>'s data as a text string,
 and should decode the string into memory in the format specified by the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-2">encoding determination</a> as a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>.</p>
     <li data-md="">
-     <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-3">readAsArrayBuffer()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-10">read method</a> is called
-and no error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-36">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-61">Blob</a></code> has occurred,
-then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-8">result</a></code> attribute must return an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code> object.</p>
+     <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-3">readAsArrayBuffer()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-11">read method</a> is called
+and no error in reading the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-38">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-64">Blob</a></code> has occurred,
+then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-9">result</a></code> attribute must return an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code> object.</p>
    </ul>
    <h5 class="heading settled" data-level="7.3.4.2" id="readAsDataURL"><span class="secno">7.3.4.2. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-4">readAsDataURL()</a></code> method</span><a class="self-link" href="#readAsDataURL"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" data-lt="readAsDataURL(blob)" id="dfn-readAsDataURL">readAsDataURL(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsDataURL">#dfn-readAsDataURL</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsDataURL-1">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-readAsDataURL-2">7.3.4. 
-Reading a File or Blob</a></span><span><a href="#ref-for-dfn-readAsDataURL-3">7.3.4.1. 
-The result attribute</a></span><span><a href="#ref-for-dfn-readAsDataURL-4">7.3.4.2. 
-The readAsDataURL() method</a></span></span></dfn> method is called,
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" id="dfn-readAsDataURL">readAsDataURL(blob)</dfn> method is called,
 the user agent must run the steps below.</p>
    <ol>
     <li data-md="">
@@ -2827,7 +2537,7 @@ and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-pro
      <p>Initiate an <a data-link-type="dfn" href="#task-read-operation" id="ref-for-task-read-operation-1">annotated task read operation</a> using the <code>blob</code> argument as <var>input</var> and handle <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">tasks queued</a> on the <a data-link-type="dfn" href="#fileReadingTaskSource" id="ref-for-fileReadingTaskSource-2">file reading task source</a> per below.</p>
     <li data-md="">
      <p>To <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-1">process read error</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-8">failure reason</a>,
-proceed to <a href="#dfn-error-steps">§7.3.4.5 Error Steps</a>.</p>
+proceed to <a href="#dfn-error-steps">§7.3.4.6 Error Steps</a>.</p>
     <li data-md="">
      <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-1">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-2">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-2">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
@@ -2838,8 +2548,8 @@ proceed to <a href="#dfn-error-steps">§7.3.4.5 Error Steps</a>.</p>
       <li data-md="">
        <p>Set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-7">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-3">DONE</a></code>.</p>
       <li data-md="">
-       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-9">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-13">read operation</a> as a DataURL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a>;
-on getting, the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-10">result</a></code> attribute returns the <code>blob</code> as a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a>.</p>
+       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-10">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-13">read operation</a> as a DataURL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a>;
+on getting, the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-11">result</a></code> attribute returns the <code>blob</code> as a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a>.</p>
        <ul>
         <li data-md="">
          <p>Use the <code>blob</code>’s <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-15">type</a></code> attribute as part of the Data URL if it is available
@@ -2858,17 +2568,10 @@ If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-
      <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-7">Terminate this algorithm</a>.</p>
    </ol>
    <h5 class="heading settled" data-level="7.3.4.3" id="readAsDataText"><span class="secno">7.3.4.3. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-4">readAsText()</a></code> method</span><a class="self-link" href="#readAsDataText"></a></h5>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-5">readAsText()</a></code> method can be called with an optional parameter, <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader/readAsText(blob, label), FileReaderSync/readAsText(blob, label)" data-dfn-type="argument" data-export="" data-lt="label" id="dfn-label">label<span class="dfn-panel" data-deco=""><b><a href="#dfn-label">#dfn-label</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-label-1">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-label-2">7.6.1. 
-The FileReaderSync API</a></span></span></dfn>,
+   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-5">readAsText()</a></code> method can be called with an optional parameter, <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader/readAsText(blob, label), FileReaderSync/readAsText(blob, label)" data-dfn-type="argument" data-export="" id="dfn-label">label</dfn>,
 which is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> argument that represents the label of an encoding <a data-link-type="biblio" href="#biblio-encoding">[Encoding]</a>;
 if provided, it must be used as part of the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-3">encoding determination</a> used when processing this method call.</p>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" data-lt="readAsText(blob, label)|readAsText(blob)" id="dfn-readAsText">readAsText(blob, optional label)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsText">#dfn-readAsText</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsText-1">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-readAsText-2">7.3.4. 
-Reading a File or Blob</a></span><span><a href="#ref-for-dfn-readAsText-3">7.3.4.1. 
-The result attribute</a></span><span><a href="#ref-for-dfn-readAsText-4">7.3.4.3. 
-The readAsText() method</a> <a href="#ref-for-dfn-readAsText-5">(2)</a></span><span><a href="#ref-for-dfn-readAsText-6">7.4. 
-Determining Encoding</a></span></span></dfn> method is called,
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" data-lt="readAsText(blob, label)|readAsText(blob)" id="dfn-readAsText">readAsText(blob, optional label)</dfn> method is called,
 the user agent must run the steps below.</p>
    <ol>
     <li data-md="">
@@ -2883,7 +2586,7 @@ and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-pro
      <p>Initiate an <a data-link-type="dfn" href="#task-read-operation" id="ref-for-task-read-operation-2">annotated task read operation</a> using the <code>blob</code> argument as <var>input</var> and handle <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">tasks queued</a> on the <a data-link-type="dfn" href="#fileReadingTaskSource" id="ref-for-fileReadingTaskSource-3">file reading task source</a> per below.</p>
     <li data-md="">
      <p>To <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-2">process read error</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-9">failure reason</a>,
-proceed to the <a href="#dfn-error-steps">§7.3.4.5 Error Steps</a>.</p>
+proceed to the <a href="#dfn-error-steps">§7.3.4.6 Error Steps</a>.</p>
     <li data-md="">
      <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-2">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-7">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-3">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
@@ -2894,7 +2597,7 @@ proceed to the <a href="#dfn-error-steps">§7.3.4.5 Error Steps</a>.</p>
       <li data-md="">
        <p>Set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-12">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-4">DONE</a></code></p>
       <li data-md="">
-       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-11">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-14">read operation</a>,
+       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-12">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-14">read operation</a>,
 represented as a string in a format determined by the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-4">encoding determination</a>.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-9">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-3">load</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
@@ -2906,11 +2609,7 @@ If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-
      <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-10">Terminate this algorithm</a>.</p>
    </ol>
    <h5 class="heading settled" data-level="7.3.4.4" id="readAsArrayBuffer"><span class="secno">7.3.4.4. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-4">readAsArrayBuffer()</a></code> method</span><a class="self-link" href="#readAsArrayBuffer"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" data-lt="readAsArrayBuffer(blob)" id="dfn-readAsArrayBuffer">readAsArrayBuffer(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsArrayBuffer">#dfn-readAsArrayBuffer</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsArrayBuffer-1">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-readAsArrayBuffer-2">7.3.4. 
-Reading a File or Blob</a></span><span><a href="#ref-for-dfn-readAsArrayBuffer-3">7.3.4.1. 
-The result attribute</a></span><span><a href="#ref-for-dfn-readAsArrayBuffer-4">7.3.4.4. 
-The readAsArrayBuffer() method</a></span></span></dfn> method is called,
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" id="dfn-readAsArrayBuffer">readAsArrayBuffer(blob)</dfn> method is called,
 the user agent must run the steps below.</p>
    <ol>
     <li data-md="">
@@ -2925,7 +2624,7 @@ and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-pro
      <p>Initiate an <a data-link-type="dfn" href="#task-read-operation" id="ref-for-task-read-operation-3">annotated task read operation</a> using the <code>blob</code> argument as <var>input</var> and handle <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">tasks queued</a> on the <a data-link-type="dfn" href="#fileReadingTaskSource" id="ref-for-fileReadingTaskSource-4">file reading task source</a> per below.</p>
     <li data-md="">
      <p>To <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-3">process read error</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-10">failure reason</a>,
-proceed to the <a href="#dfn-error-steps">§7.3.4.5 Error Steps</a>.</p>
+proceed to the <a href="#dfn-error-steps">§7.3.4.6 Error Steps</a>.</p>
     <li data-md="">
      <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-3">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-12">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-4">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
@@ -2936,7 +2635,7 @@ proceed to the <a href="#dfn-error-steps">§7.3.4.5 Error Steps</a>.</p>
       <li data-md="">
        <p>Set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-17">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-5">DONE</a></code></p>
       <li data-md="">
-       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-12">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-15">read operation</a> as an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code> object.</p>
+       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-13">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-15">read operation</a> as an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code> object.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-14">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-4">load</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
       <li data-md="">
@@ -2946,75 +2645,102 @@ If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-
     <li data-md="">
      <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-13">Terminate this algorithm</a>.</p>
    </ol>
-   <h5 class="heading settled" data-level="7.3.4.5" id="dfn-error-steps"><span class="secno">7.3.4.5. </span><span class="content"> Error Steps</span><a class="self-link" href="#dfn-error-steps"></a></h5>
-   <p>These error steps are to <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-4">process read error</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-11">failure reason</a>.</p>
+   <h5 class="heading settled" data-level="7.3.4.5" id="readAsBinaryString"><span class="secno">7.3.4.5. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsBinaryString" id="ref-for-dfn-readAsBinaryString-4">readAsBinaryString()</a></code> method</span><a class="self-link" href="#readAsBinaryString"></a></h5>
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" id="dfn-readAsBinaryString">readAsBinaryString(blob)</dfn> method is called,
+the user agent must run the steps below.</p>
    <ol>
     <li data-md="">
-     <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-20">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-6">DONE</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-13">result</a></code> to null if it is not already set to null.</p>
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-20">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-15">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-14">terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>Set the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-6">error</a></code> attribute on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>;
-on getting, the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-7">error</a></code> attribute must be a a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#domerror">DOMError</a></code> object
-that corresponds to the <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-12">failure reason</a>. <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-16">Fire a progress event</a> called <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-6">error</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     <p>If the <code>blob</code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-11">CLOSED</a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-18">readability state</a>,
+set the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-6">error</a></code> attribute of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> to return an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
+and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-16">fire a progress event</a> called <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-6">error</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-15">Terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-21">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-15">LOADING</a></code>, <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-17">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-8">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
-If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-22">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-16">LOADING</a></code> do NOT fire <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-9">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     <p>Otherwise set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-21">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-16">LOADING</a></code>.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-14">Terminate the algorithm</a> for any <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-11">read method</a>.</p>
+     <p>Initiate an <a data-link-type="dfn" href="#task-read-operation" id="ref-for-task-read-operation-4">annotated task read operation</a> using the <code>blob</code> argument as <var>input</var> and handle <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">tasks queued</a> on the <a data-link-type="dfn" href="#fileReadingTaskSource" id="ref-for-fileReadingTaskSource-5">file reading task source</a> per below.</p>
+    <li data-md="">
+     <p>To <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-4">process read error</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-11">failure reason</a>,
+proceed to the <a href="#dfn-error-steps">§7.3.4.6 Error Steps</a>.</p>
+    <li data-md="">
+     <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-4">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-17">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-5">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+    <li data-md="">
+     <p>To <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-5">process read data</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-18">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-5">progress</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+    <li data-md="">
+     <p>To <a data-link-type="dfn" href="#process-read-EOF" id="ref-for-process-read-EOF-4">process read EOF</a> run these substeps:</p>
+     <ol>
+      <li data-md="">
+       <p>Set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-22">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-6">DONE</a></code></p>
+      <li data-md="">
+       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-14">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-16">read operation</a> as a <a data-link-type="dfn" href="#binary-string" id="ref-for-binary-string-1">binary string</a>.</p>
+      <li data-md="">
+       <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-19">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-5">load</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+      <li data-md="">
+       <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-23">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-17">LOADING</a></code> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-20">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-8">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
+If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-24">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-18">LOADING</a></code> do NOT fire <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-9">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     </ol>
+    <li data-md="">
+     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-16">Terminate this algorithm</a>.</p>
    </ol>
-   <h5 class="heading settled" data-level="7.3.4.6" id="abort"><span class="secno">7.3.4.6. </span><span class="content"> The abort() method</span><a class="self-link" href="#abort"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" data-lt="abort()" id="dfn-abort">abort()<span class="dfn-panel" data-deco=""><b><a href="#dfn-abort">#dfn-abort</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-abort-1">3. 
-Terminology and Algorithms</a></span><span><a href="#ref-for-dfn-abort-2">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-abort-3">7.3.3. 
-FileReader States</a></span><span><a href="#ref-for-dfn-abort-4">7.5.1. 
-Event Summary</a></span><span><a href="#ref-for-dfn-abort-5">7.5.2. 
-Summary of Event Invariants</a></span></span></dfn> method is called,
+   <div class="note" role="note"> The use of <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-5">readAsArrayBuffer()</a></code> is preferred over <code class="idl"><a data-link-type="idl" href="#dfn-readAsBinaryString" id="ref-for-dfn-readAsBinaryString-5">readAsBinaryString()</a></code>, which is provided for backwards
+  compatibility. </div>
+   <h5 class="heading settled" data-level="7.3.4.6" id="dfn-error-steps"><span class="secno">7.3.4.6. </span><span class="content"> Error Steps</span><a class="self-link" href="#dfn-error-steps"></a></h5>
+   <p>These error steps are to <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-5">process read error</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-12">failure reason</a>.</p>
+   <ol>
+    <li data-md="">
+     <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-25">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-7">DONE</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-15">result</a></code> to null if it is not already set to null.</p>
+    <li data-md="">
+     <p>Set the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-7">error</a></code> attribute on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>;
+on getting, the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-8">error</a></code> attribute must be a a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#domerror">DOMError</a></code> object
+that corresponds to the <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-13">failure reason</a>. <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-21">Fire a progress event</a> called <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-7">error</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+    <li data-md="">
+     <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-26">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-19">LOADING</a></code>, <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-22">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-10">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
+If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-27">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-20">LOADING</a></code> do NOT fire <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-11">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+    <li data-md="">
+     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-17">Terminate the algorithm</a> for any <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-12">read method</a>.</p>
+   </ol>
+   <h5 class="heading settled" data-level="7.3.4.7" id="abort"><span class="secno">7.3.4.7. </span><span class="content"> The abort() method</span><a class="self-link" href="#abort"></a></h5>
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" id="dfn-abort">abort()</dfn> method is called,
 the user agent must run the steps below:</p>
    <ol>
     <li data-md="">
-     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-23">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-empty" id="ref-for-dfn-empty-3">EMPTY</a></code> or if <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-24">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-7">DONE</a></code> set <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-14">result</a></code> to <code>null</code> and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-15">terminate this algorithm</a>.</p>
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-28">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-empty" id="ref-for-dfn-empty-3">EMPTY</a></code> or if <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-29">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-8">DONE</a></code> set <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-16">result</a></code> to <code>null</code> and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-18">terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-25">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-17">LOADING</a></code> set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-26">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-8">DONE</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-15">result</a></code> to <code>null</code>.</p>
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-30">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-21">LOADING</a></code> set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-31">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-9">DONE</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-17">result</a></code> to <code>null</code>.</p>
     <li data-md="">
-     <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> from the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> on the <a data-link-type="dfn" href="#fileReadingTaskSource" id="ref-for-fileReadingTaskSource-5">file reading task source</a> in an affiliated <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">task queue</a>,
+     <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> from the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> on the <a data-link-type="dfn" href="#fileReadingTaskSource" id="ref-for-fileReadingTaskSource-6">file reading task source</a> in an affiliated <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">task queue</a>,
 then remove those <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> from that task queue.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-16">Terminate the algorithm</a> for the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-12">read method</a> being processed.</p>
+     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-19">Terminate the algorithm</a> for the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-13">read method</a> being processed.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-18">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-2">abort</a></code>.</p>
+     <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-23">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-2">abort</a></code>.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-19">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-10">loadend</a></code>.</p>
+     <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-24">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-12">loadend</a></code>.</p>
    </ol>
-   <h5 class="heading settled" data-level="7.3.4.7" id="blobAndFileParams"><span class="secno">7.3.4.7. </span><span class="content"> Blob Parameters</span><a class="self-link" href="#blobAndFileParams"></a></h5>
-   <p>The three <a data-link-type="dfn" href="#asynchronous-read-methods" id="ref-for-asynchronous-read-methods-1">asynchronous read methods</a>,
-the three <a data-link-type="dfn" href="#read-method-sync" id="ref-for-read-method-sync-2">synchronous read methods</a>, <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-1">createObjectURL()</a></code></code> and <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-1">createFor()</a></code></code> take a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-62">Blob</a></code> parameter.
+   <h5 class="heading settled" data-level="7.3.4.8" id="blobAndFileParams"><span class="secno">7.3.4.8. </span><span class="content"> Blob Parameters</span><a class="self-link" href="#blobAndFileParams"></a></h5>
+   <p>The <a data-link-type="dfn" href="#asynchronous-read-methods" id="ref-for-asynchronous-read-methods-1">asynchronous read methods</a>,
+the <a data-link-type="dfn" href="#read-method-sync" id="ref-for-read-method-sync-2">synchronous read methods</a>, <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-1">createObjectURL()</a></code></code> and <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-1">createFor()</a></code></code> take a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-65">Blob</a></code> parameter.
 This section defines this parameter.</p>
    <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader/readAsArrayBuffer(blob), FileReader/readAsText(blob, label), FileReader/readAsDataURL(blob), URL/createObjectURL(blob), URL/createFor(blob), FileReaderSync/readAsArrayBuffer(blob), FileReaderSync/readAsText(blob, label), FileReaderSync/readAsDataURL(blob)" data-dfn-type="argument" data-export="" data-lt="blob" id="dfn-fileBlob">blob<span class="dfn-panel" data-deco=""><b><a href="#dfn-fileBlob">#dfn-fileBlob</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-fileBlob-1">7.3. 
-The FileReader API</a> <a href="#ref-for-dfn-fileBlob-2">(2)</a> <a href="#ref-for-dfn-fileBlob-3">(3)</a></span><span><a href="#ref-for-dfn-fileBlob-4">7.6.1. 
-The FileReaderSync API</a> <a href="#ref-for-dfn-fileBlob-5">(2)</a> <a href="#ref-for-dfn-fileBlob-6">(3)</a></span><span><a href="#ref-for-dfn-fileBlob-7">9.5. 
-Creating and Revoking a Blob URL</a> <a href="#ref-for-dfn-fileBlob-8">(2)</a></span></span></dfn> 
-    <dd>This is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-63">Blob</a></code> argument
-    and must be a reference to a single <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-37">File</a></code> in a <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-11">FileList</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-64">Blob</a></code> argument not obtained from the underlying OS file system. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader/readAsArrayBuffer(blob), FileReader/readAsBinaryString(blob), FileReader/readAsText(blob, label), FileReader/readAsDataURL(blob), URL/createObjectURL(blob), URL/createFor(blob), FileReaderSync/readAsArrayBuffer(blob), FileReaderSync/readAsBinaryString(blob), FileReaderSync/readAsText(blob, label), FileReaderSync/readAsDataURL(blob)" data-dfn-type="argument" data-export="" id="dfn-fileBlob">blob</dfn> 
+    <dd>This is a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-66">Blob</a></code> argument
+    and must be a reference to a single <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-39">File</a></code> in a <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-11">FileList</a></code> or a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-67">Blob</a></code> argument not obtained from the underlying OS file system. 
    </dl>
    <h3 class="heading settled" data-level="7.4" id="enctype"><span class="secno">7.4. </span><span class="content"> Determining Encoding</span><a class="self-link" href="#enctype"></a></h3>
-   <p>When reading <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-65">Blob</a></code> objects using the <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-6">readAsText()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-13">read method</a>,
-the following <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="encoding determination" data-noexport="" id="encoding-determination">encoding determination<span class="dfn-panel" data-deco=""><b><a href="#encoding-determination">#encoding-determination</a></b><b>Referenced in:</b><span><a href="#ref-for-encoding-determination-1">4.2. 
-Attributes</a></span><span><a href="#ref-for-encoding-determination-2">7.3.4.1. 
-The result attribute</a></span><span><a href="#ref-for-encoding-determination-3">7.3.4.3. 
-The readAsText() method</a> <a href="#ref-for-encoding-determination-4">(2)</a></span><span><a href="#ref-for-encoding-determination-5">7.6.1.2. 
-The readAsText() method</a></span></span></dfn> steps must be followed:</p>
+   <p>When reading <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-68">Blob</a></code> objects using the <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-6">readAsText()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-14">read method</a>,
+the following <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="encoding-determination">encoding determination</dfn> steps must be followed:</p>
    <ol>
     <li data-md="">
      <p>Let <var>encoding</var> be null.</p>
     <li data-md="">
-     <p>If the <code class="idl"><a data-link-type="idl">label</a></code> argument is present when calling the method,
-set <var>encoding</var> to the result of the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#concept-encoding-get">getting an encoding</a> from <code class="idl"><a data-link-type="idl">label</a></code>.</p>
+     <p>If the <code class="idl"><a data-link-type="idl" href="#dfn-label" id="ref-for-dfn-label-2">label</a></code> argument is present when calling the method,
+set <var>encoding</var> to the result of the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#concept-encoding-get">getting an encoding</a> from <code class="idl"><a data-link-type="idl" href="#dfn-label" id="ref-for-dfn-label-3">label</a></code>.</p>
     <li data-md="">
      <p>If the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#concept-encoding-get">getting an encoding</a> steps above return failure,
 then set <var>encoding</var> to null.</p>
     <li data-md="">
      <p>If <var>encoding</var> is null,
-and the <code class="idl"><a data-link-type="idl">blob</a></code> argument’s <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-17">type</a></code> attribute is present,
+and the <code class="idl"><a data-link-type="idl" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-5">blob</a></code> argument’s <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-17">type</a></code> attribute is present,
 and it uses a Charset Parameter <a data-link-type="biblio" href="#biblio-rfc2046">[RFC2046]</a>,
 set <var>encoding</var> to the result of <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#concept-encoding-get">getting an encoding</a> for the portion of the Charset Parameter that is a <i>label</i> of an encoding.</p>
      <div class="example" id="example-21540bcb"><a class="self-link" href="#example-21540bcb"></a> If <code>blob</code> has a <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-18">type</a></code> attribute of <code>text/plain;charset=utf-8</code> then <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#concept-encoding-get">getting an encoding</a> is run using <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8">utf-8</a> as the label.
@@ -3028,19 +2754,14 @@ then set encoding to utf-8.</p>
     <li data-md="">
      <p><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#decode">Decode</a> this <code>blob</code> using fallback encoding <var>encoding</var>,
 and return the result.
-On getting, the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-16">result</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-15">FileReader</a></code> object
+On getting, the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-18">result</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-15">FileReader</a></code> object
 returns a string in <var>encoding</var> format.
-The synchronous <code class="idl"><a data-link-type="idl" href="#dfn-readAsTextSync" id="ref-for-dfn-readAsTextSync-1">readAsText()</a></code> method of the <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-5">FileReaderSync</a></code> object
+The synchronous <code class="idl"><a data-link-type="idl" href="#dfn-readAsTextSync" id="ref-for-dfn-readAsTextSync-1">readAsText()</a></code> method of the <code class="idl"><a data-link-type="idl" href="#d3" id="ref-for-d3-5">FileReaderSync</a></code> object
 returns a string in <var>encoding</var> format.</p>
    </ol>
    <h3 class="heading settled" data-level="7.5" id="events"><span class="secno">7.5. </span><span class="content"> Events</span><a class="self-link" href="#events"></a></h3>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-16">FileReader</a></code> object must be the event target for all events in this specification.</p>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="fire a progress event" data-noexport="" id="fire-a-progress-event">fire a progress event<span class="dfn-panel" data-deco=""><b><a href="#fire-a-progress-event">#fire-a-progress-event</a></b><b>Referenced in:</b><span><a href="#ref-for-fire-a-progress-event-1">7.3.4.2. 
-The readAsDataURL() method</a> <a href="#ref-for-fire-a-progress-event-2">(2)</a> <a href="#ref-for-fire-a-progress-event-3">(3)</a> <a href="#ref-for-fire-a-progress-event-4">(4)</a> <a href="#ref-for-fire-a-progress-event-5">(5)</a></span><span><a href="#ref-for-fire-a-progress-event-6">7.3.4.3. 
-The readAsText() method</a> <a href="#ref-for-fire-a-progress-event-7">(2)</a> <a href="#ref-for-fire-a-progress-event-8">(3)</a> <a href="#ref-for-fire-a-progress-event-9">(4)</a> <a href="#ref-for-fire-a-progress-event-10">(5)</a></span><span><a href="#ref-for-fire-a-progress-event-11">7.3.4.4. 
-The readAsArrayBuffer() method</a> <a href="#ref-for-fire-a-progress-event-12">(2)</a> <a href="#ref-for-fire-a-progress-event-13">(3)</a> <a href="#ref-for-fire-a-progress-event-14">(4)</a> <a href="#ref-for-fire-a-progress-event-15">(5)</a></span><span><a href="#ref-for-fire-a-progress-event-16">7.3.4.5. 
-Error Steps</a> <a href="#ref-for-fire-a-progress-event-17">(2)</a></span><span><a href="#ref-for-fire-a-progress-event-18">7.3.4.6. 
-The abort() method</a> <a href="#ref-for-fire-a-progress-event-19">(2)</a></span></span></dfn> <i>called e</i> (for some <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> <code>e</code> at a given <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-17">FileReader</a></code> <code>reader</code> as the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>),
+   <p>The <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-16">FileReader</a></code> object must be the event target for all events in this specification.</p>
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fire-a-progress-event">fire a progress event</dfn> <i>called e</i> (for some <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> <code>e</code> at a given <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-17">FileReader</a></code> <code>reader</code> as the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>),
 the following are normative:</p>
    <ul>
     <li data-md="">
@@ -3049,7 +2770,7 @@ the following are normative:</p>
      <p>The progress event <code>e</code> is NOT cancelable. <code>e.cancelable</code> must be false <a data-link-type="biblio" href="#biblio-dom">[DOM]</a></p>
    </ul>
    <h4 class="heading settled" data-level="7.5.1" id="event-summary"><span class="secno">7.5.1. </span><span class="content"> Event Summary</span><a class="self-link" href="#event-summary"></a></h4>
-   <p>The following are the events that are <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fired</a> at <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-18">FileReader</a></code> objects.</p>
+   <p>The following are the events that are <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fired</a> at <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-18">FileReader</a></code> objects.</p>
    <table id="event-summary-table">
     <thead>
      <tr>
@@ -3058,84 +2779,52 @@ the following are normative:</p>
       <th>Fired when… 
     <tbody>
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="loadstart" id="dfn-loadstart-event">loadstart<span class="dfn-panel" data-deco=""><b><a href="#dfn-loadstart-event">#dfn-loadstart-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-loadstart-event-1">7.3.2. 
-Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-loadstart-event-2">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-loadstart-event-3">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-dfn-loadstart-event-4">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-dfn-loadstart-event-5">7.5.2. 
-Summary of Event Invariants</a> <a href="#ref-for-dfn-loadstart-event-6">(2)</a> <a href="#ref-for-dfn-loadstart-event-7">(3)</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-loadstart-event">loadstart</dfn> 
       <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> 
       <td>When the read starts. 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="progress" id="dfn-progress-event">progress<span class="dfn-panel" data-deco=""><b><a href="#dfn-progress-event">#dfn-progress-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-progress-event-1">7.3.2. 
-Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-progress-event-2">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-progress-event-3">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-dfn-progress-event-4">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-dfn-progress-event-5">7.5.2. 
-Summary of Event Invariants</a> <a href="#ref-for-dfn-progress-event-6">(2)</a> <a href="#ref-for-dfn-progress-event-7">(3)</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-progress-event">progress</dfn> 
       <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> 
       <td>While reading (and decoding) <code>blob</code> 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="abort" id="dfn-abort-event">abort<span class="dfn-panel" data-deco=""><b><a href="#dfn-abort-event">#dfn-abort-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-abort-event-1">7.3.2. 
-Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-abort-event-2">7.3.4.6. 
-The abort() method</a></span><span><a href="#ref-for-dfn-abort-event-3">7.5.2. 
-Summary of Event Invariants</a> <a href="#ref-for-dfn-abort-event-4">(2)</a> <a href="#ref-for-dfn-abort-event-5">(3)</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-abort-event">abort</dfn> 
       <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> 
       <td>When the read has been aborted.
         For instance, by invoking the <code class="idl"><a data-link-type="idl" href="#dfn-abort" id="ref-for-dfn-abort-4">abort()</a></code> method. 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="error" id="dfn-error-event">error<span class="dfn-panel" data-deco=""><b><a href="#dfn-error-event">#dfn-error-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-error-event-1">5.2. 
-Attributes</a></span><span><a href="#ref-for-dfn-error-event-2">7.3.2. 
-Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-error-event-3">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-error-event-4">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-dfn-error-event-5">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-dfn-error-event-6">7.3.4.5. 
-Error Steps</a></span><span><a href="#ref-for-dfn-error-event-7">7.5.2. 
-Summary of Event Invariants</a> <a href="#ref-for-dfn-error-event-8">(2)</a> <a href="#ref-for-dfn-error-event-9">(3)</a> <a href="#ref-for-dfn-error-event-10">(4)</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-error-event">error</dfn> 
       <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> 
       <td>When the read has failed (see <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-6">file read errors</a>). 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="load" id="dfn-load-event">load<span class="dfn-panel" data-deco=""><b><a href="#dfn-load-event">#dfn-load-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-load-event-1">7.3.2. 
-Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-load-event-2">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-load-event-3">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-dfn-load-event-4">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-dfn-load-event-5">7.5.2. 
-Summary of Event Invariants</a> <a href="#ref-for-dfn-load-event-6">(2)</a> <a href="#ref-for-dfn-load-event-7">(3)</a> <a href="#ref-for-dfn-load-event-8">(4)</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-load-event">load</dfn> 
       <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> 
       <td>When the read has successfully completed. 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" data-lt="loadend" id="dfn-loadend-event">loadend<span class="dfn-panel" data-deco=""><b><a href="#dfn-loadend-event">#dfn-loadend-event</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-loadend-event-1">7.3.2. 
-Event Handler Content Attributes</a></span><span><a href="#ref-for-dfn-loadend-event-2">7.3.4.2. 
-The readAsDataURL() method</a> <a href="#ref-for-dfn-loadend-event-3">(2)</a></span><span><a href="#ref-for-dfn-loadend-event-4">7.3.4.3. 
-The readAsText() method</a> <a href="#ref-for-dfn-loadend-event-5">(2)</a></span><span><a href="#ref-for-dfn-loadend-event-6">7.3.4.4. 
-The readAsArrayBuffer() method</a> <a href="#ref-for-dfn-loadend-event-7">(2)</a></span><span><a href="#ref-for-dfn-loadend-event-8">7.3.4.5. 
-Error Steps</a> <a href="#ref-for-dfn-loadend-event-9">(2)</a></span><span><a href="#ref-for-dfn-loadend-event-10">7.3.4.6. 
-The abort() method</a></span><span><a href="#ref-for-dfn-loadend-event-11">7.5.2. 
-Summary of Event Invariants</a> <a href="#ref-for-dfn-loadend-event-12">(2)</a> <a href="#ref-for-dfn-loadend-event-13">(3)</a></span></span></dfn> 
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="event" data-export="" id="dfn-loadend-event">loadend</dfn> 
       <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/progress-events/#progressevent">ProgressEvent</a></code> 
       <td>When the request has completed (either in success or failure). 
    </table>
    <h4 class="heading settled" data-level="7.5.2" id="eventInvariants"><span class="secno">7.5.2. </span><span class="content"> Summary of Event Invariants</span><a class="self-link" href="#eventInvariants"></a></h4>
    <p><em>This section is informative.</em></p>
-   <p>The following are invariants applicable to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">event firing</a> for a given asynchronous <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-14">read method</a> in this specification:</p>
+   <p>The following are invariants applicable to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">event firing</a> for a given asynchronous <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-15">read method</a> in this specification:</p>
    <ol>
     <li data-md="">
-     <p>Once a <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-5">loadstart</a></code> has been fired,
-a corresponding <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-11">loadend</a></code> fires at completion of the read,
+     <p>Once a <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-6">loadstart</a></code> has been fired,
+a corresponding <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-13">loadend</a></code> fires at completion of the read,
 UNLESS any of the following are true:</p>
      <ul>
       <li data-md="">
-       <p>the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-15">read method</a> has been cancelled using <code class="idl"><a data-link-type="idl" href="#dfn-abort" id="ref-for-dfn-abort-5">abort()</a></code> and a new <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-16">read method</a> has been invoked</p>
+       <p>the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-16">read method</a> has been cancelled using <code class="idl"><a data-link-type="idl" href="#dfn-abort" id="ref-for-dfn-abort-5">abort()</a></code> and a new <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-17">read method</a> has been invoked</p>
       <li data-md="">
-       <p>the event handler function for a <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-5">load</a></code> event initiates a new read</p>
+       <p>the event handler function for a <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-6">load</a></code> event initiates a new read</p>
       <li data-md="">
-       <p>the event handler function for a <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-7">error</a></code> event initiates a new read.</p>
+       <p>the event handler function for a <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-8">error</a></code> event initiates a new read.</p>
      </ul>
-     <p class="note" role="note">Note: The events <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-6">loadstart</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-12">loadend</a></code> are not coupled in a one-to-one manner.</p>
+     <p class="note" role="note">Note: The events <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-7">loadstart</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-14">loadend</a></code> are not coupled in a one-to-one manner.</p>
      <div class="example" id="example-89381d0d">
       <a class="self-link" href="#example-89381d0d"></a> This example showcases "read-chaining":
   initiating another read from within an event handler while the "first" read continues processing. 
-<pre class="lang-javascript highlight"><span class="c1">// In code of the sort...</span>
+<pre class="lang-javascript highlight"><span></span><span class="c1">// In code of the sort...</span>
 <span class="nx">reader</span><span class="p">.</span><span class="nx">readAsText</span><span class="p">(</span><span class="nx">file</span><span class="p">);</span>
 <span class="nx">reader</span><span class="p">.</span><span class="nx">onload</span> <span class="o">=</span> <span class="kd">function</span><span class="p">(){</span><span class="nx">reader</span><span class="p">.</span><span class="nx">readAsText</span><span class="p">(</span><span class="nx">alternateFile</span><span class="p">);}</span>
 
@@ -3147,94 +2836,80 @@ UNLESS any of the following are true:</p>
 <span class="nx">reader</span><span class="p">.</span><span class="nx">abort</span><span class="p">();</span>
 <span class="nx">reader</span><span class="p">.</span><span class="nx">onabort</span> <span class="o">=</span> <span class="kd">function</span><span class="p">(){</span><span class="nx">reader</span><span class="p">.</span><span class="nx">readAsText</span><span class="p">(</span><span class="nx">updatedFile</span><span class="p">);}</span>
 
-<span class="c1">//... the loadend event must not fire for the first read</span></pre>
+<span class="c1">//... the loadend event must not fire for the first read</span>
+</pre>
      </div>
     <li data-md="">
-     <p>One <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-5">progress</a></code> event will fire when <code>blob</code> has been completely read into memory.</p>
+     <p>One <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-6">progress</a></code> event will fire when <code>blob</code> has been completely read into memory.</p>
     <li data-md="">
-     <p>No <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-6">progress</a></code> event fires before <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-7">loadstart</a></code>.</p>
+     <p>No <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-7">progress</a></code> event fires before <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-8">loadstart</a></code>.</p>
     <li data-md="">
-     <p>No <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-7">progress</a></code> event fires after any one of <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-3">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-6">load</a></code>, and <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-8">error</a></code> have fired.
-At most one of <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-4">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-7">load</a></code>, and <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-9">error</a></code> fire for a given read.</p>
+     <p>No <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-8">progress</a></code> event fires after any one of <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-3">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-7">load</a></code>, and <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-9">error</a></code> have fired.
+At most one of <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-4">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-8">load</a></code>, and <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-10">error</a></code> fire for a given read.</p>
     <li data-md="">
-     <p>No <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-5">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-8">load</a></code>, or <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-10">error</a></code> event fires after <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-13">loadend</a></code>.</p>
+     <p>No <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-5">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-9">load</a></code>, or <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-11">error</a></code> event fires after <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-15">loadend</a></code>.</p>
    </ol>
    <h3 class="heading settled" data-level="7.6" id="readingOnThreads"><span class="secno">7.6. </span><span class="content"> Reading on Threads</span><a class="self-link" href="#readingOnThreads"></a></h3>
-   <p>Web Workers allow for the use of synchronous <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-38">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-66">Blob</a></code> read APIs,
+   <p>Web Workers allow for the use of synchronous <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-40">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-69">Blob</a></code> read APIs,
 since such reads on threads do not block the main thread.
 This section defines a synchronous API, which can be used within Workers [[Web Workers]].
-Workers can avail of both the asynchronous API (the <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-19">FileReader</a></code> object) <em>and</em> the synchronous API (the <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-6">FileReaderSync</a></code> object).</p>
-   <h4 class="heading settled" data-level="7.6.1" id="FileReaderSync"><span class="secno">7.6.1. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-7">FileReaderSync</a></code> API</span><a class="self-link" href="#FileReaderSync"></a></h4>
-   <p>This interface  provides methods to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="synchronous read method" data-noexport="" id="read-method-sync">synchronously read<span class="dfn-panel" data-deco=""><b><a href="#read-method-sync">#read-method-sync</a></b><b>Referenced in:</b><span><a href="#ref-for-read-method-sync-1">7.3.4. 
-Reading a File or Blob</a></span><span><a href="#ref-for-read-method-sync-2">7.3.4.7. 
-Blob Parameters</a></span><span><a href="#ref-for-read-method-sync-3">8. 
-Errors and Exceptions</a></span></span></dfn> <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-39">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-67">Blob</a></code> objects into memory.</p>
-<pre class="idl def">[<dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="constructor" data-export="" data-lt="FileReaderSync()" id="dom-filereadersync-filereadersync">Constructor<span class="dfn-panel" data-deco=""><b><a href="#dom-filereadersync-filereadersync">#dom-filereadersync-filereadersync</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-filereadersync-filereadersync-1">7.6.1.1. 
-Constructors</a></span></span></dfn>, Exposed=Worker]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-lt="FileReaderSync" id="dfn-FileReaderSync">FileReaderSync<span class="dfn-panel" data-deco=""><b><a href="#dfn-FileReaderSync">#dfn-FileReaderSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-FileReaderSync-1">4.2. 
-Attributes</a></span><span><a href="#ref-for-dfn-FileReaderSync-2">5.2. 
-Attributes</a></span><span><a href="#ref-for-dfn-FileReaderSync-3">7.3.4. 
-Reading a File or Blob</a> <a href="#ref-for-dfn-FileReaderSync-4">(2)</a></span><span><a href="#ref-for-dfn-FileReaderSync-5">7.4. 
-Determining Encoding</a></span><span><a href="#ref-for-dfn-FileReaderSync-6">7.6. 
-Reading on Threads</a></span><span><a href="#ref-for-dfn-FileReaderSync-7">7.6.1. 
-The FileReaderSync API</a></span><span><a href="#ref-for-dfn-FileReaderSync-8">7.6.1.1. 
-Constructors</a> <a href="#ref-for-dfn-FileReaderSync-9">(2)</a></span></span></dfn> {
+Workers can avail of both the asynchronous API (the <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-19">FileReader</a></code> object) <em>and</em> the synchronous API (the <code class="idl"><a data-link-type="idl" href="#d3" id="ref-for-d3-6">FileReaderSync</a></code> object).</p>
+   <h4 class="heading settled" data-level="7.6.1" id="FileReaderSync"><span class="secno">7.6.1. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#d3" id="ref-for-d3-7">FileReaderSync</a></code> API</span><a class="self-link" href="#FileReaderSync"></a></h4>
+   <p>This interface  provides methods to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="synchronous read method" data-noexport="" id="read-method-sync">synchronously read</dfn> <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-41">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-70">Blob</a></code> objects into memory.</p>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="https://w3c.github.io/FileAPI/#dom-filereadersync-filereadersync">Constructor</a>, <a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=<span class="n">Worker</span>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="d3">FileReaderSync</dfn> {
   // Synchronously return strings
 
-  ArrayBuffer <a class="idl-code" data-link-type="method" href="#dfn-readAsArrayBufferSync" id="ref-for-dfn-readAsArrayBufferSync-1">readAsArrayBuffer</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-68">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-4">blob</a>);
-  DOMString <a class="idl-code" data-link-type="method" href="#dfn-readAsTextSync" id="ref-for-dfn-readAsTextSync-2">readAsText</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-69">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-5">blob</a>, optional DOMString <a class="idl-code" data-link-type="argument" href="#dfn-label" id="ref-for-dfn-label-2">label</a>);
-  DOMString <a class="idl-code" data-link-type="method" href="#dfn-readAsDataURLSync" id="ref-for-dfn-readAsDataURLSync-1">readAsDataURL</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-70">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-6">blob</a>);
+  <span class="kt">ArrayBuffer</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsArrayBufferSync" id="ref-for-dfn-readAsArrayBufferSync-1">readAsArrayBuffer</a>(<a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-71">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-6">blob</a>);
+  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsBinaryStringSync" id="ref-for-dfn-readAsBinaryStringSync-1">readAsBinaryString</a>(<a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-72">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-7">blob</a>);
+  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsTextSync" id="ref-for-dfn-readAsTextSync-2">readAsText</a>(<a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-73">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-8">blob</a>, <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-label" id="ref-for-dfn-label-4">label</a>);
+  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsDataURLSync" id="ref-for-dfn-readAsDataURLSync-1">readAsDataURL</a>(<a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-74">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-9">blob</a>);
 };
 </pre>
    <h5 class="heading settled" data-level="7.6.1.1" id="filereadersyncConstrctr"><span class="secno">7.6.1.1. </span><span class="content"> Constructors</span><a class="self-link" href="#filereadersyncConstrctr"></a></h5>
-   <p>When the <code class="idl"><a data-link-type="idl" href="#dom-filereadersync-filereadersync" id="ref-for-dom-filereadersync-filereadersync-1">FileReaderSync()</a></code> constructor is invoked,
-the user agent must return a new <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-8">FileReaderSync</a></code> object.</p>
+   <p>When the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dom-filereadersync-filereadersync">FileReaderSync()</a></code> constructor is invoked,
+the user agent must return a new <code class="idl"><a data-link-type="idl" href="#d3" id="ref-for-d3-8">FileReaderSync</a></code> object.</p>
    <p>In environments where the global object is represented by a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> object,
-the <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-9">FileReaderSync</a></code> constructor must be available.</p>
+the <code class="idl"><a data-link-type="idl" href="#d3" id="ref-for-d3-9">FileReaderSync</a></code> constructor must be available.</p>
    <h5 class="heading settled" data-level="7.6.1.2" id="readAsTextSync"><span class="secno">7.6.1.2. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsTextSync" id="ref-for-dfn-readAsTextSync-3">readAsText()</a></code> method</span><a class="self-link" href="#readAsTextSync"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" data-lt="readAsText(blob, label)|readAsText(blob)" id="dfn-readAsTextSync">readAsText(blob, optional label)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsTextSync">#dfn-readAsTextSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsTextSync-1">7.4. 
-Determining Encoding</a></span><span><a href="#ref-for-dfn-readAsTextSync-2">7.6.1. 
-The FileReaderSync API</a></span><span><a href="#ref-for-dfn-readAsTextSync-3">7.6.1.2. 
-The readAsText() method</a></span></span></dfn> method is called,
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" data-lt="readAsText(blob, label)|readAsText(blob)" id="dfn-readAsTextSync">readAsText(blob, optional label)</dfn> method is called,
 the following steps must be followed:</p>
    <ol>
     <li data-md="">
-     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-27">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-18">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-17">terminate this algorithm</a>.</p>
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-32">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-22">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-20">terminate this algorithm</a>.</p>
     <li data-md="">
      <p>If the <code>blob</code> has been closed through the <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-4">close()</a></code> method,
 throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-18">terminate this algorithm</a>.</p>
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-21">terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-16">read operation</a> using the <code>blob</code> argument,
+     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-17">read operation</a> using the <code>blob</code> argument,
 and with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-9">synchronous flag</a> <em>set</em>.
 If the read operation returns failure,
-throw the appropriate exception as defined in <a href="#dfn-error-codes">§8.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-19">Terminate this algorithm</a>.</p>
+throw the appropriate exception as defined in <a href="#dfn-error-codes">§8.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-22">Terminate this algorithm</a>.</p>
     <li data-md="">
      <p>If no error has occurred,
-return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-17">read operation</a> represented as a string
+return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-18">read operation</a> represented as a string
 in a format determined through the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-5">encoding determination</a> algorithm.</p>
    </ol>
    <h5 class="heading settled" data-level="7.6.1.3" id="readAsDataURLSync-section"><span class="secno">7.6.1.3. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURLSync" id="ref-for-dfn-readAsDataURLSync-2">readAsDataURL()</a></code> method</span><a class="self-link" href="#readAsDataURLSync-section"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" data-lt="readAsDataURL(blob)" id="dfn-readAsDataURLSync">readAsDataURL(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsDataURLSync">#dfn-readAsDataURLSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsDataURLSync-1">7.6.1. 
-The FileReaderSync API</a></span><span><a href="#ref-for-dfn-readAsDataURLSync-2">7.6.1.3. 
-The readAsDataURL() method</a></span></span></dfn> method is called,
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" id="dfn-readAsDataURLSync">readAsDataURL(blob)</dfn> method is called,
 the following steps must be followed:</p>
    <ol>
     <li data-md="">
-     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-28">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-19">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-20">terminate this algorithm</a>.</p>
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-33">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-23">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-23">terminate this algorithm</a>.</p>
     <li data-md="">
      <p>If the <code>blob</code> has been closed through the <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-5">close()</a></code> method,
 throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-21">terminate this algorithm</a>.</p>
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-24">terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-18">read operation</a> using the <code>blob</code> argument,
+     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-19">read operation</a> using the <code>blob</code> argument,
 and with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-10">synchronous flag</a> <em>set</em>.
-If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-19">read operation</a> returns failure,
-throw the appropriate exception as defined in <a href="#dfn-error-codes">§8.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-22">Terminate this algorithm</a>.</p>
+If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-20">read operation</a> returns failure,
+throw the appropriate exception as defined in <a href="#dfn-error-codes">§8.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-25">Terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-20">read operation</a> as a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a> subject to the considerations below:</p>
+     <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-21">read operation</a> as a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a> subject to the considerations below:</p>
      <ul>
       <li data-md="">
        <p>Use the <code>blob</code>’s <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-19">type</a></code> attribute as part of the Data URL if it is available
@@ -3245,44 +2920,58 @@ Data URLs that do not have media-types <a data-link-type="biblio" href="#biblio-
      </ul>
    </ol>
    <h5 class="heading settled" data-level="7.6.1.4" id="readAsArrayBufferSyncSection"><span class="secno">7.6.1.4. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBufferSync" id="ref-for-dfn-readAsArrayBufferSync-2">readAsArrayBuffer()</a></code> method</span><a class="self-link" href="#readAsArrayBufferSyncSection"></a></h5>
-   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" data-lt="readAsArrayBuffer(blob)" id="dfn-readAsArrayBufferSync">readAsArrayBuffer(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-readAsArrayBufferSync">#dfn-readAsArrayBufferSync</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-readAsArrayBufferSync-1">7.6.1. 
-The FileReaderSync API</a></span><span><a href="#ref-for-dfn-readAsArrayBufferSync-2">7.6.1.4. 
-The readAsArrayBuffer() method</a></span></span></dfn> method is called,
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" id="dfn-readAsArrayBufferSync">readAsArrayBuffer(blob)</dfn> method is called,
 the following steps must be followed:</p>
    <ol>
     <li data-md="">
-     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-29">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-20">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-23">terminate this algorithm</a>.</p>
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-34">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-24">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-26">terminate this algorithm</a>.</p>
     <li data-md="">
      <p>If the <code>blob</code> has been closed through the <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-6">close()</a></code> method,
 throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-24">terminate this algorithm</a>.</p>
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-27">terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-21">read operation</a> using the <code>blob</code> argument,
+     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-22">read operation</a> using the <code>blob</code> argument,
 and with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-11">synchronous flag</a> <em>set</em>.
-If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-22">read operation</a> returns failure,
-throw the appropriate exception as defined in <a href="#dfn-error-codes">§8.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-25">Terminate this algorithm</a>.</p>
+If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-23">read operation</a> returns failure,
+throw the appropriate exception as defined in <a href="#dfn-error-codes">§8.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-28">Terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-23">read operation</a> as an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code>.</p>
+     <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-24">read operation</a> as an <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer">ArrayBuffer</a></code>.</p>
    </ol>
+   <h5 class="heading settled" data-level="7.6.1.5" id="readAsBinaryStringSyncSection"><span class="secno">7.6.1.5. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsBinaryStringSync" id="ref-for-dfn-readAsBinaryStringSync-2">readAsBinaryString()</a></code> method</span><a class="self-link" href="#readAsBinaryStringSyncSection"></a></h5>
+   <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" id="dfn-readAsBinaryStringSync">readAsBinaryString(blob)</dfn> method is called,
+the following steps must be followed:</p>
+   <ol>
+    <li data-md="">
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-35">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-25">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-29">terminate this algorithm</a>.</p>
+    <li data-md="">
+     <p>If the <code>blob</code> has been closed through the <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-7">close()</a></code> method,
+throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-30">terminate this algorithm</a>.</p>
+    <li data-md="">
+     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-25">read operation</a> using the <code>blob</code> argument,
+and with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-12">synchronous flag</a> <em>set</em>.
+If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-26">read operation</a> returns failure,
+throw the appropriate exception as defined in <a href="#dfn-error-codes">§8.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-31">Terminate this algorithm</a>.</p>
+    <li data-md="">
+     <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-27">read operation</a> as an <a data-link-type="dfn" href="#binary-string" id="ref-for-binary-string-2">binary string</a>.</p>
+   </ol>
+   <div class="note" role="note"> The use of <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBufferSync" id="ref-for-dfn-readAsArrayBufferSync-3">readAsArrayBuffer()</a></code> is preferred over <code class="idl"><a data-link-type="idl" href="#dfn-readAsBinaryStringSync" id="ref-for-dfn-readAsBinaryStringSync-3">readAsBinaryString()</a></code>, which is provided for
+  backwards compatibility. </div>
    <h2 class="heading settled" data-level="8" id="ErrorAndException"><span class="secno">8. </span><span class="content"> Errors and Exceptions</span><a class="self-link" href="#ErrorAndException"></a></h2>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="file read error" data-noexport="" id="file-error-read">File read errors<span class="dfn-panel" data-deco=""><b><a href="#file-error-read">#file-error-read</a></b><b>Referenced in:</b><span><a href="#ref-for-file-error-read-1">5.2. 
-Attributes</a></span><span><a href="#ref-for-file-error-read-2">7.1. 
-The Read Operation</a> <a href="#ref-for-file-error-read-3">(2)</a> <a href="#ref-for-file-error-read-4">(3)</a></span><span><a href="#ref-for-file-error-read-5">7.3.3. 
-FileReader States</a></span><span><a href="#ref-for-file-error-read-6">7.5.1. 
-Event Summary</a></span><span><a href="#ref-for-file-error-read-7">9.4.4. 
-Sample Request and Response Headers</a></span></span></dfn> can occur when reading files from the underlying filesystem.
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="file read error" data-noexport="" id="file-error-read">File read errors</dfn> can occur when reading files from the underlying filesystem.
 The list below of potential error conditions is <em>informative</em>.</p>
    <ul>
     <li data-md="">
-     <p>The <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-40">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-71">Blob</a></code> being accessed may not exist
+     <p>The <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-42">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-75">Blob</a></code> being accessed may not exist
 at the time one of the <a data-link-type="dfn" href="#asynchronous-read-methods" id="ref-for-asynchronous-read-methods-2">asynchronous read methods</a> or <a data-link-type="dfn" href="#read-method-sync" id="ref-for-read-method-sync-3">synchronous read methods</a> are called.
 This may be due to it having been moved or deleted after a reference to it was acquired
 (e.g. concurrent modification with another application).
 See <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>.</p>
     <li data-md="">
-     <p>A <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-41">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-72">Blob</a></code> may be unreadable.
-This may be due to permission problems that occur after a reference to a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-42">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-73">Blob</a></code> has been acquired
+     <p>A <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-43">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-76">Blob</a></code> may be unreadable.
+This may be due to permission problems that occur after a reference to a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-44">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-77">Blob</a></code> has been acquired
 (e.g. concurrent lock with another application).
 Additionally, the <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-6">snapshot state</a> may have changed.
 See <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code>.</p>
@@ -3296,28 +2985,15 @@ See <a href="#security-discussion">§10 Security Considerations</a> and <code cl
    </ul>
    <h3 class="heading settled" data-level="8.1" id="dfn-error-codes"><span class="secno">8.1. </span><span class="content"> Throwing an Exception or Returning an Error</span><a class="self-link" href="#dfn-error-codes"></a></h3>
    <p><em>This section is normative.</em></p>
-   <p>Error conditions can arise when reading a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-43">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-74">Blob</a></code>.</p>
-   <p>The <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-24">read operation</a> can terminate due to error conditions when reading a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-44">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-75">Blob</a></code>;
+   <p>Error conditions can arise when reading a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-45">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-78">Blob</a></code>.</p>
+   <p>The <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-28">read operation</a> can terminate due to error conditions when reading a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-46">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-79">Blob</a></code>;
 the particular error condition that causes a read operation to return failure
-or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-5">process read error</a> is called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="failure reason" data-noexport="" id="failureReason">failure reason<span class="dfn-panel" data-deco=""><b><a href="#failureReason">#failureReason</a></b><b>Referenced in:</b><span><a href="#ref-for-failureReason-1">7.1. 
-The Read Operation</a> <a href="#ref-for-failureReason-2">(2)</a> <a href="#ref-for-failureReason-3">(3)</a> <a href="#ref-for-failureReason-4">(4)</a> <a href="#ref-for-failureReason-5">(5)</a> <a href="#ref-for-failureReason-6">(6)</a> <a href="#ref-for-failureReason-7">(7)</a></span><span><a href="#ref-for-failureReason-8">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-failureReason-9">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-failureReason-10">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-failureReason-11">7.3.4.5. 
-Error Steps</a> <a href="#ref-for-failureReason-12">(2)</a></span><span><a href="#ref-for-failureReason-13">8.1. 
-Throwing an Exception or Returning an Error</a> <a href="#ref-for-failureReason-14">(2)</a> <a href="#ref-for-failureReason-15">(3)</a> <a href="#ref-for-failureReason-16">(4)</a> <a href="#ref-for-failureReason-17">(5)</a> <a href="#ref-for-failureReason-18">(6)</a> <a href="#ref-for-failureReason-19">(7)</a> <a href="#ref-for-failureReason-20">(8)</a></span></span></dfn>.</p>
+or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-6">process read error</a> is called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="failureReason">failure reason</dfn>.</p>
    <p>Synchronous read methods <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> exceptions of the type in the table below
-if there has been an error owing to a particular <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-13">failure reason</a>.</p>
-   <p>Asynchronous read methods use the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" data-lt="error" id="dfn-error">error<span class="dfn-panel" data-deco=""><b><a href="#dfn-error">#dfn-error</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-error-1">5.2. 
-Attributes</a></span><span><a href="#ref-for-dfn-error-2">7.3. 
-The FileReader API</a></span><span><a href="#ref-for-dfn-error-3">7.3.4.2. 
-The readAsDataURL() method</a></span><span><a href="#ref-for-dfn-error-4">7.3.4.3. 
-The readAsText() method</a></span><span><a href="#ref-for-dfn-error-5">7.3.4.4. 
-The readAsArrayBuffer() method</a></span><span><a href="#ref-for-dfn-error-6">7.3.4.5. 
-Error Steps</a> <a href="#ref-for-dfn-error-7">(2)</a></span><span><a href="#ref-for-dfn-error-8">8.1. 
-Throwing an Exception or Returning an Error</a> <a href="#ref-for-dfn-error-9">(2)</a> <a href="#ref-for-dfn-error-10">(3)</a></span></span></dfn> attribute of the <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-20">FileReader</a></code> object,
+if there has been an error owing to a particular <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-14">failure reason</a>.</p>
+   <p>Asynchronous read methods use the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-error">error</dfn> attribute of the <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-20">FileReader</a></code> object,
 which must return a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#domerror">DOMError</a></code> object of the most appropriate type from the table below
-if there has been an error owing to a particular <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-14">failure reason</a>,
+if there has been an error owing to a particular <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-15">failure reason</a>,
 or otherwise return null.</p>
    <table class="data">
     <thead>
@@ -3328,9 +3004,9 @@ or otherwise return null.</p>
      <tr>
       <td><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> 
       <td>
-       If the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-45">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-76">Blob</a></code> resource could not be found at the time the read was processed,
-        this is the <dfn data-dfn-type="dfn" data-noexport="" id="NotFoundFR">NotFound<a class="self-link" href="#NotFoundFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-15">failure reason</a>. 
-       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-8">error</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception
+       If the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-47">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-80">Blob</a></code> resource could not be found at the time the read was processed,
+        this is the <dfn data-dfn-type="dfn" data-noexport="" id="NotFoundFR">NotFound<a class="self-link" href="#NotFoundFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-16">failure reason</a>. 
+       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-9">error</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception
         and synchronous read methods must <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception.</p>
      <tr>
       <td><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> 
@@ -3338,32 +3014,32 @@ or otherwise return null.</p>
        If: 
        <ul>
         <li data-md="">
-         <p>it is determined that certain files are unsafe for access within a Web application, this is the <dfn data-dfn-type="dfn" data-noexport="" id="UnsafeFileFR">UnsafeFile<a class="self-link" href="#UnsafeFileFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-16">failure reason</a>.</p>
+         <p>it is determined that certain files are unsafe for access within a Web application, this is the <dfn data-dfn-type="dfn" data-noexport="" id="UnsafeFileFR">UnsafeFile<a class="self-link" href="#UnsafeFileFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-17">failure reason</a>.</p>
         <li data-md="">
-         <p>it is determined that too many read calls are being made on <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-46">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-77">Blob</a></code> resources, this is the <dfn data-dfn-type="dfn" data-noexport="" id="TooManyReadsFR">TooManyReads<a class="self-link" href="#TooManyReadsFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-17">failure reason</a>.</p>
+         <p>it is determined that too many read calls are being made on <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-48">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-81">Blob</a></code> resources, this is the <dfn data-dfn-type="dfn" data-noexport="" id="TooManyReadsFR">TooManyReads<a class="self-link" href="#TooManyReadsFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-18">failure reason</a>.</p>
        </ul>
-       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-9">error</a></code> attribute may return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> exception
+       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-10">error</a></code> attribute may return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> exception
         and synchronous read methods may <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> exception.</p>
-       <p>This is a security error to be used in situations not covered by any other <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-18">failure reason</a>.</p>
+       <p>This is a security error to be used in situations not covered by any other <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-19">failure reason</a>.</p>
      <tr>
       <td><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code> 
       <td>
        If: 
        <ul>
         <li data-md="">
-         <p>the <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-7">snapshot state</a> of a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-47">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-78">Blob</a></code> does not match the state of the underlying storage,
-this is the <dfn data-dfn-type="dfn" data-noexport="" id="SnapshotStateFR">SnapshotState<a class="self-link" href="#SnapshotStateFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-19">failure reason</a>.</p>
+         <p>the <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-7">snapshot state</a> of a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-49">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-82">Blob</a></code> does not match the state of the underlying storage,
+this is the <dfn data-dfn-type="dfn" data-noexport="" id="SnapshotStateFR">SnapshotState<a class="self-link" href="#SnapshotStateFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-20">failure reason</a>.</p>
         <li data-md="">
-         <p>the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-48">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-79">Blob</a></code> cannot be read,
+         <p>the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-50">File</a></code> or <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-83">Blob</a></code> cannot be read,
 typically due due to permission problems that occur after a <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-8">snapshot state</a> has been established
 (e.g. concurrent lock on the underlying storage with another application)
-then this is the <dfn data-dfn-type="dfn" data-noexport="" id="FileLockFR">FileLock<a class="self-link" href="#FileLockFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-20">failure reason</a>.</p>
+then this is the <dfn data-dfn-type="dfn" data-noexport="" id="FileLockFR">FileLock<a class="self-link" href="#FileLockFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-21">failure reason</a>.</p>
        </ul>
-       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-10">error</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code> exception
+       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-11">error</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code> exception
         and synchronous read methods must <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code> exception.</p>
    </table>
    <h2 class="heading settled" data-level="9" id="url"><span class="secno">9. </span><span class="content"> A URL for Blob and File reference</span><a class="self-link" href="#url"></a></h2>
-   <p>This section defines a scheme for a URL used to refer to <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-80">Blob</a></code> objects (and <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-49">File</a></code> objects).</p>
+   <p>This section defines a scheme for a URL used to refer to <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-84">Blob</a></code> objects (and <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-51">File</a></code> objects).</p>
    <h3 class="heading settled" data-level="9.1" id="use-cases-scheme"><span class="secno">9.1. </span><span class="content"> Requirements for a New Scheme</span><a class="self-link" href="#use-cases-scheme"></a></h3>
    <p>This specification defines a scheme with URLs of the sort: <code>blob:550e8400-e29b-41d4-a716-446655440000#aboutABBA</code>.
 This section provides some requirements and is an informative discussion.</p>
@@ -3379,19 +3055,19 @@ so that web applications can respond to scenarios where the resource is not foun
     <li data-md="">
      <p>This scheme should have an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> policy and a <a data-link-type="dfn" href="#lifeTime" id="ref-for-lifeTime-1">lifetime</a> stipulation,
 to allow safe access to binary data from web applications.</p>
-     <p>URLs in this scheme should be used as a references to "in-memory" <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-81">Blob</a></code>s,
+     <p>URLs in this scheme should be used as a references to "in-memory" <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-85">Blob</a></code>s,
 and also be re-used elsewhere on the platform to refer to binary resources
 (e.g. for video-conferencing <a data-link-type="biblio" href="#biblio-webrtc">[WebRTC]</a>).
 URLs in this scheme are designed for impermanence,
 since they will be typically used to access "in memory" resources.</p>
     <li data-md="">
      <p>Developers should have the ability to revoke URLs in this scheme,
-so that they no longer refer to <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-82">Blob</a></code> objects.
+so that they no longer refer to <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-86">Blob</a></code> objects.
 This includes scenarios where file references are no longer needed by a program,
-but also other uses of <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-83">Blob</a></code> objects.
-Consider a scenario where a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-84">Blob</a></code> object can be exported from a drawing program
+but also other uses of <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-87">Blob</a></code> objects.
+Consider a scenario where a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-88">Blob</a></code> object can be exported from a drawing program
 which uses the canvas element and API <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.
-A snapshot of the drawing can be created by exporting a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-85">Blob</a></code>.
+A snapshot of the drawing can be created by exporting a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-89">Blob</a></code>.
 This scheme can be used with the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> <a data-link-type="biblio" href="#biblio-html">[HTML]</a> element to display the snapshot;
 if the user deletes the snapshot,
 any reference to the snapshot in memory via a URL should be invalid,
@@ -3409,7 +3085,7 @@ One broad consideration in determining what scheme to use is providing something
     <li data-md="">
      <p>HTTP could be repurposed for the use cases mentioned above;
 it already comes with well-defined request-response semantics that are already used by web applications.
-But <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-86">Blob</a></code> resources are typically "in-memory" resident
+But <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-90">Blob</a></code> resources are typically "in-memory" resident
 (e.g. after a file has been read into memory),
 and are thus unlike "traditional" HTTP resources that are dereferenced via DNS.
 While some user agents automatically "proxy" the underlying file system on the local machine via an HTTP server
@@ -3437,32 +3113,18 @@ In theory, URLs make no guarantee about what sort of resource is obtained when t
 that is left to content labeling and media type.
 But in practice, the name of the scheme creates an expectation about both the resource
 and the protocol of the request-response transaction.
-Choosing a name that clarifies the primary use case—<wbr>namely, access to memory-resident <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-87">Blob</a></code> resources—<wbr>is a worthwhile compromise,
+Choosing a name that clarifies the primary use case—<wbr>namely, access to memory-resident <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-91">Blob</a></code> resources—<wbr>is a worthwhile compromise,
 and favors clarity, familiarity, and consistency across the web platform.</p>
    </ul>
    <h3 class="heading settled" data-level="9.3" id="DefinitionOfScheme"><span class="secno">9.3. </span><span class="content"> The Blob URL</span><a class="self-link" href="#DefinitionOfScheme"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="Blob URL" id="blob-url">Blob URL<span class="dfn-panel" data-deco=""><b><a href="#blob-url">#blob-url</a></b><b>Referenced in:</b><span><a href="#ref-for-blob-url-1">4.2. 
-Attributes</a></span><span><a href="#ref-for-blob-url-2">4.3.1. 
-The slice method</a></span><span><a href="#ref-for-blob-url-3">9.3. 
-The Blob URL</a></span><span><a href="#ref-for-blob-url-4">9.3.1. 
-Origin of Blob URLs</a></span><span><a href="#ref-for-blob-url-5">9.3.3. 
-Discussion of Fragment Identifier</a></span><span><a href="#ref-for-blob-url-6">9.4. 
-Dereferencing Model for Blob URLs</a> <a href="#ref-for-blob-url-7">(2)</a></span><span><a href="#ref-for-blob-url-8">9.4.2. 
-Response Headers</a></span><span><a href="#ref-for-blob-url-9">9.4.3. 
-Network Errors</a> <a href="#ref-for-blob-url-10">(2)</a> <a href="#ref-for-blob-url-11">(3)</a></span><span><a href="#ref-for-blob-url-12">9.4.4. 
-Sample Request and Response Headers</a></span><span><a href="#ref-for-blob-url-13">9.5. 
-Creating and Revoking a Blob URL</a> <a href="#ref-for-blob-url-14">(2)</a> <a href="#ref-for-blob-url-15">(3)</a> <a href="#ref-for-blob-url-16">(4)</a></span><span><a href="#ref-for-blob-url-17">9.5.1. 
-Methods and Parameters</a> <a href="#ref-for-blob-url-18">(2)</a> <a href="#ref-for-blob-url-19">(3)</a> <a href="#ref-for-blob-url-20">(4)</a> <a href="#ref-for-blob-url-21">(5)</a> <a href="#ref-for-blob-url-22">(6)</a> <a href="#ref-for-blob-url-23">(7)</a> <a href="#ref-for-blob-url-24">(8)</a> <a href="#ref-for-blob-url-25">(9)</a> <a href="#ref-for-blob-url-26">(10)</a></span><span><a href="#ref-for-blob-url-27">9.5.2. 
-Examples of Blob URL Creation and Revocation</a> <a href="#ref-for-blob-url-28">(2)</a> <a href="#ref-for-blob-url-29">(3)</a> <a href="#ref-for-blob-url-30">(4)</a> <a href="#ref-for-blob-url-31">(5)</a> <a href="#ref-for-blob-url-32">(6)</a> <a href="#ref-for-blob-url-33">(7)</a></span><span><a href="#ref-for-blob-url-34">9.6. 
-Lifetime of Blob URLs</a> <a href="#ref-for-blob-url-35">(2)</a> <a href="#ref-for-blob-url-36">(3)</a> <a href="#ref-for-blob-url-37">(4)</a> <a href="#ref-for-blob-url-38">(5)</a> <a href="#ref-for-blob-url-39">(6)</a> <a href="#ref-for-blob-url-40">(7)</a> <a href="#ref-for-blob-url-41">(8)</a> <a href="#ref-for-blob-url-42">(9)</a> <a href="#ref-for-blob-url-43">(10)</a> <a href="#ref-for-blob-url-44">(11)</a> <a href="#ref-for-blob-url-45">(12)</a> <a href="#ref-for-blob-url-46">(13)</a></span><span><a href="#ref-for-blob-url-47">10. 
-Security Considerations</a></span></span></dfn> is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> with a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a> of <code>blob</code>,
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="blob-url">Blob URL</dfn> is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> with a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a> of <code>blob</code>,
 a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host">host</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-3">Blob URL</a>,
 a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a> with one entry comprised of a UUID <a data-link-type="biblio" href="#biblio-rfc4122">[RFC4122]</a> (see <a href="#ABNFUUID">An ABNF for UUID</a>),
-and an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-object">object</a> of the associated <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-88">Blob</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-50">File</a></code>.
+and an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-object">object</a> of the associated <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-92">Blob</a></code> or <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-52">File</a></code>.
 A Blob URL may contain an optional <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment">fragment</a>.
 The Blob URL is serialized as a string according to the <a data-link-type="dfn" href="#unicodeBlobURL" id="ref-for-unicodeBlobURL-1">Unicode Serialization of a Blob URL</a> algorithm.</p>
    <p>A <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment">fragment</a>, if used,
-has a distinct interpretation depending on the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-89">Blob</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-51">File</a></code> resource in question
+has a distinct interpretation depending on the media type of the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-93">Blob</a></code> or <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-53">File</a></code> resource in question
 (see <a href="#fragmentDiscussion">§9.3.3 Discussion of Fragment Identifier</a>).</p>
 <pre>blob = scheme ":" origin "/" UUID [fragIdentifier]
 
@@ -3481,17 +3143,14 @@ and are revoked using <code>URL.<code class="idl"><a data-link-type="idl" href="
 The <dfn data-dfn-type="dfn" data-lt="origin of a Blob URL|Blob URL’s origin" data-noexport="" id="origin-of-a-blob-url">origin of a Blob URL<a class="self-link" href="#origin-of-a-blob-url"></a></dfn> must be the same as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> specified by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> at the time the method that created it—<wbr>either <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-3">createObjectURL()</a></code></code> or <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-3">createFor()</a></code></code>—<wbr>was called.</p>
    <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of a Blob URL,
 when serialized as a string,
-must conform to the Web Origin Specification’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Unicode Serialization of an Origin algorithm" data-noexport="" id="unicode-serialization-of-an-origin-algorithm">Unicode Serialization of an Origin algorithm<span class="dfn-panel" data-deco=""><b><a href="#unicode-serialization-of-an-origin-algorithm">#unicode-serialization-of-an-origin-algorithm</a></b><b>Referenced in:</b><span><a href="#ref-for-unicode-serialization-of-an-origin-algorithm-1">9.3.2. 
-Unicode Serialization of a Blob URL</a> <a href="#ref-for-unicode-serialization-of-an-origin-algorithm-2">(2)</a> <a href="#ref-for-unicode-serialization-of-an-origin-algorithm-3">(3)</a></span></span></dfn> <a data-link-type="biblio" href="#biblio-rfc6454">[RFC6454]</a>. <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#http-cors-protocol">Cross-origin requests</a> on Blob URLs must return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
+must conform to the Web Origin Specification’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unicode-serialization-of-an-origin-algorithm">Unicode Serialization of an Origin algorithm</dfn> <a data-link-type="biblio" href="#biblio-rfc6454">[RFC6454]</a>. <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#http-cors-protocol">Cross-origin requests</a> on Blob URLs must return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
    <p class="note" role="note">Note: In practice this means that HTTP and HTTPS <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origins</a> are covered by this specification as valid origins for use with Blob URLs.
 This specification does not address the case of non-HTTP and non-HTTPS <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origins</a>.
 For instance <code>blob:file:///Users/arunranga/702efefb-c234-4988-a73b-6104f1b615ee</code> (which uses the "file:" <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a>)
 may have behavior that is undefined,
 even though user agents may treat such Blob URLs as valid.</p>
    <h4 class="heading settled" data-level="9.3.2" id="unicodeSerializationOfBlobURL"><span class="secno">9.3.2. </span><span class="content"> Unicode Serialization of a Blob URL</span><a class="self-link" href="#unicodeSerializationOfBlobURL"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Unicode Serialization of a Blob URL" data-noexport="" id="unicodeBlobURL">Unicode Serialization of a Blob URL<span class="dfn-panel" data-deco=""><b><a href="#unicodeBlobURL">#unicodeBlobURL</a></b><b>Referenced in:</b><span><a href="#ref-for-unicodeBlobURL-1">9.3. 
-The Blob URL</a></span><span><a href="#ref-for-unicodeBlobURL-2">9.5.1. 
-Methods and Parameters</a> <a href="#ref-for-unicodeBlobURL-3">(2)</a> <a href="#ref-for-unicodeBlobURL-4">(3)</a> <a href="#ref-for-unicodeBlobURL-5">(4)</a></span></span></dfn> is the value returned by the following algorithm,
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unicodeBlobURL">Unicode Serialization of a Blob URL</dfn> is the value returned by the following algorithm,
 which is invoked by <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-4">createObjectURL()</a></code></code> and/or <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-4">createFor()</a></code></code>:</p>
    <ol>
     <li data-md="">
@@ -3529,12 +3188,7 @@ nor the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor
    <h3 class="heading settled" data-level="9.4" id="requestResponseModel"><span class="secno">9.4. </span><span class="content"> Dereferencing Model for Blob URLs</span><a class="self-link" href="#requestResponseModel"></a></h3>
    <p><em>This section is informative.</em></p>
    <p class="note" role="note">Note: The <a data-link-type="biblio" href="#biblio-url">[URL]</a> and <a data-link-type="biblio" href="#biblio-fetch">[Fetch]</a> specifications should be considered normative for parsing and fetching <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-6">Blob URLs</a>.</p>
-   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-7">Blob URLs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="dereference" data-noexport="" id="dereference">dereferenced<span class="dfn-panel" data-deco=""><b><a href="#dereference">#dereference</a></b><b>Referenced in:</b><span><a href="#ref-for-dereference-1">4.2. 
-Attributes</a></span><span><a href="#ref-for-dereference-2">9.3.3. 
-Discussion of Fragment Identifier</a></span><span><a href="#ref-for-dereference-3">9.5.1. 
-Methods and Parameters</a> <a href="#ref-for-dereference-4">(2)</a></span><span><a href="#ref-for-dereference-5">9.5.2. 
-Examples of Blob URL Creation and Revocation</a></span><span><a href="#ref-for-dereference-6">9.6. 
-Lifetime of Blob URLs</a></span></span></dfn> when the user agent retrieves the resource identified by the Blob URL
+   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-7">Blob URLs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="dereference" data-noexport="" id="dereference">dereferenced</dfn> when the user agent retrieves the resource identified by the Blob URL
 and returns it to the requesting entity.
 This section provides guidance on <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">requests</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">responses</a>.</p>
    <p>Only <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">requests</a> with GET <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a> are supported.
@@ -3544,19 +3198,19 @@ Specifically, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#conce
 and no <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network errors</a> are generated.</p>
    <h4 class="heading settled" data-level="9.4.2" id="processing-media-types"><span class="secno">9.4.2. </span><span class="content"> Response Headers</span><a class="self-link" href="#processing-media-types"></a></h4>
    <p>Along with <a href="#TwoHundredOK">200 OK</a> responses,
-user agents use a Content-Type header <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a> that is equal to the value of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-90">Blob</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-21">type</a></code> attribute,
+user agents use a Content-Type header <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a> that is equal to the value of the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-94">Blob</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-21">type</a></code> attribute,
 if it is not the empty string.</p>
    <p>Along with <a href="#TwoHundredOK">200 OK</a> responses,
-user agents use a Content-Length header <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a> that is equal to the value of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-91">Blob</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-11">size</a></code> attribute.</p>
+user agents use a Content-Length header <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a> that is equal to the value of the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-95">Blob</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-11">size</a></code> attribute.</p>
    <p>If a Content-Type header <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a> is provided,
 then user agents obtain and process that media type
 in a manner consistent with the Mime Sniffing specification <a data-link-type="biblio" href="#biblio-mimesniff">[MIMESNIFF]</a>.</p>
-   <p>If a resource identified with a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-8">Blob URL</a> is a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-52">File</a></code> object,
+   <p>If a resource identified with a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-8">Blob URL</a> is a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-54">File</a></code> object,
 user agents use that file’s <code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-4">name</a></code> attribute,
 as if the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> had a <code>Content-Disposition</code> header
-with the filename parameter set to the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-53">File</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-5">name</a></code> attribute <a data-link-type="biblio" href="#biblio-rfc6266">[RFC6266]</a>.</p>
+with the filename parameter set to the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-55">File</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-5">name</a></code> attribute <a data-link-type="biblio" href="#biblio-rfc6266">[RFC6266]</a>.</p>
    <p class="note" role="note">Note: A corollary to this is a non-normative implementation guideline:
-that the "File Save As" user interface in user agents takes into account the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-54">File</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-6">name</a></code> attribute
+that the "File Save As" user interface in user agents takes into account the <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-56">File</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-6">name</a></code> attribute
 if presenting a default name to save the file as.</p>
    <h4 class="heading settled" data-level="9.4.3" id="NetworkError"><span class="secno">9.4.3. </span><span class="content"> Network Errors</span><a class="self-link" href="#NetworkError"></a></h4>
    <p>Responses that do not succeed with a <a href="#TwoHundredOK">200 OK</a> act as if a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> has occurred.
@@ -3577,7 +3231,7 @@ this also results in the <a data-link-type="dfn" href="#blob-url" id="ref-for-bl
    <h4 class="heading settled" data-level="9.4.4" id="ProtocolExamples"><span class="secno">9.4.4. </span><span class="content"> Sample Request and Response Headers</span><a class="self-link" href="#ProtocolExamples"></a></h4>
    <p><em>This section is informative.</em></p>
    <p>This section provides sample exchanges between web applications and user agents using <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-12">Blob URLs</a>.
-A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> can be triggered using HTML markup of the sort <code class="lang-markup highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"blob:http://example.org:8080/550e8400-e29b-41d4-a716-446655440000"</span><span class="nt">></span></code>.
+A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> can be triggered using HTML markup of the sort <code class="lang-markup highlight"><span></span><span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"blob:http://example.org:8080/550e8400-e29b-41d4-a716-446655440000"</span><span class="p">></span> </code>.
 These examples merely illustrate the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>;
 web developers are not likely to interact with all the headers,
 but the <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-xmlhttprequest-getallresponseheaders">getAllResponseHeaders()</a></code> method of <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest">XMLHttpRequest</a></code>, if used,
@@ -3586,7 +3240,7 @@ will show relevant <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#
     <a class="self-link" href="#example-2f07eb67"></a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">Requests</a> could look like this: 
 <pre>GET http://example.org:8080/550e8400-e29b-41d4-a716-446655440000
 </pre>
-    <p>If the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-92">Blob</a></code> has an affiliated media type <a data-link-type="biblio" href="#biblio-rfc2046">[RFC2046]</a> represented by its <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-22">type</a></code> attribute,
+    <p>If the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-96">Blob</a></code> has an affiliated media type <a data-link-type="biblio" href="#biblio-rfc2046">[RFC2046]</a> represented by its <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-22">type</a></code> attribute,
   then the response message should include the Content-Type header from RFC7231 <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a>.
   See <a href="#processing-media-types">§9.4.2 Response Headers</a>.</p>
     <p>Example response:</p>
@@ -3596,7 +3250,7 @@ Content-Length: 21897
 
 ....
 </pre>
-    <p>If there is a <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-7">file read error</a> associated with the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-93">Blob</a></code>,
+    <p>If there is a <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-7">file read error</a> associated with the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-97">Blob</a></code>,
   then a user agent acts as if a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> has occurred.</p>
    </div>
    <h3 class="heading settled" data-level="9.5" id="creating-revoking"><span class="secno">9.5. </span><span class="content"> Creating and Revoking a Blob URL</span><a class="self-link" href="#creating-revoking"></a></h3>
@@ -3606,11 +3260,11 @@ Revocation of a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-14
 and if it is dereferenced after it is revoked,
 user agents must act as if a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> has occurred.
 This section describes a supplemental interface to the URL specification <a data-link-type="biblio" href="#biblio-url">[URL]</a> and presents methods for <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-16">Blob URL</a> creation and revocation.</p>
-<pre class="idl def">[Exposed=(Window,DedicatedWorker,SharedWorker)]
-partial interface <a class="idl-code" data-link-type="interface" href="https://url.spec.whatwg.org/#url">URL</a> {
-  static DOMString <a class="idl-code" data-link-type="method" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-6">createObjectURL</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-94">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-7">blob</a>);
-  static DOMString <a class="idl-code" data-link-type="method" href="#dfn-createFor" id="ref-for-dfn-createFor-6">createFor</a>(<a data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-95">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-8">blob</a>);
-  static void <a class="idl-code" data-link-type="method" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-2">revokeObjectURL</a>(DOMString <a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-1">url</a>);
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=(<span class="n">Window</span>,<span class="n">DedicatedWorker</span>,<span class="n">SharedWorker</span>)]
+<span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://url.spec.whatwg.org/#url">URL</a> {
+  <span class="kt">static</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-6">createObjectURL</a>(<a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-98">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-10">blob</a>);
+  <span class="kt">static</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-createFor" id="ref-for-dfn-createFor-6">createFor</a>(<a class="n" data-link-type="idl-name" href="#d" id="ref-for-d-99">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-11">blob</a>);
+  <span class="kt">static</span> <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-2">revokeObjectURL</a>(<span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-1">url</a>);
 };
 </pre>
    <p>ECMAScript user agents of this specification must ensure
@@ -3620,21 +3274,13 @@ In other words, <code>URL.prototype</code> must evaluate to true if the user age
 and must NOT evaluate to true otherwise.</p>
    <h4 class="heading settled" data-level="9.5.1" id="createRevokeMethodsParams"><span class="secno">9.5.1. </span><span class="content"> Methods and Parameters</span><a class="self-link" href="#createRevokeMethodsParams"></a></h4>
    <dl>
-    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" data-lt="createObjectURL(blob)" id="dfn-createObjectURL">createObjectURL(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-createObjectURL">#dfn-createObjectURL</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-createObjectURL-1">7.3.4.7. 
-Blob Parameters</a></span><span><a href="#ref-for-dfn-createObjectURL-2">9.3.1. 
-Origin of Blob URLs</a> <a href="#ref-for-dfn-createObjectURL-3">(2)</a></span><span><a href="#ref-for-dfn-createObjectURL-4">9.3.2. 
-Unicode Serialization of a Blob URL</a></span><span><a href="#ref-for-dfn-createObjectURL-5">9.3.3. 
-Discussion of Fragment Identifier</a></span><span><a href="#ref-for-dfn-createObjectURL-6">9.5. 
-Creating and Revoking a Blob URL</a></span><span><a href="#ref-for-dfn-createObjectURL-7">9.5.1. 
-Methods and Parameters</a></span><span><a href="#ref-for-dfn-createObjectURL-8">9.5.2. 
-Examples of Blob URL Creation and Revocation</a></span><span><a href="#ref-for-dfn-createObjectURL-9">9.6. 
-Lifetime of Blob URLs</a> <a href="#ref-for-dfn-createObjectURL-10">(2)</a></span></span></dfn> static method 
+    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" id="dfn-createObjectURL">createObjectURL(blob)</dfn> static method 
     <dd>
      Returns a unique <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-17">Blob URL</a>.
     This method must act as follows: 
      <ol>
       <li data-md="">
-       <p>If called with a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-96">Blob</a></code> argument that has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-18">readability state</a> of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-11"><code>CLOSED</code></a>,
+       <p>If called with a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-100">Blob</a></code> argument that has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-19">readability state</a> of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-12"><code>CLOSED</code></a>,
 user agents must return the output of the <a data-link-type="dfn" href="#unicodeBlobURL" id="ref-for-unicodeBlobURL-2">Unicode Serialization of a Blob URL</a>.</p>
        <p class="note" role="note">Note: No entry is added to the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-4">Blob URL Store</a>;
 consequently, when this <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-18">Blob URL</a> is <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-3">dereferenced</a>,
@@ -3650,22 +3296,14 @@ a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-e
          <p>Return <var>url</var>.</p>
        </ol>
      </ol>
-    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" data-lt="createFor(blob)" id="dfn-createFor">createFor(blob)<span class="dfn-panel" data-deco=""><b><a href="#dfn-createFor">#dfn-createFor</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-createFor-1">7.3.4.7. 
-Blob Parameters</a></span><span><a href="#ref-for-dfn-createFor-2">9.3.1. 
-Origin of Blob URLs</a> <a href="#ref-for-dfn-createFor-3">(2)</a></span><span><a href="#ref-for-dfn-createFor-4">9.3.2. 
-Unicode Serialization of a Blob URL</a></span><span><a href="#ref-for-dfn-createFor-5">9.3.3. 
-Discussion of Fragment Identifier</a></span><span><a href="#ref-for-dfn-createFor-6">9.5. 
-Creating and Revoking a Blob URL</a></span><span><a href="#ref-for-dfn-createFor-7">9.5.2. 
-Examples of Blob URL Creation and Revocation</a> <a href="#ref-for-dfn-createFor-8">(2)</a> <a href="#ref-for-dfn-createFor-9">(3)</a></span><span><a href="#ref-for-dfn-createFor-10">9.6. 
-Lifetime of Blob URLs</a> <a href="#ref-for-dfn-createFor-11">(2)</a> <a href="#ref-for-dfn-createFor-12">(3)</a> <a href="#ref-for-dfn-createFor-13">(4)</a></span></span></dfn> static method 
+    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" id="dfn-createFor">createFor(blob)</dfn> static method 
     <dd>
-     Returns a unique <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-19">Blob URL</a>. <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-20">Blob URLs</a> created with this method are said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="auto-revoking" data-noexport="" id="autoRevoking">auto-revoking<span class="dfn-panel" data-deco=""><b><a href="#autoRevoking">#autoRevoking</a></b><b>Referenced in:</b><span><a href="#ref-for-autoRevoking-1">9.6. 
-Lifetime of Blob URLs</a></span></span></dfn> since user-agents are responsible for the revocation of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-21">Blob URL</a>s created with this method,
+     Returns a unique <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-19">Blob URL</a>. <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-20">Blob URLs</a> created with this method are said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="autoRevoking">auto-revoking</dfn> since user-agents are responsible for the revocation of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-21">Blob URL</a>s created with this method,
     subject to the <a data-link-type="dfn" href="#lifeTime" id="ref-for-lifeTime-2">lifetime stipulation</a> for <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-22">Blob URL</a>s.
     This method must act as follows: 
      <ol>
       <li data-md="">
-       <p>If called with a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-97">Blob</a></code> argument that has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-19">readability state</a> of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-12"><code>CLOSED</code></a>,
+       <p>If called with a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-101">Blob</a></code> argument that has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-20">readability state</a> of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-13"><code>CLOSED</code></a>,
 user agents must return the output of the <a data-link-type="dfn" href="#unicodeBlobURL" id="ref-for-unicodeBlobURL-4">Unicode Serialization of a Blob URL</a>.</p>
        <p class="note" role="note">Note: No entry is added to the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-5">Blob URL Store</a>;
 consequently, when this <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-23">Blob URL</a> is <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-4">dereferenced</a>,
@@ -3685,29 +3323,26 @@ a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-e
      </ol>
      <div class="example" id="example-e1e6ab6c">
       <a class="self-link" href="#example-e1e6ab6c"></a> In the example below,
-      after obtaining a reference to a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-98">Blob</a></code> object
-      (in this case, a user-selected <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-55">File</a></code> from the underlying file system),
-      the static method <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-7">createObjectURL()</a></code></code> is called on that <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-99">Blob</a></code> object. 
-<pre class="lang-javascript highlight"><span class="kd">var</span> <span class="nx">file</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s1">'file'</span><span class="p">).</span><span class="nx">files</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>
+      after obtaining a reference to a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-102">Blob</a></code> object
+      (in this case, a user-selected <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-57">File</a></code> from the underlying file system),
+      the static method <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-7">createObjectURL()</a></code></code> is called on that <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-103">Blob</a></code> object. 
+<pre class="lang-javascript highlight"><span></span><span class="kd">var</span> <span class="nx">file</span> <span class="o">=</span> <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s1">'file'</span><span class="p">).</span><span class="nx">files</span><span class="p">[</span><span class="mi">0</span><span class="p">];</span>
 <span class="k">if</span><span class="p">(</span><span class="nx">file</span><span class="p">){</span>
   <span class="nx">blobURLref</span> <span class="o">=</span> <span class="nb">window</span><span class="p">.</span><span class="nx">URL</span><span class="p">.</span><span class="nx">createObjectURL</span><span class="p">(</span><span class="nx">file</span><span class="p">);</span>
   <span class="nx">myimg</span><span class="p">.</span><span class="nx">src</span> <span class="o">=</span> <span class="nx">blobURLref</span><span class="p">;</span>
 
   <span class="p">....</span>
 
-<span class="p">}</span></pre>
+<span class="p">}</span>
+</pre>
      </div>
-    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" data-lt="revokeObjectURL(url)" id="dfn-revokeObjectURL">revokeObjectURL(url)<span class="dfn-panel" data-deco=""><b><a href="#dfn-revokeObjectURL">#dfn-revokeObjectURL</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-revokeObjectURL-1">9.3.1. 
-Origin of Blob URLs</a></span><span><a href="#ref-for-dfn-revokeObjectURL-2">9.5. 
-Creating and Revoking a Blob URL</a></span><span><a href="#ref-for-dfn-revokeObjectURL-3">9.5.1. 
-Methods and Parameters</a> <a href="#ref-for-dfn-revokeObjectURL-4">(2)</a></span><span><a href="#ref-for-dfn-revokeObjectURL-5">9.5.2. 
-Examples of Blob URL Creation and Revocation</a> <a href="#ref-for-dfn-revokeObjectURL-6">(2)</a> <a href="#ref-for-dfn-revokeObjectURL-7">(3)</a></span></span></dfn> static method 
+    <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" id="dfn-revokeObjectURL">revokeObjectURL(url)</dfn> static method 
     <dd>
      Revokes the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-24">Blob URL</a> provided in the string <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-2">url</a></code> by removing the corresponding entry from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-6">Blob URL Store</a>.
     This method must act as follows: 
      <ol>
       <li data-md="">
-       <p>If the <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-3">url</a></code> refers to a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-100">Blob</a></code> that has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-20">readability state</a> of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-13"><code>CLOSED</code></a> OR if the value provided for the <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-4">url</a></code> argument is not a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-25">Blob URL</a>,
+       <p>If the <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-3">url</a></code> refers to a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-104">Blob</a></code> that has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-21">readability state</a> of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-14"><code>CLOSED</code></a> OR if the value provided for the <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-4">url</a></code> argument is not a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-25">Blob URL</a>,
 OR if the value provided for the <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-5">url</a></code> argument does not have an entry in the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-7">Blob URL Store</a>,
 this method call does nothing.
 User agents may display a message on the error console.</p>
@@ -3716,34 +3351,34 @@ User agents may display a message on the error console.</p>
        <p class="note" role="note">Note: Subsequent attemps to dereference <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-7">url</a></code> result in a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>,
 since the entry has been removed from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-9">Blob URL Store</a>.</p>
      </ol>
-     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL/revokeObjectURL(url)" data-dfn-type="argument" data-export="" data-lt="url" id="dfn-urlarg">url<span class="dfn-panel" data-deco=""><b><a href="#dfn-urlarg">#dfn-urlarg</a></b><b>Referenced in:</b><span><a href="#ref-for-dfn-urlarg-1">9.5. 
-Creating and Revoking a Blob URL</a></span><span><a href="#ref-for-dfn-urlarg-2">9.5.1. 
-Methods and Parameters</a> <a href="#ref-for-dfn-urlarg-3">(2)</a> <a href="#ref-for-dfn-urlarg-4">(3)</a> <a href="#ref-for-dfn-urlarg-5">(4)</a> <a href="#ref-for-dfn-urlarg-6">(5)</a> <a href="#ref-for-dfn-urlarg-7">(6)</a></span></span></dfn> argument to the <code class="idl"><a data-link-type="idl" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-3">revokeObjectURL()</a></code> method
+     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL/revokeObjectURL(url)" data-dfn-type="argument" data-export="" id="dfn-urlarg">url</dfn> argument to the <code class="idl"><a data-link-type="idl" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-3">revokeObjectURL()</a></code> method
     is a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-26">Blob URL</a> string.</p>
      <div class="example" id="example-a97f8a33">
       <a class="self-link" href="#example-a97f8a33"></a> In the example below, <code>window1</code> and <code>window2</code> are separate,
       but in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>; <code>window2</code> could be an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code> inside <code>window1</code>. 
-<pre class="lang-javascript highlight"><span class="nx">myurl</span> <span class="o">=</span> <span class="nx">window1</span><span class="p">.</span><span class="nx">URL</span><span class="p">.</span><span class="nx">createObjectURL</span><span class="p">(</span><span class="nx">myblob</span><span class="p">);</span>
-<span class="nx">window2</span><span class="p">.</span><span class="nx">URL</span><span class="p">.</span><span class="nx">revokeObjectURL</span><span class="p">(</span><span class="nx">myurl</span><span class="p">);</span></pre>
+<pre class="lang-javascript highlight"><span></span><span class="nx">myurl</span> <span class="o">=</span> <span class="nx">window1</span><span class="p">.</span><span class="nx">URL</span><span class="p">.</span><span class="nx">createObjectURL</span><span class="p">(</span><span class="nx">myblob</span><span class="p">);</span>
+<span class="nx">window2</span><span class="p">.</span><span class="nx">URL</span><span class="p">.</span><span class="nx">revokeObjectURL</span><span class="p">(</span><span class="nx">myurl</span><span class="p">);</span>
+</pre>
       <p>Since <code>window1</code> and <code>window2</code> are in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a> and share the same <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-10">Blob URL Store</a>,
       the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-4">revokeObjectURL()</a></code></code> call
       ensures that subsequent dereferencing of <code>myurl</code> results in a the user agent acting as if a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> has occurred.</p>
      </div>
    </dl>
    <h4 class="heading settled" data-level="9.5.2" id="examplesOfCreationRevocation"><span class="secno">9.5.2. </span><span class="content"> Examples of Blob URL Creation and Revocation</span><a class="self-link" href="#examplesOfCreationRevocation"></a></h4>
-   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-27">Blob URL</a>s are strings that are used to <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-5">dereference</a> <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-101">Blob</a></code> objects,
+   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-27">Blob URL</a>s are strings that are used to <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-5">dereference</a> <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-105">Blob</a></code> objects,
 and can persist for as long as the <code>document</code> from which they were minted
 using <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-8">createObjectURL()</a></code></code> or <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-7">createFor()</a></code></code>—<wbr>see <a href="#lifeTime" id="ref-for-lifeTime-3">§9.6 Lifetime of Blob URLs</a>.</p>
    <p>This section gives sample usage of creation and revocation of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-28">Blob URL</a>s with explanations.</p>
    <div class="example" id="example-1c236228">
     <a class="self-link" href="#example-1c236228"></a> In the example below, two <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> elements <a data-link-type="biblio" href="#biblio-html">[HTML]</a> refer to the same <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-29">Blob URL</a>: 
-<pre class="lang-javascript highlight"><span class="nx">url</span> <span class="o">=</span> <span class="nx">URL</span><span class="p">.</span><span class="nx">createObjectURL</span><span class="p">(</span><span class="nx">blob</span><span class="p">);</span>
+<pre class="lang-javascript highlight"><span></span><span class="nx">url</span> <span class="o">=</span> <span class="nx">URL</span><span class="p">.</span><span class="nx">createObjectURL</span><span class="p">(</span><span class="nx">blob</span><span class="p">);</span>
 <span class="nx">img1</span><span class="p">.</span><span class="nx">src</span> <span class="o">=</span> <span class="nx">url</span><span class="p">;</span>
-<span class="nx">img2</span><span class="p">.</span><span class="nx">src</span> <span class="o">=</span> <span class="nx">url</span><span class="p">;</span></pre>
+<span class="nx">img2</span><span class="p">.</span><span class="nx">src</span> <span class="o">=</span> <span class="nx">url</span><span class="p">;</span>
+</pre>
    </div>
    <div class="example" id="example-7d838eae">
     <a class="self-link" href="#example-7d838eae"></a> In the example below, <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-5">revokeObjectURL()</a></code></code> is explicitly called. 
-<pre class="lang-javascript highlight"><span class="kd">var</span> <span class="nx">blobURLref</span> <span class="o">=</span> <span class="nx">URL</span><span class="p">.</span><span class="nx">createObjectURL</span><span class="p">(</span><span class="nx">file</span><span class="p">);</span>
+<pre class="lang-javascript highlight"><span></span><span class="kd">var</span> <span class="nx">blobURLref</span> <span class="o">=</span> <span class="nx">URL</span><span class="p">.</span><span class="nx">createObjectURL</span><span class="p">(</span><span class="nx">file</span><span class="p">);</span>
 <span class="nx">img1</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Image</span><span class="p">();</span>
 <span class="nx">img2</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Image</span><span class="p">();</span>
 
@@ -3760,7 +3395,8 @@ using <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjec
   <span class="nx">msg</span><span class="p">(</span><span class="s2">"Images cannot be previewed!"</span><span class="p">);</span>
   <span class="c1">// revoke the string-based reference</span>
   <span class="nx">URL</span><span class="p">.</span><span class="nx">revokeObjectURL</span><span class="p">(</span><span class="nx">blobURLref</span><span class="p">);</span>
-<span class="p">}</span></pre>
+<span class="p">}</span>
+</pre>
    </div>
    <p>The example above allows multiple references to a single <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-30">Blob URL</a>,
 and the web developer then revokes the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-31">Blob URL</a> string after both image objects have been loaded.
@@ -3771,16 +3407,17 @@ developers should pair it with a corresponding call to <code>URL.<code class="id
     <a class="self-link" href="#example-ffe52a2e"></a> This example uses <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-8">createFor()</a></code></code>,
   which allows uses such as the one above,
   and obviates the need for a corresponding call by the web developer to <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-7">revokeObjectURL()</a></code></code>. 
-<pre class="lang-javascript highlight"><span class="kd">var</span> <span class="nx">blobURLref2</span> <span class="o">=</span> <span class="nx">URL</span><span class="p">.</span><span class="nx">createFor</span><span class="p">(</span><span class="nx">file</span><span class="p">);</span>
+<pre class="lang-javascript highlight"><span></span><span class="kd">var</span> <span class="nx">blobURLref2</span> <span class="o">=</span> <span class="nx">URL</span><span class="p">.</span><span class="nx">createFor</span><span class="p">(</span><span class="nx">file</span><span class="p">);</span>
 <span class="nx">img1</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Image</span><span class="p">();</span>
 <span class="nx">img1</span><span class="p">.</span><span class="nx">src</span> <span class="o">=</span> <span class="nx">blobURLref2</span><span class="p">;</span>
-<span class="p">....</span></pre>
+<span class="p">....</span>
+</pre>
    </div>
    <div class="example" id="example-54a0e6ac">
     <a class="self-link" href="#example-54a0e6ac"></a> This example uses <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-9">createFor()</a></code></code> to mint a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-33">Blob URL</a>,
   and appends a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment">fragment</a> that has an understood meaning within the resource
   (in this case, it references an anchor within the HTML document). 
-<pre class="lang-javascript highlight"><span class="c1">// file is an HTML file</span>
+<pre class="lang-javascript highlight"><span></span><span class="c1">// file is an HTML file</span>
 <span class="c1">// One of the anchor identifiers in file is "#applicationInfo"</span>
 
 <span class="kd">var</span> <span class="nx">blobURLAnchorRef</span> <span class="o">=</span> <span class="nx">URL</span><span class="p">.</span><span class="nx">createFor</span><span class="p">(</span><span class="nx">file</span><span class="p">)</span> <span class="o">+</span> <span class="s2">"#applicationInfo"</span><span class="p">;</span>
@@ -3789,33 +3426,21 @@ developers should pair it with a corresponding call to <code>URL.<code class="id
 
 <span class="kd">var</span> <span class="nx">windowRef</span> <span class="o">=</span> <span class="nx">openPopup</span><span class="p">(</span><span class="nx">blobURLAnchorRef</span><span class="p">,</span> <span class="s2">"Application Info"</span><span class="p">);</span>
 
-<span class="p">....</span></pre>
+<span class="p">....</span>
+</pre>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-for="blob url" data-dfn-type="dfn" data-export="" data-level="9.6" data-lt="lifetime|lifetime stipulation" id="lifeTime"><span class="secno">9.6. </span><span class="content"> Lifetime of Blob URLs</span><span class="dfn-panel" data-deco=""><b><a href="#lifeTime">#lifeTime</a></b><b>Referenced in:</b><span><a href="#ref-for-lifeTime-1">9.1. 
-Requirements for a New Scheme</a></span><span><a href="#ref-for-lifeTime-2">9.5.1. 
-Methods and Parameters</a></span><span><a href="#ref-for-lifeTime-3">9.5.2. 
-Examples of Blob URL Creation and Revocation</a></span></span></h3>
-   <p>A global object which exposes <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-9">createObjectURL()</a></code></code> or <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-10">createFor()</a></code></code> must maintain a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Blob URL Store" data-noexport="" id="BlobURLStore">Blob URL Store<span class="dfn-panel" data-deco=""><b><a href="#BlobURLStore">#BlobURLStore</a></b><b>Referenced in:</b><span><a href="#ref-for-BlobURLStore-1">4.3.2. 
-The close method</a></span><span><a href="#ref-for-BlobURLStore-2">9.4.3. 
-Network Errors</a> <a href="#ref-for-BlobURLStore-3">(2)</a></span><span><a href="#ref-for-BlobURLStore-4">9.5.1. 
-Methods and Parameters</a> <a href="#ref-for-BlobURLStore-5">(2)</a> <a href="#ref-for-BlobURLStore-6">(3)</a> <a href="#ref-for-BlobURLStore-7">(4)</a> <a href="#ref-for-BlobURLStore-8">(5)</a> <a href="#ref-for-BlobURLStore-9">(6)</a> <a href="#ref-for-BlobURLStore-10">(7)</a></span><span><a href="#ref-for-BlobURLStore-11">9.6. 
-Lifetime of Blob URLs</a> <a href="#ref-for-BlobURLStore-12">(2)</a> <a href="#ref-for-BlobURLStore-13">(3)</a> <a href="#ref-for-BlobURLStore-14">(4)</a> <a href="#ref-for-BlobURLStore-15">(5)</a> <a href="#ref-for-BlobURLStore-16">(6)</a></span></span></dfn> which is a list of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-34">Blob URLs</a> created by the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-10">createObjectURL()</a></code></code> method
+   <h3 class="heading settled dfn-paneled" data-dfn-for="blob url" data-dfn-type="dfn" data-export="" data-level="9.6" data-lt="lifetime|lifetime stipulation" id="lifeTime"><span class="secno">9.6. </span><span class="content"> Lifetime of Blob URLs</span></h3>
+   <p>A global object which exposes <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-9">createObjectURL()</a></code></code> or <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-10">createFor()</a></code></code> must maintain a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="BlobURLStore">Blob URL Store</dfn> which is a list of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-34">Blob URLs</a> created by the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-10">createObjectURL()</a></code></code> method
 or the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-11">createFor()</a></code></code> method,
-and the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-102">Blob</a></code> resource that each refers to.</p>
-   <p>A global object which exposes <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-12">createFor()</a></code></code> must maintain a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Revocation List" data-noexport="" id="revokeList">Revocation List<span class="dfn-panel" data-deco=""><b><a href="#revokeList">#revokeList</a></b><b>Referenced in:</b><span><a href="#ref-for-revokeList-1">9.6. 
-Lifetime of Blob URLs</a> <a href="#ref-for-revokeList-2">(2)</a> <a href="#ref-for-revokeList-3">(3)</a> <a href="#ref-for-revokeList-4">(4)</a> <a href="#ref-for-revokeList-5">(5)</a></span></span></dfn> which is a list of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-35">Blob URLs</a> created with the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-13">createFor()</a></code></code> method.</p>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="add an entry|add the entry|add an entry to the Blob URL Store|add the entry to the Blob URL Store" data-noexport="" id="add-an-entry">add an entry to the Blob URL Store<span class="dfn-panel" data-deco=""><b><a href="#add-an-entry">#add-an-entry</a></b><b>Referenced in:</b><span><a href="#ref-for-add-an-entry-1">9.5.1. 
-Methods and Parameters</a> <a href="#ref-for-add-an-entry-2">(2)</a></span></span></dfn> for a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-36">Blob URL</a> and a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-103">Blob</a></code> input,
-the user-agent must add the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-37">Blob URL</a> and a reference to the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-104">Blob</a></code> it refers to to the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-11">Blob URL Store</a>.</p>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob revocation list" data-dfn-type="dfn" data-lt="add an entry|add the entry|add an entry to the Revocation List|add the entry to the Revocation List" data-noexport="" id="add-an-entry-revoke">add an entry to the Revocation List<span class="dfn-panel" data-deco=""><b><a href="#add-an-entry-revoke">#add-an-entry-revoke</a></b><b>Referenced in:</b><span><a href="#ref-for-add-an-entry-revoke-1">9.5.1. 
-Methods and Parameters</a></span></span></dfn> for a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-38">Blob URL</a>,
+and the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-106">Blob</a></code> resource that each refers to.</p>
+   <p>A global object which exposes <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-12">createFor()</a></code></code> must maintain a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="revokeList">Revocation List</dfn> which is a list of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-35">Blob URLs</a> created with the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createFor" id="ref-for-dfn-createFor-13">createFor()</a></code></code> method.</p>
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="add an entry|add the entry|add an entry to the Blob URL Store|add the entry to the Blob URL Store" data-noexport="" id="add-an-entry">add an entry to the Blob URL Store</dfn> for a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-36">Blob URL</a> and a <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-107">Blob</a></code> input,
+the user-agent must add the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-37">Blob URL</a> and a reference to the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-108">Blob</a></code> it refers to to the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-11">Blob URL Store</a>.</p>
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob revocation list" data-dfn-type="dfn" data-lt="add an entry|add the entry|add an entry to the Revocation List|add the entry to the Revocation List" data-noexport="" id="add-an-entry-revoke">add an entry to the Revocation List</dfn> for a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-38">Blob URL</a>,
 user agents must add the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-39">Blob URL</a> to the <a data-link-type="dfn" href="#revokeList" id="ref-for-revokeList-1">Revocation List</a>.
 This is only for <a data-link-type="dfn" href="#autoRevoking" id="ref-for-autoRevoking-1">auto-revoking</a> <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-40">Blob URL</a>s.</p>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="remove an entry|remove the entry|remove an entry from the Blob URL Store|remove the entry from the Blob URL Store" data-noexport="" id="removeTheEntry">remove an entry from the Blob URL Store<span class="dfn-panel" data-deco=""><b><a href="#removeTheEntry">#removeTheEntry</a></b><b>Referenced in:</b><span><a href="#ref-for-removeTheEntry-1">4.3.2. 
-The close method</a></span><span><a href="#ref-for-removeTheEntry-2">9.5.1. 
-Methods and Parameters</a></span><span><a href="#ref-for-removeTheEntry-3">9.6. 
-Lifetime of Blob URLs</a></span></span></dfn> for a given <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-41">Blob URL</a> or for a given <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-105">Blob</a></code>,
-user agents must remove the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-42">Blob URL</a> and the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-106">Blob</a></code> it refers to from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-12">Blob URL Store</a>.
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="remove an entry|remove the entry|remove an entry from the Blob URL Store|remove the entry from the Blob URL Store" data-noexport="" id="removeTheEntry">remove an entry from the Blob URL Store</dfn> for a given <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-41">Blob URL</a> or for a given <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-109">Blob</a></code>,
+user agents must remove the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-42">Blob URL</a> and the <code class="idl"><a data-link-type="idl" href="#d" id="ref-for-d-110">Blob</a></code> it refers to from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-12">Blob URL Store</a>.
 Subsequent attempts to <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-6">dereference</a> this URL must result in a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
    <p>The <a data-link-type="dfn" href="#revokeList" id="ref-for-revokeList-2">Revocation List</a> and the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-13">Blob URL Store</a> must be processed together as follows:</p>
    <ol>
@@ -3835,7 +3460,7 @@ user agents must remove all <a data-link-type="dfn" href="#blob-url" id="ref-for
 as well as provides a means for files to be accessed by unique identifiers,
 and as such is subject to some security considerations.
 This specification also assumes that the primary user interaction is with the <code>&lt;input type="file"/></code> element of HTML forms <a data-link-type="biblio" href="#biblio-html">[HTML]</a>,
-and that all files that are being read by <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-21">FileReader</a></code> objects have first been selected by the user.
+and that all files that are being read by <code class="idl"><a data-link-type="idl" href="#d2" id="ref-for-d2-21">FileReader</a></code> objects have first been selected by the user.
 Important security considerations include preventing malicious file selection attacks (selection looping),
 preventing access to system-sensitive files,
 and guarding against modifications of files on disk after a selection has taken place.</p>
@@ -3843,7 +3468,7 @@ and guarding against modifications of files on disk after a selection has taken 
     <li data-md="">
      <p><dfn data-dfn-type="dfn" data-noexport="" id="selection-looping">Preventing selection looping<a class="self-link" href="#selection-looping"></a></dfn>.
 During file selection, a user may be bombarded with the file picker associated with <code>&lt;input type="file"/></code> (in a "must choose" loop that forces selection before the file picker is dismissed)
-and a user agent may prevent file access to any selections by making the <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-12">FileList</a></code> object returned be of size 0.</p>
+and a user agent may prevent file access to any selections by making the <code class="idl"><a data-link-type="idl" href="#d1" id="ref-for-d1-12">FileList</a></code> object returned be of size 0.</p>
     <li data-md="">
      <p><dfn data-dfn-type="dfn" data-noexport="" id="sensitive-files">System-sensitive files<a class="self-link" href="#sensitive-files"></a></dfn> (e.g. files in /usr/bin, password files, and other native operating system executables)
 typically should not be exposed to web content,
@@ -3884,7 +3509,7 @@ which is useful for offline data access for web applications.</p>
      <p class="note" role="note">Note: While this specification doesn’t provide an explicit API call to trigger downloads,
 the HTML5 specification has addressed this.
 The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-hyperlink-download">download</a></code> attribute of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code> element initiates a download,
-saving a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-56">File</a></code> with the name specified.
+saving a <code class="idl"><a data-link-type="idl" href="#d0" id="ref-for-d0-58">File</a></code> with the name specified.
 The combination of this API and the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-hyperlink-download">download</a></code> attribute on <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-a-element">a</a></code> elements
 allows for the creation of files within web applications,
 and the ability to save them locally.</p>
@@ -3964,7 +3589,7 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#dfn-abort">abort()</a><span>, in §7.3.4.6</span>
+   <li><a href="#dfn-abort">abort()</a><span>, in §7.3.4.7</span>
    <li><a href="#dfn-abort-event">abort</a><span>, in §7.5.1</span>
    <li>
     add an entry
@@ -3985,12 +3610,8 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <li><a href="#task-read-operation">annotated task read operation</a><span>, in §7.1</span>
    <li><a href="#asynchronous-read-methods">asynchronous read method</a><span>, in §7.3.4</span>
    <li><a href="#autoRevoking">auto-revoking</a><span>, in §9.5.1</span>
-   <li><a href="#dom-blob-blob">Blob()</a><span>, in §4</span>
-   <li><a href="#dfn-Blob">Blob</a><span>, in §4</span>
-   <li><a href="#dom-blob-blob">Blob(blobParts)</a><span>, in §4</span>
-   <li><a href="#dom-blob-blob">Blob(blobParts, options)</a><span>, in §4</span>
-   <li><a href="#typedefdef-blobpart">BlobPart</a><span>, in §4</span>
-   <li><a href="#dfn-BlobPropertyBag">BlobPropertyBag</a><span>, in §4</span>
+   <li><a href="#binary-string">binary string</a><span>, in §7.3.4.1</span>
+   <li><a href="#d">Blob</a><span>, in §4</span>
    <li><a href="#blob-url">Blob URL</a><span>, in §9.3</span>
    <li><a href="#origin-of-a-blob-url">Blob URL’s origin</a><span>, in §9.3.1</span>
    <li><a href="#BlobURLStore">Blob URL Store</a><span>, in §9.6</span>
@@ -4011,17 +3632,12 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
      <li><a href="#dfn-error">attribute for FileReader</a><span>, in §8.1</span>
     </ul>
    <li><a href="#failureReason">failure reason</a><span>, in §8.1</span>
-   <li><a href="#dfn-file">File</a><span>, in §5</span>
-   <li><a href="#dom-file-file">File(fileBits, fileName)</a><span>, in §5</span>
-   <li><a href="#dom-file-file">File(fileBits, fileName, options)</a><span>, in §5</span>
-   <li><a href="#dfn-filelist">FileList</a><span>, in §6</span>
+   <li><a href="#d0">File</a><span>, in §5</span>
+   <li><a href="#d1">FileList</a><span>, in §6</span>
    <li><a href="#FileLockFR">FileLock</a><span>, in §8.1</span>
-   <li><a href="#dfn-FilePropertyBag">FilePropertyBag</a><span>, in §5</span>
-   <li><a href="#dom-filereader-filereader">FileReader()</a><span>, in §7.3</span>
-   <li><a href="#dfn-filereader">FileReader</a><span>, in §7.3</span>
+   <li><a href="#d2">FileReader</a><span>, in §7.3</span>
    <li><a href="#file-error-read">file read error</a><span>, in §8</span>
-   <li><a href="#dom-filereadersync-filereadersync">FileReaderSync()</a><span>, in §7.6.1</span>
-   <li><a href="#dfn-FileReaderSync">FileReaderSync</a><span>, in §7.6.1</span>
+   <li><a href="#d3">FileReaderSync</a><span>, in §7.6.1</span>
    <li><a href="#fileReadingTaskSource">file reading task source</a><span>, in §7.2</span>
    <li><a href="#file-type-guidelines">file type guidelines</a><span>, in §5</span>
    <li><a href="#fire-a-progress-event">fire a progress event</a><span>, in §7.5</span>
@@ -4062,6 +3678,12 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
     <ul>
      <li><a href="#dfn-readAsArrayBuffer">method for FileReader</a><span>, in §7.3.4.4</span>
      <li><a href="#dfn-readAsArrayBufferSync">method for FileReaderSync</a><span>, in §7.6.1.4</span>
+    </ul>
+   <li>
+    readAsBinaryString(blob)
+    <ul>
+     <li><a href="#dfn-readAsBinaryString">method for FileReader</a><span>, in §7.3.4.5</span>
+     <li><a href="#dfn-readAsBinaryStringSync">method for FileReaderSync</a><span>, in §7.6.1.5</span>
     </ul>
    <li>
     readAsDataURL(blob)
@@ -4141,6 +3763,20 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
      <li><a href="https://fetch.spec.whatwg.org/#concept-response">response</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[file-1]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/FileAPI/#dom-blob-blob">Blob()</a>
+     <li><a href="https://w3c.github.io/FileAPI/#dom-blob-blob">Blob(blobParts, options)</a>
+     <li><a href="https://w3c.github.io/FileAPI/#typedefdef-blobpart">BlobPart</a>
+     <li><a href="https://w3c.github.io/FileAPI/#dfn-BlobPropertyBag">BlobPropertyBag</a>
+     <li><a href="https://w3c.github.io/FileAPI/#dom-file-file">File(fileBits, fileName, options)</a>
+     <li><a href="https://w3c.github.io/FileAPI/#dfn-FilePropertyBag">FilePropertyBag</a>
+     <li><a href="https://w3c.github.io/FileAPI/#dom-filereader-filereader">FileReader()</a>
+     <li><a href="https://w3c.github.io/FileAPI/#dom-filereadersync-filereadersync">FileReaderSync()</a>
+     <li><a href="https://w3c.github.io/FileAPI/#dom-blob-blob-blobparts-options-options">options</a>
+     <li><a href="https://w3c.github.io/FileAPI/#dfn-slice">slice(start, end)</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
      <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#datatransfer">DataTransfer</a>
@@ -4212,8 +3848,13 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
      <li><a href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a>
      <li><a href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a>
      <li><a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>
+     <li><a href="https://heycam.github.io/webidl/#dom-USVString">USVString</a>
+     <li><a href="https://heycam.github.io/webidl/#dom-boolean">boolean</a>
+     <li><a href="https://heycam.github.io/webidl/#dom-longlong">long long</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-supported-property-indices">supported property indices</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-throw">throw</a>
+     <li><a href="https://heycam.github.io/webidl/#dom-unsignedlong">unsigned long</a>
+     <li><a href="https://heycam.github.io/webidl/#dom-unsignedlonglong">unsigned long long</a>
     </ul>
    <li>
     <a data-link-type="biblio">[XHR]</a> defines the following terms:
@@ -4234,6 +3875,8 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <dd>Anne van Kesteren. <a href="https://encoding.spec.whatwg.org/">Encoding Standard</a>. Living Standard. URL: <a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>
    <dt id="biblio-fetch">[Fetch]
    <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dt id="biblio-file-1">[FILE-1]
+   <dd>File API URL: <a href="https://w3c.github.io/FileAPI/">https://w3c.github.io/FileAPI/</a>
    <dt id="biblio-html">[HTML]
    <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-mimesniff">[MIMESNIFF]
@@ -4263,11 +3906,11 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <dt id="biblio-unicode">[Unicode]
    <dd><a href="http://www.unicode.org/versions/latest/">The Unicode Standard</a>. URL: <a href="http://www.unicode.org/versions/latest/">http://www.unicode.org/versions/latest/</a>
    <dt id="biblio-url">[URL]
-   <dd>Anne van Kesteren; Sam Ruby. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-webidl">[WebIDL]
    <dd>Cameron McCormack; Boris Zbarsky. <a href="https://heycam.github.io/webidl/">WebIDL Level 1</a>. 8 March 2016. CR. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
    <dt id="biblio-workers">[Workers]
-   <dd>Ian Hickson. <a href="http://www.w3.org/TR/workers/">Web Workers</a>. 24 September 2015. WD. URL: <a href="http://www.w3.org/TR/workers/">http://www.w3.org/TR/workers/</a>
+   <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/workers.html">Web Workers</a>. 24 September 2015. WD. URL: <a href="https://html.spec.whatwg.org/multipage/workers.html">https://html.spec.whatwg.org/multipage/workers.html</a>
    <dt id="biblio-xhr">[XHR]
    <dd>Anne van Kesteren. <a href="https://xhr.spec.whatwg.org/">XMLHttpRequest Standard</a>. Living Standard. URL: <a href="https://xhr.spec.whatwg.org/">https://xhr.spec.whatwg.org/</a>
   </dl>
@@ -4282,98 +3925,100 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <dt id="biblio-rfc4122">[RFC4122]
    <dd>P. Leach; M. Mealling; R. Salz. <a href="https://tools.ietf.org/html/rfc4122">A Universally Unique IDentifier (UUID) URN Namespace</a>. July 2005. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc4122">https://tools.ietf.org/html/rfc4122</a>
    <dt id="biblio-webrtc">[WebRTC]
-   <dd>Adam Bergkvist; et al. <a href="http://www.w3.org/TR/webrtc/">WebRTC 1.0: Real-time Communication Between Browsers</a>. 28 January 2016. WD. URL: <a href="http://www.w3.org/TR/webrtc/">http://www.w3.org/TR/webrtc/</a>
+   <dd>Adam Bergkvist; et al. <a href="https://w3c.github.io/webrtc-pc/">WebRTC 1.0: Real-time Communication Between Browsers</a>. 31 May 2016. WD. URL: <a href="https://w3c.github.io/webrtc-pc/">https://w3c.github.io/webrtc-pc/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl def">[<a href="#dom-blob-blob">Constructor</a>(optional sequence&lt;<a data-link-type="idl-name" href="#typedefdef-blobpart">BlobPart</a>> <a class="idl-code" data-link-type="argument" href="#dfn-blobParts">blobParts</a>, optional <a data-link-type="idl-name" href="#dfn-BlobPropertyBag">BlobPropertyBag</a> <a href="#dom-blob-blob-blobparts-options-options">options</a>),
-Exposed=(Window,Worker)]
-interface <a href="#dfn-Blob">Blob</a> {
+<pre class="idl def">[<a class="nv idl-code" data-link-type="constructor" href="https://w3c.github.io/FileAPI/#dom-blob-blob">Constructor</a>(<span class="kt">optional</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#typedefdef-blobpart">BlobPart</a>> <a class="nv idl-code" data-link-type="argument" href="#dfn-blobParts">blobParts</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-BlobPropertyBag">BlobPropertyBag</a> <a class="nv idl-code" data-link-type="argument" href="https://w3c.github.io/FileAPI/#dom-blob-blob-blobparts-options-options">options</a>),
+<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <a class="nv" href="#d">Blob</a> {
 
-  readonly attribute unsigned long long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long " href="#dfn-size">size</a>;
-  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString " href="#dfn-type">type</a>;
-  readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dfn-isClosed">isClosed</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long" href="#dfn-size">size</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dfn-type">type</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dfn-isClosed">isClosed</a>;
 
   //slice Blob into byte-ranged chunks
 
-  <a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="method" href="#dfn-slice">slice</a>([Clamp] optional long long <a class="idl-code" data-link-type="argument" href="#dfn-start">start</a>,
-            [Clamp] optional long long <a class="idl-code" data-link-type="argument" href="#dfn-end">end</a>,
-            optional DOMString <a class="idl-code" data-link-type="argument" href="#dfn-contentTypeBlob">contentType</a>);
-  void <a class="idl-code" data-link-type="method" href="#dfn-close">close</a>();
+  <a class="n" data-link-type="idl-name" href="#d">Blob</a> <a class="nv idl-code" data-link-type="method" href="https://w3c.github.io/FileAPI/#dfn-slice">slice</a>([<a class="nv idl-code" data-link-type="extended-attribute">Clamp</a>] <span class="kt">optional</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-start">start</a>,
+            [<a class="nv idl-code" data-link-type="extended-attribute">Clamp</a>] <span class="kt">optional</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-end">end</a>,
+            <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-contentTypeBlob">contentType</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-close">close</a>();
 
 };
 
-dictionary <a href="#dfn-BlobPropertyBag">BlobPropertyBag</a> {
-  DOMString <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dfn-BPtype">type</a> = "";
+<span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="https://w3c.github.io/FileAPI/#dfn-BlobPropertyBag">BlobPropertyBag</a> {
+  <span class="kt">DOMString</span> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dfn-BPtype">type</a> = "";
 };
 
-typedef (ArrayBuffer or <a data-link-type="idl-name" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBufferView">ArrayBufferView</a> or <a data-link-type="idl-name" href="#dfn-Blob">Blob</a> or USVString) <a href="#typedefdef-blobpart">BlobPart</a>;
+<span class="kt">typedef</span> (<span class="kt">ArrayBuffer</span> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://www.khronos.org/registry/typedarray/specs/latest/#ArrayBufferView">ArrayBufferView</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="#d">Blob</a> <span class="kt">or</span> <span class="kt">USVString</span>) <a class="nv idl-code" data-link-type="typedef" href="https://w3c.github.io/FileAPI/#typedefdef-blobpart">BlobPart</a>;
 
-[<a href="#dom-file-file">Constructor</a>(sequence&lt;<a data-link-type="idl-name" href="#typedefdef-blobpart">BlobPart</a>> <a class="idl-code" data-link-type="argument" href="#dfn-fileBits">fileBits</a>,
-            [EnsureUTF16] DOMString <a class="idl-code" data-link-type="argument" href="#dfn-fileName">fileName</a>,
-            optional <a data-link-type="idl-name" href="#dfn-FilePropertyBag">FilePropertyBag</a> <a href="#dom-file-file-filebits-filename-options-options">options</a>),
-Exposed=(Window,Worker)]
-interface <a href="#dfn-file">File</a> : <a data-link-type="idl-name" href="#dfn-Blob">Blob</a> {
-  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString " href="#dfn-name">name</a>;
-  readonly attribute long long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="long long " href="#dfn-lastModified">lastModified</a>;
+[<a class="nv idl-code" data-link-type="constructor" href="https://w3c.github.io/FileAPI/#dom-file-file">Constructor</a>(<span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#typedefdef-blobpart">BlobPart</a>> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBits">fileBits</a>,
+            [<a class="nv idl-code" data-link-type="extended-attribute">EnsureUTF16</a>] <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileName">fileName</a>,
+            <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-FilePropertyBag">FilePropertyBag</a> <a class="nv idl-code" data-link-type="argument" href="https://w3c.github.io/FileAPI/#dom-file-file-filebits-filename-options-options">options</a>),
+<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <a class="nv" href="#d0">File</a> : <a class="n" data-link-type="idl-name" href="#d">Blob</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dfn-name">name</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long long" href="#dfn-lastModified">lastModified</a>;
 };
 
-dictionary <a href="#dfn-FilePropertyBag">FilePropertyBag</a> : <a data-link-type="idl-name" href="#dfn-BlobPropertyBag">BlobPropertyBag</a> {
-  long long <a class="idl-code" data-link-type="dict-member" data-type="long long " href="#dfn-FPdate">lastModified</a>;
+<span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="https://w3c.github.io/FileAPI/#dfn-FilePropertyBag">FilePropertyBag</a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/FileAPI/#dfn-BlobPropertyBag">BlobPropertyBag</a> {
+  <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="dict-member" data-type="long long " href="#dfn-FPdate">lastModified</a>;
 };
 
-[Exposed=(Window,Worker)]
-interface <a href="#dfn-filelist">FileList</a> {
-  getter <a data-link-type="idl-name" href="#dfn-file">File</a>? <a class="idl-code" data-link-type="method" href="#dfn-item">item</a>(unsigned long <a class="idl-code" data-link-type="argument" href="#dfn-index">index</a>);
-  readonly attribute unsigned long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long " href="#dfn-length">length</a>;
+[<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <a class="nv" href="#d1">FileList</a> {
+  <span class="kt">getter</span> <a class="n" data-link-type="idl-name" href="#d0">File</a>? <a class="nv idl-code" data-link-type="method" href="#dfn-item">item</a>(<span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-index">index</a>);
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dfn-length">length</a>;
 };
 
-[<a href="#dom-filereader-filereader">Constructor</a>, Exposed=(Window,Worker)]
-interface <a href="#dfn-filereader">FileReader</a>: <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
+[<a class="nv idl-code" data-link-type="constructor" href="https://w3c.github.io/FileAPI/#dom-filereader-filereader">Constructor</a>, <a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <a class="nv" href="#d2">FileReader</a>: <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
 
   // async read methods
-  void <a class="idl-code" data-link-type="method" href="#dfn-readAsArrayBuffer">readAsArrayBuffer</a>(<a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
-  void <a class="idl-code" data-link-type="method" href="#dfn-readAsText">readAsText</a>(<a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>, optional DOMString <a class="idl-code" data-link-type="argument" href="#dfn-label">label</a>);
-  void <a class="idl-code" data-link-type="method" href="#dfn-readAsDataURL">readAsDataURL</a>(<a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsArrayBuffer">readAsArrayBuffer</a>(<a class="n" data-link-type="idl-name" href="#d">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsBinaryString">readAsBinaryString</a>(<a class="n" data-link-type="idl-name" href="#d">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsText">readAsText</a>(<a class="n" data-link-type="idl-name" href="#d">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>, <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-label">label</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsDataURL">readAsDataURL</a>(<a class="n" data-link-type="idl-name" href="#d">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
 
-  void <a class="idl-code" data-link-type="method" href="#dfn-abort">abort</a>();
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-abort">abort</a>();
 
   // states
-  const unsigned short <a class="idl-code" data-link-type="const" href="#dfn-empty">EMPTY</a> = 0;
-  const unsigned short <a class="idl-code" data-link-type="const" href="#dfn-loading">LOADING</a> = 1;
-  const unsigned short <a class="idl-code" data-link-type="const" href="#dfn-done">DONE</a> = 2;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dfn-empty">EMPTY</a> = 0;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dfn-loading">LOADING</a> = 1;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dfn-done">DONE</a> = 2;
 
 
-  readonly attribute unsigned short <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned short " href="#dfn-readyState">readyState</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned short" href="#dfn-readyState">readyState</a>;
 
   // File or Blob data
-  readonly attribute (DOMString or ArrayBuffer)? <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="(DOMString or ArrayBuffer)? " href="#dfn-result">result</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> (<span class="kt">DOMString</span> <span class="kt">or</span> <span class="kt">ArrayBuffer</span>)? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="(DOMString or ArrayBuffer)?" href="#dfn-result">result</a>;
 
-  readonly attribute <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#domerror">DOMError</a>? <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMError? " href="#dfn-error">error</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#domerror">DOMError</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMError?" href="#dfn-error">error</a>;
 
   // event handler content attributes
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onloadstart">onloadstart</a>;
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onprogress">onprogress</a>;
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onload">onload</a>;
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onabort">onabort</a>;
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onerror">onerror</a>;
-  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="idl-code" data-link-type="attribute" data-type="EventHandler " href="#dfn-onloadend">onloadend</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onloadstart">onloadstart</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onprogress">onprogress</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onload">onload</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onabort">onabort</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onerror">onerror</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dfn-onloadend">onloadend</a>;
 
 };
 
-[<a href="#dom-filereadersync-filereadersync">Constructor</a>, Exposed=Worker]
-interface <a href="#dfn-FileReaderSync">FileReaderSync</a> {
+[<a class="nv idl-code" data-link-type="constructor" href="https://w3c.github.io/FileAPI/#dom-filereadersync-filereadersync">Constructor</a>, <a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=<span class="n">Worker</span>]
+<span class="kt">interface</span> <a class="nv" href="#d3">FileReaderSync</a> {
   // Synchronously return strings
 
-  ArrayBuffer <a class="idl-code" data-link-type="method" href="#dfn-readAsArrayBufferSync">readAsArrayBuffer</a>(<a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
-  DOMString <a class="idl-code" data-link-type="method" href="#dfn-readAsTextSync">readAsText</a>(<a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>, optional DOMString <a class="idl-code" data-link-type="argument" href="#dfn-label">label</a>);
-  DOMString <a class="idl-code" data-link-type="method" href="#dfn-readAsDataURLSync">readAsDataURL</a>(<a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
+  <span class="kt">ArrayBuffer</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsArrayBufferSync">readAsArrayBuffer</a>(<a class="n" data-link-type="idl-name" href="#d">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
+  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsBinaryStringSync">readAsBinaryString</a>(<a class="n" data-link-type="idl-name" href="#d">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
+  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsTextSync">readAsText</a>(<a class="n" data-link-type="idl-name" href="#d">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>, <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-label">label</a>);
+  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsDataURLSync">readAsDataURL</a>(<a class="n" data-link-type="idl-name" href="#d">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
 };
 
-[Exposed=(Window,DedicatedWorker,SharedWorker)]
-partial interface <a class="idl-code" data-link-type="interface" href="https://url.spec.whatwg.org/#url">URL</a> {
-  static DOMString <a class="idl-code" data-link-type="method" href="#dfn-createObjectURL">createObjectURL</a>(<a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
-  static DOMString <a class="idl-code" data-link-type="method" href="#dfn-createFor">createFor</a>(<a data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
-  static void <a class="idl-code" data-link-type="method" href="#dfn-revokeObjectURL">revokeObjectURL</a>(DOMString <a class="idl-code" data-link-type="argument" href="#dfn-urlarg">url</a>);
+[<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=(<span class="n">Window</span>,<span class="n">DedicatedWorker</span>,<span class="n">SharedWorker</span>)]
+<span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://url.spec.whatwg.org/#url">URL</a> {
+  <span class="kt">static</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-createObjectURL">createObjectURL</a>(<a class="n" data-link-type="idl-name" href="#d">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
+  <span class="kt">static</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-createFor">createFor</a>(<a class="n" data-link-type="idl-name" href="#d">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob">blob</a>);
+  <span class="kt">static</span> <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-revokeObjectURL">revokeObjectURL</a>(<span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-urlarg">url</a>);
 };
 
 </pre>
@@ -4381,18 +4026,1394 @@ partial interface <a class="idl-code" data-link-type="interface" href="https://u
   <div style="counter-reset:issue">
    <div class="issue"> This section is provisional; more security data may supplement this in subsequent drafts.<a href="#issue-61296551"> ↵ </a></div>
   </div>
-<script>
+  <aside class="dfn-panel" data-for="dfn-conforming-implementation">
+   <b><a href="#dfn-conforming-implementation">#dfn-conforming-implementation</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-conforming-implementation-1">2. 
+Conformance</a>
+    <li><a href="#ref-for-dfn-conforming-implementation-2">2.1. 
+Dependencies</a> <a href="#ref-for-dfn-conforming-implementation-3">(2)</a> <a href="#ref-for-dfn-conforming-implementation-4">(3)</a> <a href="#ref-for-dfn-conforming-implementation-5">(4)</a> <a href="#ref-for-dfn-conforming-implementation-6">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="terminate-an-algorithm">
+   <b><a href="#terminate-an-algorithm">#terminate-an-algorithm</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-terminate-an-algorithm-1">4.3.2. 
+The close method</a>
+    <li><a href="#ref-for-terminate-an-algorithm-2">7.1. 
+The Read Operation</a> <a href="#ref-for-terminate-an-algorithm-3">(2)</a> <a href="#ref-for-terminate-an-algorithm-4">(3)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-5">7.3.4.2. 
+The readAsDataURL() method</a> <a href="#ref-for-terminate-an-algorithm-6">(2)</a> <a href="#ref-for-terminate-an-algorithm-7">(3)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-8">7.3.4.3. 
+The readAsText() method</a> <a href="#ref-for-terminate-an-algorithm-9">(2)</a> <a href="#ref-for-terminate-an-algorithm-10">(3)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-11">7.3.4.4. 
+The readAsArrayBuffer() method</a> <a href="#ref-for-terminate-an-algorithm-12">(2)</a> <a href="#ref-for-terminate-an-algorithm-13">(3)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-14">7.3.4.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-terminate-an-algorithm-15">(2)</a> <a href="#ref-for-terminate-an-algorithm-16">(3)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-17">7.3.4.6. 
+Error Steps</a>
+    <li><a href="#ref-for-terminate-an-algorithm-18">7.3.4.7. 
+The abort() method</a> <a href="#ref-for-terminate-an-algorithm-19">(2)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-20">7.6.1.2. 
+The readAsText() method</a> <a href="#ref-for-terminate-an-algorithm-21">(2)</a> <a href="#ref-for-terminate-an-algorithm-22">(3)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-23">7.6.1.3. 
+The readAsDataURL() method</a> <a href="#ref-for-terminate-an-algorithm-24">(2)</a> <a href="#ref-for-terminate-an-algorithm-25">(3)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-26">7.6.1.4. 
+The readAsArrayBuffer() method</a> <a href="#ref-for-terminate-an-algorithm-27">(2)</a> <a href="#ref-for-terminate-an-algorithm-28">(3)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-29">7.6.1.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-terminate-an-algorithm-30">(2)</a> <a href="#ref-for-terminate-an-algorithm-31">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="UnixEpoch">
+   <b><a href="#UnixEpoch">#UnixEpoch</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-UnixEpoch-1">5.1. 
+Constructor</a> <a href="#ref-for-UnixEpoch-2">(2)</a>
+    <li><a href="#ref-for-UnixEpoch-3">5.2. 
+Attributes</a> <a href="#ref-for-UnixEpoch-4">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="readabilityState">
+   <b><a href="#readabilityState">#readabilityState</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-readabilityState-1">4. 
+The Blob Interface and Binary Data</a> <a href="#ref-for-readabilityState-2">(2)</a>
+    <li><a href="#ref-for-readabilityState-3">4.1. 
+Constructors</a> <a href="#ref-for-readabilityState-4">(2)</a>
+    <li><a href="#ref-for-readabilityState-5">4.2. 
+Attributes</a> <a href="#ref-for-readabilityState-6">(2)</a> <a href="#ref-for-readabilityState-7">(3)</a>
+    <li><a href="#ref-for-readabilityState-8">4.3.1. 
+The slice method</a> <a href="#ref-for-readabilityState-9">(2)</a> <a href="#ref-for-readabilityState-10">(3)</a>
+    <li><a href="#ref-for-readabilityState-11">4.3.2. 
+The close method</a> <a href="#ref-for-readabilityState-12">(2)</a>
+    <li><a href="#ref-for-readabilityState-13">5.1. 
+Constructor</a>
+    <li><a href="#ref-for-readabilityState-14">7.1. 
+The Read Operation</a>
+    <li><a href="#ref-for-readabilityState-15">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-readabilityState-16">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-readabilityState-17">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-readabilityState-18">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-readabilityState-19">9.5.1. 
+Methods and Parameters</a> <a href="#ref-for-readabilityState-20">(2)</a> <a href="#ref-for-readabilityState-21">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-openState">
+   <b><a href="#dfn-openState">#dfn-openState</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-openState-1">4. 
+The Blob Interface and Binary Data</a>
+    <li><a href="#ref-for-dfn-openState-2">4.1. 
+Constructors</a> <a href="#ref-for-dfn-openState-3">(2)</a>
+    <li><a href="#ref-for-dfn-openState-4">4.2. 
+Attributes</a>
+    <li><a href="#ref-for-dfn-openState-5">5.1. 
+Constructor</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="closed">
+   <b><a href="#closed">#closed</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-closed-1">4. 
+The Blob Interface and Binary Data</a>
+    <li><a href="#ref-for-closed-2">4.3.2. 
+The close method</a>
+    <li><a href="#ref-for-closed-3">9.4.3. 
+Network Errors</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-closedState">
+   <b><a href="#dfn-closedState">#dfn-closedState</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-closedState-1">4. 
+The Blob Interface and Binary Data</a>
+    <li><a href="#ref-for-dfn-closedState-2">4.2. 
+Attributes</a> <a href="#ref-for-dfn-closedState-3">(2)</a> <a href="#ref-for-dfn-closedState-4">(3)</a>
+    <li><a href="#ref-for-dfn-closedState-5">4.3.2. 
+The close method</a> <a href="#ref-for-dfn-closedState-6">(2)</a>
+    <li><a href="#ref-for-dfn-closedState-7">7.1. 
+The Read Operation</a>
+    <li><a href="#ref-for-dfn-closedState-8">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-dfn-closedState-9">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-dfn-closedState-10">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-closedState-11">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-dfn-closedState-12">9.5.1. 
+Methods and Parameters</a> <a href="#ref-for-dfn-closedState-13">(2)</a> <a href="#ref-for-dfn-closedState-14">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="snapshot-state">
+   <b><a href="#snapshot-state">#snapshot-state</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-snapshot-state-1">4. 
+The Blob Interface and Binary Data</a>
+    <li><a href="#ref-for-snapshot-state-2">5. 
+The File Interface</a> <a href="#ref-for-snapshot-state-3">(2)</a> <a href="#ref-for-snapshot-state-4">(3)</a> <a href="#ref-for-snapshot-state-5">(4)</a>
+    <li><a href="#ref-for-snapshot-state-6">8. 
+Errors and Exceptions</a>
+    <li><a href="#ref-for-snapshot-state-7">8.1. 
+Throwing an Exception or Returning an Error</a> <a href="#ref-for-snapshot-state-8">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="d">
+   <b><a href="#d">#d</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-d-1">1. 
+Introduction</a> <a href="#ref-for-d-2">(2)</a> <a href="#ref-for-d-3">(3)</a>
+    <li><a href="#ref-for-d-4">4. 
+The Blob Interface and Binary Data</a> <a href="#ref-for-d-5">(2)</a> <a href="#ref-for-d-6">(3)</a> <a href="#ref-for-d-7">(4)</a> <a href="#ref-for-d-8">(5)</a> <a href="#ref-for-d-9">(6)</a> <a href="#ref-for-d-10">(7)</a> <a href="#ref-for-d-11">(8)</a>
+    <li><a href="#ref-for-d-12">4.1. 
+Constructors</a> <a href="#ref-for-d-13">(2)</a> <a href="#ref-for-d-14">(3)</a> <a href="#ref-for-d-15">(4)</a> <a href="#ref-for-d-16">(5)</a> <a href="#ref-for-d-17">(6)</a>
+    <li><a href="#ref-for-d-18">4.1.1. 
+Constructor Parameters</a> <a href="#ref-for-d-19">(2)</a>
+    <li><a href="#ref-for-d-20">4.2. 
+Attributes</a> <a href="#ref-for-d-21">(2)</a> <a href="#ref-for-d-22">(3)</a> <a href="#ref-for-d-23">(4)</a> <a href="#ref-for-d-24">(5)</a> <a href="#ref-for-d-25">(6)</a> <a href="#ref-for-d-26">(7)</a> <a href="#ref-for-d-27">(8)</a>
+    <li><a href="#ref-for-d-28">4.3.1. 
+The slice method</a> <a href="#ref-for-d-29">(2)</a> <a href="#ref-for-d-30">(3)</a> <a href="#ref-for-d-31">(4)</a> <a href="#ref-for-d-32">(5)</a> <a href="#ref-for-d-33">(6)</a> <a href="#ref-for-d-34">(7)</a>
+    <li><a href="#ref-for-d-35">4.3.2. 
+The close method</a> <a href="#ref-for-d-36">(2)</a>
+    <li><a href="#ref-for-d-37">5. 
+The File Interface</a> <a href="#ref-for-d-38">(2)</a>
+    <li><a href="#ref-for-d-39">5.1. 
+Constructor</a> <a href="#ref-for-d-40">(2)</a> <a href="#ref-for-d-41">(3)</a>
+    <li><a href="#ref-for-d-42">5.1.1. 
+Constructor Parameters</a>
+    <li><a href="#ref-for-d-43">5.2. 
+Attributes</a>
+    <li><a href="#ref-for-d-44">7.1. 
+The Read Operation</a> <a href="#ref-for-d-45">(2)</a> <a href="#ref-for-d-46">(3)</a> <a href="#ref-for-d-47">(4)</a> <a href="#ref-for-d-48">(5)</a>
+    <li><a href="#ref-for-d-49">7.2. 
+The File Reading Task Source</a>
+    <li><a href="#ref-for-d-50">7.3. 
+The FileReader API</a> <a href="#ref-for-d-51">(2)</a> <a href="#ref-for-d-52">(3)</a> <a href="#ref-for-d-53">(4)</a>
+    <li><a href="#ref-for-d-54">7.3.3. 
+FileReader States</a> <a href="#ref-for-d-55">(2)</a> <a href="#ref-for-d-56">(3)</a>
+    <li><a href="#ref-for-d-57">7.3.4.1. 
+The result attribute</a> <a href="#ref-for-d-58">(2)</a> <a href="#ref-for-d-59">(3)</a> <a href="#ref-for-d-60">(4)</a> <a href="#ref-for-d-61">(5)</a> <a href="#ref-for-d-62">(6)</a> <a href="#ref-for-d-63">(7)</a> <a href="#ref-for-d-64">(8)</a>
+    <li><a href="#ref-for-d-65">7.3.4.8. 
+Blob Parameters</a> <a href="#ref-for-d-66">(2)</a> <a href="#ref-for-d-67">(3)</a>
+    <li><a href="#ref-for-d-68">7.4. 
+Determining Encoding</a>
+    <li><a href="#ref-for-d-69">7.6. 
+Reading on Threads</a>
+    <li><a href="#ref-for-d-70">7.6.1. 
+The FileReaderSync API</a> <a href="#ref-for-d-71">(2)</a> <a href="#ref-for-d-72">(3)</a> <a href="#ref-for-d-73">(4)</a> <a href="#ref-for-d-74">(5)</a>
+    <li><a href="#ref-for-d-75">8. 
+Errors and Exceptions</a> <a href="#ref-for-d-76">(2)</a> <a href="#ref-for-d-77">(3)</a>
+    <li><a href="#ref-for-d-78">8.1. 
+Throwing an Exception or Returning an Error</a> <a href="#ref-for-d-79">(2)</a> <a href="#ref-for-d-80">(3)</a> <a href="#ref-for-d-81">(4)</a> <a href="#ref-for-d-82">(5)</a> <a href="#ref-for-d-83">(6)</a>
+    <li><a href="#ref-for-d-84">9. 
+A URL for Blob and File reference</a>
+    <li><a href="#ref-for-d-85">9.1. 
+Requirements for a New Scheme</a> <a href="#ref-for-d-86">(2)</a> <a href="#ref-for-d-87">(3)</a> <a href="#ref-for-d-88">(4)</a> <a href="#ref-for-d-89">(5)</a>
+    <li><a href="#ref-for-d-90">9.2. 
+Discussion of Existing Schemes</a> <a href="#ref-for-d-91">(2)</a>
+    <li><a href="#ref-for-d-92">9.3. 
+The Blob URL</a> <a href="#ref-for-d-93">(2)</a>
+    <li><a href="#ref-for-d-94">9.4.2. 
+Response Headers</a> <a href="#ref-for-d-95">(2)</a>
+    <li><a href="#ref-for-d-96">9.4.4. 
+Sample Request and Response Headers</a> <a href="#ref-for-d-97">(2)</a>
+    <li><a href="#ref-for-d-98">9.5. 
+Creating and Revoking a Blob URL</a> <a href="#ref-for-d-99">(2)</a>
+    <li><a href="#ref-for-d-100">9.5.1. 
+Methods and Parameters</a> <a href="#ref-for-d-101">(2)</a> <a href="#ref-for-d-102">(3)</a> <a href="#ref-for-d-103">(4)</a> <a href="#ref-for-d-104">(5)</a>
+    <li><a href="#ref-for-d-105">9.5.2. 
+Examples of Blob URL Creation and Revocation</a>
+    <li><a href="#ref-for-d-106">9.6. 
+Lifetime of Blob URLs</a> <a href="#ref-for-d-107">(2)</a> <a href="#ref-for-d-108">(3)</a> <a href="#ref-for-d-109">(4)</a> <a href="#ref-for-d-110">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-blobParts">
+   <b><a href="#dfn-blobParts">#dfn-blobParts</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-blobParts-1">4. 
+The Blob Interface and Binary Data</a>
+    <li><a href="#ref-for-dfn-blobParts-2">4.1. 
+Constructors</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-BPtype">
+   <b><a href="#dfn-BPtype">#dfn-BPtype</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-BPtype-1">4. 
+The Blob Interface and Binary Data</a>
+    <li><a href="#ref-for-dfn-BPtype-2">4.1. 
+Constructors</a> <a href="#ref-for-dfn-BPtype-3">(2)</a>
+    <li><a href="#ref-for-dfn-BPtype-4">5.1. 
+Constructor</a> <a href="#ref-for-dfn-BPtype-5">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-size">
+   <b><a href="#dfn-size">#dfn-size</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-size-1">4. 
+The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-size-2">(2)</a>
+    <li><a href="#ref-for-dfn-size-3">4.1. 
+Constructors</a> <a href="#ref-for-dfn-size-4">(2)</a>
+    <li><a href="#ref-for-dfn-size-5">4.2. 
+Attributes</a>
+    <li><a href="#ref-for-dfn-size-6">4.3.1. 
+The slice method</a> <a href="#ref-for-dfn-size-7">(2)</a> <a href="#ref-for-dfn-size-8">(3)</a>
+    <li><a href="#ref-for-dfn-size-9">5.1. 
+Constructor</a>
+    <li><a href="#ref-for-dfn-size-10">7.1. 
+The Read Operation</a>
+    <li><a href="#ref-for-dfn-size-11">9.4.2. 
+Response Headers</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-type">
+   <b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-type-1">4. 
+The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-type-2">(2)</a>
+    <li><a href="#ref-for-dfn-type-3">4.1. 
+Constructors</a> <a href="#ref-for-dfn-type-4">(2)</a> <a href="#ref-for-dfn-type-5">(3)</a>
+    <li><a href="#ref-for-dfn-type-6">4.2. 
+Attributes</a> <a href="#ref-for-dfn-type-7">(2)</a> <a href="#ref-for-dfn-type-8">(3)</a>
+    <li><a href="#ref-for-dfn-type-9">4.3.1. 
+The slice method</a> <a href="#ref-for-dfn-type-10">(2)</a>
+    <li><a href="#ref-for-dfn-type-11">5. 
+The File Interface</a> <a href="#ref-for-dfn-type-12">(2)</a>
+    <li><a href="#ref-for-dfn-type-13">5.1. 
+Constructor</a> <a href="#ref-for-dfn-type-14">(2)</a>
+    <li><a href="#ref-for-dfn-type-15">7.3.4.2. 
+The readAsDataURL() method</a> <a href="#ref-for-dfn-type-16">(2)</a>
+    <li><a href="#ref-for-dfn-type-17">7.4. 
+Determining Encoding</a> <a href="#ref-for-dfn-type-18">(2)</a>
+    <li><a href="#ref-for-dfn-type-19">7.6.1.3. 
+The readAsDataURL() method</a> <a href="#ref-for-dfn-type-20">(2)</a>
+    <li><a href="#ref-for-dfn-type-21">9.4.2. 
+Response Headers</a>
+    <li><a href="#ref-for-dfn-type-22">9.4.4. 
+Sample Request and Response Headers</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-isClosed">
+   <b><a href="#dfn-isClosed">#dfn-isClosed</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-isClosed-1">4. 
+The Blob Interface and Binary Data</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-slice">
+   <b><a href="#dfn-slice">#dfn-slice</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-slice-1">4.2. 
+Attributes</a>
+    <li><a href="#ref-for-dfn-slice-2">4.3.1. 
+The slice method</a> <a href="#ref-for-dfn-slice-3">(2)</a> <a href="#ref-for-dfn-slice-4">(3)</a> <a href="#ref-for-dfn-slice-5">(4)</a> <a href="#ref-for-dfn-slice-6">(5)</a> <a href="#ref-for-dfn-slice-7">(6)</a> <a href="#ref-for-dfn-slice-8">(7)</a> <a href="#ref-for-dfn-slice-9">(8)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-start">
+   <b><a href="#dfn-start">#dfn-start</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-start-1">4. 
+The Blob Interface and Binary Data</a>
+    <li><a href="#ref-for-dfn-start-2">4.3.1. 
+The slice method</a> <a href="#ref-for-dfn-start-3">(2)</a> <a href="#ref-for-dfn-start-4">(3)</a> <a href="#ref-for-dfn-start-5">(4)</a> <a href="#ref-for-dfn-start-6">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-end">
+   <b><a href="#dfn-end">#dfn-end</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-end-1">4. 
+The Blob Interface and Binary Data</a>
+    <li><a href="#ref-for-dfn-end-2">4.3.1. 
+The slice method</a> <a href="#ref-for-dfn-end-3">(2)</a> <a href="#ref-for-dfn-end-4">(3)</a> <a href="#ref-for-dfn-end-5">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-contentTypeBlob">
+   <b><a href="#dfn-contentTypeBlob">#dfn-contentTypeBlob</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-contentTypeBlob-1">4. 
+The Blob Interface and Binary Data</a>
+    <li><a href="#ref-for-dfn-contentTypeBlob-2">4.3.1. 
+The slice method</a> <a href="#ref-for-dfn-contentTypeBlob-3">(2)</a> <a href="#ref-for-dfn-contentTypeBlob-4">(3)</a> <a href="#ref-for-dfn-contentTypeBlob-5">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-close">
+   <b><a href="#dfn-close">#dfn-close</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-close-1">4. 
+The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-close-2">(2)</a>
+    <li><a href="#ref-for-dfn-close-3">4.2. 
+Attributes</a>
+    <li><a href="#ref-for-dfn-close-4">7.6.1.2. 
+The readAsText() method</a>
+    <li><a href="#ref-for-dfn-close-5">7.6.1.3. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-dfn-close-6">7.6.1.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-close-7">7.6.1.5. 
+The readAsBinaryString() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="file-type-guidelines">
+   <b><a href="#file-type-guidelines">#file-type-guidelines</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-file-type-guidelines-1">4.2. 
+Attributes</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="d0">
+   <b><a href="#d0">#d0</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-d0-1">1. 
+Introduction</a> <a href="#ref-for-d0-2">(2)</a> <a href="#ref-for-d0-3">(3)</a>
+    <li><a href="#ref-for-d0-4">4. 
+The Blob Interface and Binary Data</a>
+    <li><a href="#ref-for-d0-5">4.3.1. 
+The slice method</a> <a href="#ref-for-d0-6">(2)</a>
+    <li><a href="#ref-for-d0-7">5. 
+The File Interface</a> <a href="#ref-for-d0-8">(2)</a> <a href="#ref-for-d0-9">(3)</a> <a href="#ref-for-d0-10">(4)</a> <a href="#ref-for-d0-11">(5)</a> <a href="#ref-for-d0-12">(6)</a>
+    <li><a href="#ref-for-d0-13">5.1. 
+Constructor</a> <a href="#ref-for-d0-14">(2)</a> <a href="#ref-for-d0-15">(3)</a>
+    <li><a href="#ref-for-d0-16">5.1.1. 
+Constructor Parameters</a>
+    <li><a href="#ref-for-d0-17">5.2. 
+Attributes</a> <a href="#ref-for-d0-18">(2)</a> <a href="#ref-for-d0-19">(3)</a> <a href="#ref-for-d0-20">(4)</a>
+    <li><a href="#ref-for-d0-21">6. 
+The FileList Interface</a> <a href="#ref-for-d0-22">(2)</a>
+    <li><a href="#ref-for-d0-23">6.2. 
+Methods and Parameters</a> <a href="#ref-for-d0-24">(2)</a> <a href="#ref-for-d0-25">(3)</a> <a href="#ref-for-d0-26">(4)</a> <a href="#ref-for-d0-27">(5)</a>
+    <li><a href="#ref-for-d0-28">7.2. 
+The File Reading Task Source</a>
+    <li><a href="#ref-for-d0-29">7.3.3. 
+FileReader States</a> <a href="#ref-for-d0-30">(2)</a> <a href="#ref-for-d0-31">(3)</a>
+    <li><a href="#ref-for-d0-32">7.3.4.1. 
+The result attribute</a> <a href="#ref-for-d0-33">(2)</a> <a href="#ref-for-d0-34">(3)</a> <a href="#ref-for-d0-35">(4)</a> <a href="#ref-for-d0-36">(5)</a> <a href="#ref-for-d0-37">(6)</a> <a href="#ref-for-d0-38">(7)</a>
+    <li><a href="#ref-for-d0-39">7.3.4.8. 
+Blob Parameters</a>
+    <li><a href="#ref-for-d0-40">7.6. 
+Reading on Threads</a>
+    <li><a href="#ref-for-d0-41">7.6.1. 
+The FileReaderSync API</a>
+    <li><a href="#ref-for-d0-42">8. 
+Errors and Exceptions</a> <a href="#ref-for-d0-43">(2)</a> <a href="#ref-for-d0-44">(3)</a>
+    <li><a href="#ref-for-d0-45">8.1. 
+Throwing an Exception or Returning an Error</a> <a href="#ref-for-d0-46">(2)</a> <a href="#ref-for-d0-47">(3)</a> <a href="#ref-for-d0-48">(4)</a> <a href="#ref-for-d0-49">(5)</a> <a href="#ref-for-d0-50">(6)</a>
+    <li><a href="#ref-for-d0-51">9. 
+A URL for Blob and File reference</a>
+    <li><a href="#ref-for-d0-52">9.3. 
+The Blob URL</a> <a href="#ref-for-d0-53">(2)</a>
+    <li><a href="#ref-for-d0-54">9.4.2. 
+Response Headers</a> <a href="#ref-for-d0-55">(2)</a> <a href="#ref-for-d0-56">(3)</a>
+    <li><a href="#ref-for-d0-57">9.5.1. 
+Methods and Parameters</a>
+    <li><a href="#ref-for-d0-58">11. 
+Requirements and Use Cases</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-fileBits">
+   <b><a href="#dfn-fileBits">#dfn-fileBits</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-fileBits-1">5. 
+The File Interface</a>
+    <li><a href="#ref-for-dfn-fileBits-2">5.1. 
+Constructor</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-fileName">
+   <b><a href="#dfn-fileName">#dfn-fileName</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-fileName-1">5. 
+The File Interface</a>
+    <li><a href="#ref-for-dfn-fileName-2">5.1. 
+Constructor</a> <a href="#ref-for-dfn-fileName-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-FPdate">
+   <b><a href="#dfn-FPdate">#dfn-FPdate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-FPdate-1">5. 
+The File Interface</a>
+    <li><a href="#ref-for-dfn-FPdate-2">5.1. 
+Constructor</a> <a href="#ref-for-dfn-FPdate-3">(2)</a> <a href="#ref-for-dfn-FPdate-4">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-name">
+   <b><a href="#dfn-name">#dfn-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-name-1">5. 
+The File Interface</a> <a href="#ref-for-dfn-name-2">(2)</a>
+    <li><a href="#ref-for-dfn-name-3">5.1. 
+Constructor</a>
+    <li><a href="#ref-for-dfn-name-4">9.4.2. 
+Response Headers</a> <a href="#ref-for-dfn-name-5">(2)</a> <a href="#ref-for-dfn-name-6">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-lastModified">
+   <b><a href="#dfn-lastModified">#dfn-lastModified</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-lastModified-1">5. 
+The File Interface</a>
+    <li><a href="#ref-for-dfn-lastModified-2">5.1. 
+Constructor</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="d1">
+   <b><a href="#d1">#d1</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-d1-1">5.2. 
+Attributes</a>
+    <li><a href="#ref-for-d1-2">6. 
+The FileList Interface</a> <a href="#ref-for-d1-3">(2)</a>
+    <li><a href="#ref-for-d1-4">6.1. 
+Attributes</a>
+    <li><a href="#ref-for-d1-5">6.2. 
+Methods and Parameters</a> <a href="#ref-for-d1-6">(2)</a> <a href="#ref-for-d1-7">(3)</a> <a href="#ref-for-d1-8">(4)</a> <a href="#ref-for-d1-9">(5)</a> <a href="#ref-for-d1-10">(6)</a>
+    <li><a href="#ref-for-d1-11">7.3.4.8. 
+Blob Parameters</a>
+    <li><a href="#ref-for-d1-12">10. 
+Security Considerations</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-length">
+   <b><a href="#dfn-length">#dfn-length</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-length-1">6. 
+The FileList Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-item">
+   <b><a href="#dfn-item">#dfn-item</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-item-1">6. 
+The FileList Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-index">
+   <b><a href="#dfn-index">#dfn-index</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-index-1">6. 
+The FileList Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="synchronousFlag">
+   <b><a href="#synchronousFlag">#synchronousFlag</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-synchronousFlag-1">7.1. 
+The Read Operation</a> <a href="#ref-for-synchronousFlag-2">(2)</a> <a href="#ref-for-synchronousFlag-3">(3)</a> <a href="#ref-for-synchronousFlag-4">(4)</a> <a href="#ref-for-synchronousFlag-5">(5)</a> <a href="#ref-for-synchronousFlag-6">(6)</a> <a href="#ref-for-synchronousFlag-7">(7)</a> <a href="#ref-for-synchronousFlag-8">(8)</a>
+    <li><a href="#ref-for-synchronousFlag-9">7.6.1.2. 
+The readAsText() method</a>
+    <li><a href="#ref-for-synchronousFlag-10">7.6.1.3. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-synchronousFlag-11">7.6.1.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-synchronousFlag-12">7.6.1.5. 
+The readAsBinaryString() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="readOperation">
+   <b><a href="#readOperation">#readOperation</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-readOperation-1">4.3.1. 
+The slice method</a>
+    <li><a href="#ref-for-readOperation-2">5.2. 
+Attributes</a>
+    <li><a href="#ref-for-readOperation-3">7.1. 
+The Read Operation</a> <a href="#ref-for-readOperation-4">(2)</a> <a href="#ref-for-readOperation-5">(3)</a> <a href="#ref-for-readOperation-6">(4)</a> <a href="#ref-for-readOperation-7">(5)</a> <a href="#ref-for-readOperation-8">(6)</a> <a href="#ref-for-readOperation-9">(7)</a> <a href="#ref-for-readOperation-10">(8)</a> <a href="#ref-for-readOperation-11">(9)</a> <a href="#ref-for-readOperation-12">(10)</a>
+    <li><a href="#ref-for-readOperation-13">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-readOperation-14">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-readOperation-15">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-readOperation-16">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-readOperation-17">7.6.1.2. 
+The readAsText() method</a> <a href="#ref-for-readOperation-18">(2)</a>
+    <li><a href="#ref-for-readOperation-19">7.6.1.3. 
+The readAsDataURL() method</a> <a href="#ref-for-readOperation-20">(2)</a> <a href="#ref-for-readOperation-21">(3)</a>
+    <li><a href="#ref-for-readOperation-22">7.6.1.4. 
+The readAsArrayBuffer() method</a> <a href="#ref-for-readOperation-23">(2)</a> <a href="#ref-for-readOperation-24">(3)</a>
+    <li><a href="#ref-for-readOperation-25">7.6.1.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-readOperation-26">(2)</a> <a href="#ref-for-readOperation-27">(3)</a>
+    <li><a href="#ref-for-readOperation-28">8.1. 
+Throwing an Exception or Returning an Error</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="task-read-operation">
+   <b><a href="#task-read-operation">#task-read-operation</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-task-read-operation-1">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-task-read-operation-2">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-task-read-operation-3">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-task-read-operation-4">7.3.4.5. 
+The readAsBinaryString() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="process-read-error">
+   <b><a href="#process-read-error">#process-read-error</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-process-read-error-1">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-process-read-error-2">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-process-read-error-3">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-process-read-error-4">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-process-read-error-5">7.3.4.6. 
+Error Steps</a>
+    <li><a href="#ref-for-process-read-error-6">8.1. 
+Throwing an Exception or Returning an Error</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="process-read">
+   <b><a href="#process-read">#process-read</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-process-read-1">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-process-read-2">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-process-read-3">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-process-read-4">7.3.4.5. 
+The readAsBinaryString() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="process-read-data">
+   <b><a href="#process-read-data">#process-read-data</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-process-read-data-1">7.1. 
+The Read Operation</a>
+    <li><a href="#ref-for-process-read-data-2">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-process-read-data-3">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-process-read-data-4">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-process-read-data-5">7.3.4.5. 
+The readAsBinaryString() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="process-read-EOF">
+   <b><a href="#process-read-EOF">#process-read-EOF</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-process-read-EOF-1">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-process-read-EOF-2">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-process-read-EOF-3">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-process-read-EOF-4">7.3.4.5. 
+The readAsBinaryString() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="fileReadingTaskSource">
+   <b><a href="#fileReadingTaskSource">#fileReadingTaskSource</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fileReadingTaskSource-1">7.1. 
+The Read Operation</a>
+    <li><a href="#ref-for-fileReadingTaskSource-2">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-fileReadingTaskSource-3">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-fileReadingTaskSource-4">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-fileReadingTaskSource-5">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-fileReadingTaskSource-6">7.3.4.7. 
+The abort() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="d2">
+   <b><a href="#d2">#d2</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-d2-1">1. 
+Introduction</a>
+    <li><a href="#ref-for-d2-2">4.2. 
+Attributes</a>
+    <li><a href="#ref-for-d2-3">7.3.1. 
+Constructor</a> <a href="#ref-for-d2-4">(2)</a>
+    <li><a href="#ref-for-d2-5">7.3.2. 
+Event Handler Content Attributes</a>
+    <li><a href="#ref-for-d2-6">7.3.3. 
+FileReader States</a> <a href="#ref-for-d2-7">(2)</a> <a href="#ref-for-d2-8">(3)</a> <a href="#ref-for-d2-9">(4)</a> <a href="#ref-for-d2-10">(5)</a>
+    <li><a href="#ref-for-d2-11">7.3.4. 
+Reading a File or Blob</a> <a href="#ref-for-d2-12">(2)</a> <a href="#ref-for-d2-13">(3)</a>
+    <li><a href="#ref-for-d2-14">7.3.4.1. 
+The result attribute</a>
+    <li><a href="#ref-for-d2-15">7.4. 
+Determining Encoding</a>
+    <li><a href="#ref-for-d2-16">7.5. 
+Events</a> <a href="#ref-for-d2-17">(2)</a>
+    <li><a href="#ref-for-d2-18">7.5.1. 
+Event Summary</a>
+    <li><a href="#ref-for-d2-19">7.6. 
+Reading on Threads</a>
+    <li><a href="#ref-for-d2-20">8.1. 
+Throwing an Exception or Returning an Error</a>
+    <li><a href="#ref-for-d2-21">10. 
+Security Considerations</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-onloadstart">
+   <b><a href="#dfn-onloadstart">#dfn-onloadstart</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-onloadstart-1">7.3. 
+The FileReader API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-onprogress">
+   <b><a href="#dfn-onprogress">#dfn-onprogress</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-onprogress-1">7.3. 
+The FileReader API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-onabort">
+   <b><a href="#dfn-onabort">#dfn-onabort</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-onabort-1">7.3. 
+The FileReader API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-onerror">
+   <b><a href="#dfn-onerror">#dfn-onerror</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-onerror-1">7.3. 
+The FileReader API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-onload">
+   <b><a href="#dfn-onload">#dfn-onload</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-onload-1">7.3. 
+The FileReader API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-onloadend">
+   <b><a href="#dfn-onloadend">#dfn-onloadend</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-onloadend-1">7.3. 
+The FileReader API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-readyState">
+   <b><a href="#dfn-readyState">#dfn-readyState</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-readyState-1">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-readyState-2">7.3.3. 
+FileReader States</a>
+    <li><a href="#ref-for-dfn-readyState-3">7.3.4. 
+Reading a File or Blob</a>
+    <li><a href="#ref-for-dfn-readyState-4">7.3.4.1. 
+The result attribute</a>
+    <li><a href="#ref-for-dfn-readyState-5">7.3.4.2. 
+The readAsDataURL() method</a> <a href="#ref-for-dfn-readyState-6">(2)</a> <a href="#ref-for-dfn-readyState-7">(3)</a> <a href="#ref-for-dfn-readyState-8">(4)</a> <a href="#ref-for-dfn-readyState-9">(5)</a>
+    <li><a href="#ref-for-dfn-readyState-10">7.3.4.3. 
+The readAsText() method</a> <a href="#ref-for-dfn-readyState-11">(2)</a> <a href="#ref-for-dfn-readyState-12">(3)</a> <a href="#ref-for-dfn-readyState-13">(4)</a> <a href="#ref-for-dfn-readyState-14">(5)</a>
+    <li><a href="#ref-for-dfn-readyState-15">7.3.4.4. 
+The readAsArrayBuffer() method</a> <a href="#ref-for-dfn-readyState-16">(2)</a> <a href="#ref-for-dfn-readyState-17">(3)</a> <a href="#ref-for-dfn-readyState-18">(4)</a> <a href="#ref-for-dfn-readyState-19">(5)</a>
+    <li><a href="#ref-for-dfn-readyState-20">7.3.4.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-dfn-readyState-21">(2)</a> <a href="#ref-for-dfn-readyState-22">(3)</a> <a href="#ref-for-dfn-readyState-23">(4)</a> <a href="#ref-for-dfn-readyState-24">(5)</a>
+    <li><a href="#ref-for-dfn-readyState-25">7.3.4.6. 
+Error Steps</a> <a href="#ref-for-dfn-readyState-26">(2)</a> <a href="#ref-for-dfn-readyState-27">(3)</a>
+    <li><a href="#ref-for-dfn-readyState-28">7.3.4.7. 
+The abort() method</a> <a href="#ref-for-dfn-readyState-29">(2)</a> <a href="#ref-for-dfn-readyState-30">(3)</a> <a href="#ref-for-dfn-readyState-31">(4)</a>
+    <li><a href="#ref-for-dfn-readyState-32">7.6.1.2. 
+The readAsText() method</a>
+    <li><a href="#ref-for-dfn-readyState-33">7.6.1.3. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-dfn-readyState-34">7.6.1.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-readyState-35">7.6.1.5. 
+The readAsBinaryString() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-empty">
+   <b><a href="#dfn-empty">#dfn-empty</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-empty-1">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-empty-2">7.3.4.1. 
+The result attribute</a>
+    <li><a href="#ref-for-dfn-empty-3">7.3.4.7. 
+The abort() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-loading">
+   <b><a href="#dfn-loading">#dfn-loading</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-loading-1">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-loading-2">7.3.4. 
+Reading a File or Blob</a>
+    <li><a href="#ref-for-dfn-loading-3">7.3.4.2. 
+The readAsDataURL() method</a> <a href="#ref-for-dfn-loading-4">(2)</a> <a href="#ref-for-dfn-loading-5">(3)</a> <a href="#ref-for-dfn-loading-6">(4)</a>
+    <li><a href="#ref-for-dfn-loading-7">7.3.4.3. 
+The readAsText() method</a> <a href="#ref-for-dfn-loading-8">(2)</a> <a href="#ref-for-dfn-loading-9">(3)</a> <a href="#ref-for-dfn-loading-10">(4)</a>
+    <li><a href="#ref-for-dfn-loading-11">7.3.4.4. 
+The readAsArrayBuffer() method</a> <a href="#ref-for-dfn-loading-12">(2)</a> <a href="#ref-for-dfn-loading-13">(3)</a> <a href="#ref-for-dfn-loading-14">(4)</a>
+    <li><a href="#ref-for-dfn-loading-15">7.3.4.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-dfn-loading-16">(2)</a> <a href="#ref-for-dfn-loading-17">(3)</a> <a href="#ref-for-dfn-loading-18">(4)</a>
+    <li><a href="#ref-for-dfn-loading-19">7.3.4.6. 
+Error Steps</a> <a href="#ref-for-dfn-loading-20">(2)</a>
+    <li><a href="#ref-for-dfn-loading-21">7.3.4.7. 
+The abort() method</a>
+    <li><a href="#ref-for-dfn-loading-22">7.6.1.2. 
+The readAsText() method</a>
+    <li><a href="#ref-for-dfn-loading-23">7.6.1.3. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-dfn-loading-24">7.6.1.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-loading-25">7.6.1.5. 
+The readAsBinaryString() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-done">
+   <b><a href="#dfn-done">#dfn-done</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-done-1">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-done-2">7.3.3. 
+FileReader States</a>
+    <li><a href="#ref-for-dfn-done-3">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-dfn-done-4">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-dfn-done-5">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-done-6">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-dfn-done-7">7.3.4.6. 
+Error Steps</a>
+    <li><a href="#ref-for-dfn-done-8">7.3.4.7. 
+The abort() method</a> <a href="#ref-for-dfn-done-9">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="asynchronous-read-methods">
+   <b><a href="#asynchronous-read-methods">#asynchronous-read-methods</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-asynchronous-read-methods-1">7.3.4.8. 
+Blob Parameters</a>
+    <li><a href="#ref-for-asynchronous-read-methods-2">8. 
+Errors and Exceptions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="read-method">
+   <b><a href="#read-method">#read-method</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-read-method-1">3. 
+Terminology and Algorithms</a>
+    <li><a href="#ref-for-read-method-2">7.3.3. 
+FileReader States</a> <a href="#ref-for-read-method-3">(2)</a> <a href="#ref-for-read-method-4">(3)</a> <a href="#ref-for-read-method-5">(4)</a>
+    <li><a href="#ref-for-read-method-6">7.3.4.1. 
+The result attribute</a> <a href="#ref-for-read-method-7">(2)</a> <a href="#ref-for-read-method-8">(3)</a> <a href="#ref-for-read-method-9">(4)</a> <a href="#ref-for-read-method-10">(5)</a> <a href="#ref-for-read-method-11">(6)</a>
+    <li><a href="#ref-for-read-method-12">7.3.4.6. 
+Error Steps</a>
+    <li><a href="#ref-for-read-method-13">7.3.4.7. 
+The abort() method</a>
+    <li><a href="#ref-for-read-method-14">7.4. 
+Determining Encoding</a>
+    <li><a href="#ref-for-read-method-15">7.5.2. 
+Summary of Event Invariants</a> <a href="#ref-for-read-method-16">(2)</a> <a href="#ref-for-read-method-17">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-result">
+   <b><a href="#dfn-result">#dfn-result</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-result-1">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-result-2">7.3.4.1. 
+The result attribute</a> <a href="#ref-for-dfn-result-3">(2)</a> <a href="#ref-for-dfn-result-4">(3)</a> <a href="#ref-for-dfn-result-5">(4)</a> <a href="#ref-for-dfn-result-6">(5)</a> <a href="#ref-for-dfn-result-7">(6)</a> <a href="#ref-for-dfn-result-8">(7)</a> <a href="#ref-for-dfn-result-9">(8)</a>
+    <li><a href="#ref-for-dfn-result-10">7.3.4.2. 
+The readAsDataURL() method</a> <a href="#ref-for-dfn-result-11">(2)</a>
+    <li><a href="#ref-for-dfn-result-12">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-dfn-result-13">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-result-14">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-dfn-result-15">7.3.4.6. 
+Error Steps</a>
+    <li><a href="#ref-for-dfn-result-16">7.3.4.7. 
+The abort() method</a> <a href="#ref-for-dfn-result-17">(2)</a>
+    <li><a href="#ref-for-dfn-result-18">7.4. 
+Determining Encoding</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="binary-string">
+   <b><a href="#binary-string">#binary-string</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-binary-string-1">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-binary-string-2">7.6.1.5. 
+The readAsBinaryString() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-readAsDataURL">
+   <b><a href="#dfn-readAsDataURL">#dfn-readAsDataURL</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-readAsDataURL-1">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-readAsDataURL-2">7.3.4. 
+Reading a File or Blob</a>
+    <li><a href="#ref-for-dfn-readAsDataURL-3">7.3.4.1. 
+The result attribute</a>
+    <li><a href="#ref-for-dfn-readAsDataURL-4">7.3.4.2. 
+The readAsDataURL() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-label">
+   <b><a href="#dfn-label">#dfn-label</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-label-1">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-label-2">7.4. 
+Determining Encoding</a> <a href="#ref-for-dfn-label-3">(2)</a>
+    <li><a href="#ref-for-dfn-label-4">7.6.1. 
+The FileReaderSync API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-readAsText">
+   <b><a href="#dfn-readAsText">#dfn-readAsText</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-readAsText-1">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-readAsText-2">7.3.4. 
+Reading a File or Blob</a>
+    <li><a href="#ref-for-dfn-readAsText-3">7.3.4.1. 
+The result attribute</a>
+    <li><a href="#ref-for-dfn-readAsText-4">7.3.4.3. 
+The readAsText() method</a> <a href="#ref-for-dfn-readAsText-5">(2)</a>
+    <li><a href="#ref-for-dfn-readAsText-6">7.4. 
+Determining Encoding</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-readAsArrayBuffer">
+   <b><a href="#dfn-readAsArrayBuffer">#dfn-readAsArrayBuffer</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-readAsArrayBuffer-1">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-readAsArrayBuffer-2">7.3.4. 
+Reading a File or Blob</a>
+    <li><a href="#ref-for-dfn-readAsArrayBuffer-3">7.3.4.1. 
+The result attribute</a>
+    <li><a href="#ref-for-dfn-readAsArrayBuffer-4">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-readAsArrayBuffer-5">7.3.4.5. 
+The readAsBinaryString() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-readAsBinaryString">
+   <b><a href="#dfn-readAsBinaryString">#dfn-readAsBinaryString</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-readAsBinaryString-1">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-readAsBinaryString-2">7.3.4. 
+Reading a File or Blob</a>
+    <li><a href="#ref-for-dfn-readAsBinaryString-3">7.3.4.1. 
+The result attribute</a>
+    <li><a href="#ref-for-dfn-readAsBinaryString-4">7.3.4.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-dfn-readAsBinaryString-5">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-abort">
+   <b><a href="#dfn-abort">#dfn-abort</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-abort-1">3. 
+Terminology and Algorithms</a>
+    <li><a href="#ref-for-dfn-abort-2">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-abort-3">7.3.3. 
+FileReader States</a>
+    <li><a href="#ref-for-dfn-abort-4">7.5.1. 
+Event Summary</a>
+    <li><a href="#ref-for-dfn-abort-5">7.5.2. 
+Summary of Event Invariants</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-fileBlob">
+   <b><a href="#dfn-fileBlob">#dfn-fileBlob</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-fileBlob-1">7.3. 
+The FileReader API</a> <a href="#ref-for-dfn-fileBlob-2">(2)</a> <a href="#ref-for-dfn-fileBlob-3">(3)</a> <a href="#ref-for-dfn-fileBlob-4">(4)</a>
+    <li><a href="#ref-for-dfn-fileBlob-5">7.4. 
+Determining Encoding</a>
+    <li><a href="#ref-for-dfn-fileBlob-6">7.6.1. 
+The FileReaderSync API</a> <a href="#ref-for-dfn-fileBlob-7">(2)</a> <a href="#ref-for-dfn-fileBlob-8">(3)</a> <a href="#ref-for-dfn-fileBlob-9">(4)</a>
+    <li><a href="#ref-for-dfn-fileBlob-10">9.5. 
+Creating and Revoking a Blob URL</a> <a href="#ref-for-dfn-fileBlob-11">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="encoding-determination">
+   <b><a href="#encoding-determination">#encoding-determination</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-encoding-determination-1">4.2. 
+Attributes</a>
+    <li><a href="#ref-for-encoding-determination-2">7.3.4.1. 
+The result attribute</a>
+    <li><a href="#ref-for-encoding-determination-3">7.3.4.3. 
+The readAsText() method</a> <a href="#ref-for-encoding-determination-4">(2)</a>
+    <li><a href="#ref-for-encoding-determination-5">7.6.1.2. 
+The readAsText() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="fire-a-progress-event">
+   <b><a href="#fire-a-progress-event">#fire-a-progress-event</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fire-a-progress-event-1">7.3.4.2. 
+The readAsDataURL() method</a> <a href="#ref-for-fire-a-progress-event-2">(2)</a> <a href="#ref-for-fire-a-progress-event-3">(3)</a> <a href="#ref-for-fire-a-progress-event-4">(4)</a> <a href="#ref-for-fire-a-progress-event-5">(5)</a>
+    <li><a href="#ref-for-fire-a-progress-event-6">7.3.4.3. 
+The readAsText() method</a> <a href="#ref-for-fire-a-progress-event-7">(2)</a> <a href="#ref-for-fire-a-progress-event-8">(3)</a> <a href="#ref-for-fire-a-progress-event-9">(4)</a> <a href="#ref-for-fire-a-progress-event-10">(5)</a>
+    <li><a href="#ref-for-fire-a-progress-event-11">7.3.4.4. 
+The readAsArrayBuffer() method</a> <a href="#ref-for-fire-a-progress-event-12">(2)</a> <a href="#ref-for-fire-a-progress-event-13">(3)</a> <a href="#ref-for-fire-a-progress-event-14">(4)</a> <a href="#ref-for-fire-a-progress-event-15">(5)</a>
+    <li><a href="#ref-for-fire-a-progress-event-16">7.3.4.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-fire-a-progress-event-17">(2)</a> <a href="#ref-for-fire-a-progress-event-18">(3)</a> <a href="#ref-for-fire-a-progress-event-19">(4)</a> <a href="#ref-for-fire-a-progress-event-20">(5)</a>
+    <li><a href="#ref-for-fire-a-progress-event-21">7.3.4.6. 
+Error Steps</a> <a href="#ref-for-fire-a-progress-event-22">(2)</a>
+    <li><a href="#ref-for-fire-a-progress-event-23">7.3.4.7. 
+The abort() method</a> <a href="#ref-for-fire-a-progress-event-24">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-loadstart-event">
+   <b><a href="#dfn-loadstart-event">#dfn-loadstart-event</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-loadstart-event-1">7.3.2. 
+Event Handler Content Attributes</a>
+    <li><a href="#ref-for-dfn-loadstart-event-2">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-dfn-loadstart-event-3">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-dfn-loadstart-event-4">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-loadstart-event-5">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-dfn-loadstart-event-6">7.5.2. 
+Summary of Event Invariants</a> <a href="#ref-for-dfn-loadstart-event-7">(2)</a> <a href="#ref-for-dfn-loadstart-event-8">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-progress-event">
+   <b><a href="#dfn-progress-event">#dfn-progress-event</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-progress-event-1">7.3.2. 
+Event Handler Content Attributes</a>
+    <li><a href="#ref-for-dfn-progress-event-2">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-dfn-progress-event-3">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-dfn-progress-event-4">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-progress-event-5">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-dfn-progress-event-6">7.5.2. 
+Summary of Event Invariants</a> <a href="#ref-for-dfn-progress-event-7">(2)</a> <a href="#ref-for-dfn-progress-event-8">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-abort-event">
+   <b><a href="#dfn-abort-event">#dfn-abort-event</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-abort-event-1">7.3.2. 
+Event Handler Content Attributes</a>
+    <li><a href="#ref-for-dfn-abort-event-2">7.3.4.7. 
+The abort() method</a>
+    <li><a href="#ref-for-dfn-abort-event-3">7.5.2. 
+Summary of Event Invariants</a> <a href="#ref-for-dfn-abort-event-4">(2)</a> <a href="#ref-for-dfn-abort-event-5">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-error-event">
+   <b><a href="#dfn-error-event">#dfn-error-event</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-error-event-1">5.2. 
+Attributes</a>
+    <li><a href="#ref-for-dfn-error-event-2">7.3.2. 
+Event Handler Content Attributes</a>
+    <li><a href="#ref-for-dfn-error-event-3">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-dfn-error-event-4">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-dfn-error-event-5">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-error-event-6">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-dfn-error-event-7">7.3.4.6. 
+Error Steps</a>
+    <li><a href="#ref-for-dfn-error-event-8">7.5.2. 
+Summary of Event Invariants</a> <a href="#ref-for-dfn-error-event-9">(2)</a> <a href="#ref-for-dfn-error-event-10">(3)</a> <a href="#ref-for-dfn-error-event-11">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-load-event">
+   <b><a href="#dfn-load-event">#dfn-load-event</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-load-event-1">7.3.2. 
+Event Handler Content Attributes</a>
+    <li><a href="#ref-for-dfn-load-event-2">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-dfn-load-event-3">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-dfn-load-event-4">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-load-event-5">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-dfn-load-event-6">7.5.2. 
+Summary of Event Invariants</a> <a href="#ref-for-dfn-load-event-7">(2)</a> <a href="#ref-for-dfn-load-event-8">(3)</a> <a href="#ref-for-dfn-load-event-9">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-loadend-event">
+   <b><a href="#dfn-loadend-event">#dfn-loadend-event</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-loadend-event-1">7.3.2. 
+Event Handler Content Attributes</a>
+    <li><a href="#ref-for-dfn-loadend-event-2">7.3.4.2. 
+The readAsDataURL() method</a> <a href="#ref-for-dfn-loadend-event-3">(2)</a>
+    <li><a href="#ref-for-dfn-loadend-event-4">7.3.4.3. 
+The readAsText() method</a> <a href="#ref-for-dfn-loadend-event-5">(2)</a>
+    <li><a href="#ref-for-dfn-loadend-event-6">7.3.4.4. 
+The readAsArrayBuffer() method</a> <a href="#ref-for-dfn-loadend-event-7">(2)</a>
+    <li><a href="#ref-for-dfn-loadend-event-8">7.3.4.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-dfn-loadend-event-9">(2)</a>
+    <li><a href="#ref-for-dfn-loadend-event-10">7.3.4.6. 
+Error Steps</a> <a href="#ref-for-dfn-loadend-event-11">(2)</a>
+    <li><a href="#ref-for-dfn-loadend-event-12">7.3.4.7. 
+The abort() method</a>
+    <li><a href="#ref-for-dfn-loadend-event-13">7.5.2. 
+Summary of Event Invariants</a> <a href="#ref-for-dfn-loadend-event-14">(2)</a> <a href="#ref-for-dfn-loadend-event-15">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="read-method-sync">
+   <b><a href="#read-method-sync">#read-method-sync</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-read-method-sync-1">7.3.4. 
+Reading a File or Blob</a>
+    <li><a href="#ref-for-read-method-sync-2">7.3.4.8. 
+Blob Parameters</a>
+    <li><a href="#ref-for-read-method-sync-3">8. 
+Errors and Exceptions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="d3">
+   <b><a href="#d3">#d3</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-d3-1">4.2. 
+Attributes</a>
+    <li><a href="#ref-for-d3-2">5.2. 
+Attributes</a>
+    <li><a href="#ref-for-d3-3">7.3.4. 
+Reading a File or Blob</a> <a href="#ref-for-d3-4">(2)</a>
+    <li><a href="#ref-for-d3-5">7.4. 
+Determining Encoding</a>
+    <li><a href="#ref-for-d3-6">7.6. 
+Reading on Threads</a>
+    <li><a href="#ref-for-d3-7">7.6.1. 
+The FileReaderSync API</a>
+    <li><a href="#ref-for-d3-8">7.6.1.1. 
+Constructors</a> <a href="#ref-for-d3-9">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-readAsTextSync">
+   <b><a href="#dfn-readAsTextSync">#dfn-readAsTextSync</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-readAsTextSync-1">7.4. 
+Determining Encoding</a>
+    <li><a href="#ref-for-dfn-readAsTextSync-2">7.6.1. 
+The FileReaderSync API</a>
+    <li><a href="#ref-for-dfn-readAsTextSync-3">7.6.1.2. 
+The readAsText() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-readAsDataURLSync">
+   <b><a href="#dfn-readAsDataURLSync">#dfn-readAsDataURLSync</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-readAsDataURLSync-1">7.6.1. 
+The FileReaderSync API</a>
+    <li><a href="#ref-for-dfn-readAsDataURLSync-2">7.6.1.3. 
+The readAsDataURL() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-readAsArrayBufferSync">
+   <b><a href="#dfn-readAsArrayBufferSync">#dfn-readAsArrayBufferSync</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-readAsArrayBufferSync-1">7.6.1. 
+The FileReaderSync API</a>
+    <li><a href="#ref-for-dfn-readAsArrayBufferSync-2">7.6.1.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-readAsArrayBufferSync-3">7.6.1.5. 
+The readAsBinaryString() method</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-readAsBinaryStringSync">
+   <b><a href="#dfn-readAsBinaryStringSync">#dfn-readAsBinaryStringSync</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-readAsBinaryStringSync-1">7.6.1. 
+The FileReaderSync API</a>
+    <li><a href="#ref-for-dfn-readAsBinaryStringSync-2">7.6.1.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-dfn-readAsBinaryStringSync-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="file-error-read">
+   <b><a href="#file-error-read">#file-error-read</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-file-error-read-1">5.2. 
+Attributes</a>
+    <li><a href="#ref-for-file-error-read-2">7.1. 
+The Read Operation</a> <a href="#ref-for-file-error-read-3">(2)</a> <a href="#ref-for-file-error-read-4">(3)</a>
+    <li><a href="#ref-for-file-error-read-5">7.3.3. 
+FileReader States</a>
+    <li><a href="#ref-for-file-error-read-6">7.5.1. 
+Event Summary</a>
+    <li><a href="#ref-for-file-error-read-7">9.4.4. 
+Sample Request and Response Headers</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="failureReason">
+   <b><a href="#failureReason">#failureReason</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-failureReason-1">7.1. 
+The Read Operation</a> <a href="#ref-for-failureReason-2">(2)</a> <a href="#ref-for-failureReason-3">(3)</a> <a href="#ref-for-failureReason-4">(4)</a> <a href="#ref-for-failureReason-5">(5)</a> <a href="#ref-for-failureReason-6">(6)</a> <a href="#ref-for-failureReason-7">(7)</a>
+    <li><a href="#ref-for-failureReason-8">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-failureReason-9">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-failureReason-10">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-failureReason-11">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-failureReason-12">7.3.4.6. 
+Error Steps</a> <a href="#ref-for-failureReason-13">(2)</a>
+    <li><a href="#ref-for-failureReason-14">8.1. 
+Throwing an Exception or Returning an Error</a> <a href="#ref-for-failureReason-15">(2)</a> <a href="#ref-for-failureReason-16">(3)</a> <a href="#ref-for-failureReason-17">(4)</a> <a href="#ref-for-failureReason-18">(5)</a> <a href="#ref-for-failureReason-19">(6)</a> <a href="#ref-for-failureReason-20">(7)</a> <a href="#ref-for-failureReason-21">(8)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-error">
+   <b><a href="#dfn-error">#dfn-error</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-error-1">5.2. 
+Attributes</a>
+    <li><a href="#ref-for-dfn-error-2">7.3. 
+The FileReader API</a>
+    <li><a href="#ref-for-dfn-error-3">7.3.4.2. 
+The readAsDataURL() method</a>
+    <li><a href="#ref-for-dfn-error-4">7.3.4.3. 
+The readAsText() method</a>
+    <li><a href="#ref-for-dfn-error-5">7.3.4.4. 
+The readAsArrayBuffer() method</a>
+    <li><a href="#ref-for-dfn-error-6">7.3.4.5. 
+The readAsBinaryString() method</a>
+    <li><a href="#ref-for-dfn-error-7">7.3.4.6. 
+Error Steps</a> <a href="#ref-for-dfn-error-8">(2)</a>
+    <li><a href="#ref-for-dfn-error-9">8.1. 
+Throwing an Exception or Returning an Error</a> <a href="#ref-for-dfn-error-10">(2)</a> <a href="#ref-for-dfn-error-11">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="blob-url">
+   <b><a href="#blob-url">#blob-url</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-blob-url-1">4.2. 
+Attributes</a>
+    <li><a href="#ref-for-blob-url-2">4.3.1. 
+The slice method</a>
+    <li><a href="#ref-for-blob-url-3">9.3. 
+The Blob URL</a>
+    <li><a href="#ref-for-blob-url-4">9.3.1. 
+Origin of Blob URLs</a>
+    <li><a href="#ref-for-blob-url-5">9.3.3. 
+Discussion of Fragment Identifier</a>
+    <li><a href="#ref-for-blob-url-6">9.4. 
+Dereferencing Model for Blob URLs</a> <a href="#ref-for-blob-url-7">(2)</a>
+    <li><a href="#ref-for-blob-url-8">9.4.2. 
+Response Headers</a>
+    <li><a href="#ref-for-blob-url-9">9.4.3. 
+Network Errors</a> <a href="#ref-for-blob-url-10">(2)</a> <a href="#ref-for-blob-url-11">(3)</a>
+    <li><a href="#ref-for-blob-url-12">9.4.4. 
+Sample Request and Response Headers</a>
+    <li><a href="#ref-for-blob-url-13">9.5. 
+Creating and Revoking a Blob URL</a> <a href="#ref-for-blob-url-14">(2)</a> <a href="#ref-for-blob-url-15">(3)</a> <a href="#ref-for-blob-url-16">(4)</a>
+    <li><a href="#ref-for-blob-url-17">9.5.1. 
+Methods and Parameters</a> <a href="#ref-for-blob-url-18">(2)</a> <a href="#ref-for-blob-url-19">(3)</a> <a href="#ref-for-blob-url-20">(4)</a> <a href="#ref-for-blob-url-21">(5)</a> <a href="#ref-for-blob-url-22">(6)</a> <a href="#ref-for-blob-url-23">(7)</a> <a href="#ref-for-blob-url-24">(8)</a> <a href="#ref-for-blob-url-25">(9)</a> <a href="#ref-for-blob-url-26">(10)</a>
+    <li><a href="#ref-for-blob-url-27">9.5.2. 
+Examples of Blob URL Creation and Revocation</a> <a href="#ref-for-blob-url-28">(2)</a> <a href="#ref-for-blob-url-29">(3)</a> <a href="#ref-for-blob-url-30">(4)</a> <a href="#ref-for-blob-url-31">(5)</a> <a href="#ref-for-blob-url-32">(6)</a> <a href="#ref-for-blob-url-33">(7)</a>
+    <li><a href="#ref-for-blob-url-34">9.6. 
+Lifetime of Blob URLs</a> <a href="#ref-for-blob-url-35">(2)</a> <a href="#ref-for-blob-url-36">(3)</a> <a href="#ref-for-blob-url-37">(4)</a> <a href="#ref-for-blob-url-38">(5)</a> <a href="#ref-for-blob-url-39">(6)</a> <a href="#ref-for-blob-url-40">(7)</a> <a href="#ref-for-blob-url-41">(8)</a> <a href="#ref-for-blob-url-42">(9)</a> <a href="#ref-for-blob-url-43">(10)</a> <a href="#ref-for-blob-url-44">(11)</a> <a href="#ref-for-blob-url-45">(12)</a> <a href="#ref-for-blob-url-46">(13)</a>
+    <li><a href="#ref-for-blob-url-47">10. 
+Security Considerations</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="unicode-serialization-of-an-origin-algorithm">
+   <b><a href="#unicode-serialization-of-an-origin-algorithm">#unicode-serialization-of-an-origin-algorithm</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-unicode-serialization-of-an-origin-algorithm-1">9.3.2. 
+Unicode Serialization of a Blob URL</a> <a href="#ref-for-unicode-serialization-of-an-origin-algorithm-2">(2)</a> <a href="#ref-for-unicode-serialization-of-an-origin-algorithm-3">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="unicodeBlobURL">
+   <b><a href="#unicodeBlobURL">#unicodeBlobURL</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-unicodeBlobURL-1">9.3. 
+The Blob URL</a>
+    <li><a href="#ref-for-unicodeBlobURL-2">9.5.1. 
+Methods and Parameters</a> <a href="#ref-for-unicodeBlobURL-3">(2)</a> <a href="#ref-for-unicodeBlobURL-4">(3)</a> <a href="#ref-for-unicodeBlobURL-5">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dereference">
+   <b><a href="#dereference">#dereference</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dereference-1">4.2. 
+Attributes</a>
+    <li><a href="#ref-for-dereference-2">9.3.3. 
+Discussion of Fragment Identifier</a>
+    <li><a href="#ref-for-dereference-3">9.5.1. 
+Methods and Parameters</a> <a href="#ref-for-dereference-4">(2)</a>
+    <li><a href="#ref-for-dereference-5">9.5.2. 
+Examples of Blob URL Creation and Revocation</a>
+    <li><a href="#ref-for-dereference-6">9.6. 
+Lifetime of Blob URLs</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-createObjectURL">
+   <b><a href="#dfn-createObjectURL">#dfn-createObjectURL</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-createObjectURL-1">7.3.4.8. 
+Blob Parameters</a>
+    <li><a href="#ref-for-dfn-createObjectURL-2">9.3.1. 
+Origin of Blob URLs</a> <a href="#ref-for-dfn-createObjectURL-3">(2)</a>
+    <li><a href="#ref-for-dfn-createObjectURL-4">9.3.2. 
+Unicode Serialization of a Blob URL</a>
+    <li><a href="#ref-for-dfn-createObjectURL-5">9.3.3. 
+Discussion of Fragment Identifier</a>
+    <li><a href="#ref-for-dfn-createObjectURL-6">9.5. 
+Creating and Revoking a Blob URL</a>
+    <li><a href="#ref-for-dfn-createObjectURL-7">9.5.1. 
+Methods and Parameters</a>
+    <li><a href="#ref-for-dfn-createObjectURL-8">9.5.2. 
+Examples of Blob URL Creation and Revocation</a>
+    <li><a href="#ref-for-dfn-createObjectURL-9">9.6. 
+Lifetime of Blob URLs</a> <a href="#ref-for-dfn-createObjectURL-10">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-createFor">
+   <b><a href="#dfn-createFor">#dfn-createFor</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-createFor-1">7.3.4.8. 
+Blob Parameters</a>
+    <li><a href="#ref-for-dfn-createFor-2">9.3.1. 
+Origin of Blob URLs</a> <a href="#ref-for-dfn-createFor-3">(2)</a>
+    <li><a href="#ref-for-dfn-createFor-4">9.3.2. 
+Unicode Serialization of a Blob URL</a>
+    <li><a href="#ref-for-dfn-createFor-5">9.3.3. 
+Discussion of Fragment Identifier</a>
+    <li><a href="#ref-for-dfn-createFor-6">9.5. 
+Creating and Revoking a Blob URL</a>
+    <li><a href="#ref-for-dfn-createFor-7">9.5.2. 
+Examples of Blob URL Creation and Revocation</a> <a href="#ref-for-dfn-createFor-8">(2)</a> <a href="#ref-for-dfn-createFor-9">(3)</a>
+    <li><a href="#ref-for-dfn-createFor-10">9.6. 
+Lifetime of Blob URLs</a> <a href="#ref-for-dfn-createFor-11">(2)</a> <a href="#ref-for-dfn-createFor-12">(3)</a> <a href="#ref-for-dfn-createFor-13">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="autoRevoking">
+   <b><a href="#autoRevoking">#autoRevoking</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-autoRevoking-1">9.6. 
+Lifetime of Blob URLs</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-revokeObjectURL">
+   <b><a href="#dfn-revokeObjectURL">#dfn-revokeObjectURL</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-revokeObjectURL-1">9.3.1. 
+Origin of Blob URLs</a>
+    <li><a href="#ref-for-dfn-revokeObjectURL-2">9.5. 
+Creating and Revoking a Blob URL</a>
+    <li><a href="#ref-for-dfn-revokeObjectURL-3">9.5.1. 
+Methods and Parameters</a> <a href="#ref-for-dfn-revokeObjectURL-4">(2)</a>
+    <li><a href="#ref-for-dfn-revokeObjectURL-5">9.5.2. 
+Examples of Blob URL Creation and Revocation</a> <a href="#ref-for-dfn-revokeObjectURL-6">(2)</a> <a href="#ref-for-dfn-revokeObjectURL-7">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-urlarg">
+   <b><a href="#dfn-urlarg">#dfn-urlarg</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-urlarg-1">9.5. 
+Creating and Revoking a Blob URL</a>
+    <li><a href="#ref-for-dfn-urlarg-2">9.5.1. 
+Methods and Parameters</a> <a href="#ref-for-dfn-urlarg-3">(2)</a> <a href="#ref-for-dfn-urlarg-4">(3)</a> <a href="#ref-for-dfn-urlarg-5">(4)</a> <a href="#ref-for-dfn-urlarg-6">(5)</a> <a href="#ref-for-dfn-urlarg-7">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="lifeTime">
+   <b><a href="#lifeTime">#lifeTime</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-lifeTime-1">9.1. 
+Requirements for a New Scheme</a>
+    <li><a href="#ref-for-lifeTime-2">9.5.1. 
+Methods and Parameters</a>
+    <li><a href="#ref-for-lifeTime-3">9.5.2. 
+Examples of Blob URL Creation and Revocation</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="BlobURLStore">
+   <b><a href="#BlobURLStore">#BlobURLStore</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-BlobURLStore-1">4.3.2. 
+The close method</a>
+    <li><a href="#ref-for-BlobURLStore-2">9.4.3. 
+Network Errors</a> <a href="#ref-for-BlobURLStore-3">(2)</a>
+    <li><a href="#ref-for-BlobURLStore-4">9.5.1. 
+Methods and Parameters</a> <a href="#ref-for-BlobURLStore-5">(2)</a> <a href="#ref-for-BlobURLStore-6">(3)</a> <a href="#ref-for-BlobURLStore-7">(4)</a> <a href="#ref-for-BlobURLStore-8">(5)</a> <a href="#ref-for-BlobURLStore-9">(6)</a> <a href="#ref-for-BlobURLStore-10">(7)</a>
+    <li><a href="#ref-for-BlobURLStore-11">9.6. 
+Lifetime of Blob URLs</a> <a href="#ref-for-BlobURLStore-12">(2)</a> <a href="#ref-for-BlobURLStore-13">(3)</a> <a href="#ref-for-BlobURLStore-14">(4)</a> <a href="#ref-for-BlobURLStore-15">(5)</a> <a href="#ref-for-BlobURLStore-16">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="revokeList">
+   <b><a href="#revokeList">#revokeList</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-revokeList-1">9.6. 
+Lifetime of Blob URLs</a> <a href="#ref-for-revokeList-2">(2)</a> <a href="#ref-for-revokeList-3">(3)</a> <a href="#ref-for-revokeList-4">(4)</a> <a href="#ref-for-revokeList-5">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="add-an-entry">
+   <b><a href="#add-an-entry">#add-an-entry</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-add-an-entry-1">9.5.1. 
+Methods and Parameters</a> <a href="#ref-for-add-an-entry-2">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="add-an-entry-revoke">
+   <b><a href="#add-an-entry-revoke">#add-an-entry-revoke</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-add-an-entry-revoke-1">9.5.1. 
+Methods and Parameters</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="removeTheEntry">
+   <b><a href="#removeTheEntry">#removeTheEntry</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-removeTheEntry-1">4.3.2. 
+The close method</a>
+    <li><a href="#ref-for-removeTheEntry-2">9.5.1. 
+Methods and Parameters</a>
+    <li><a href="#ref-for-removeTheEntry-3">9.6. 
+Lifetime of Blob URLs</a>
+   </ul>
+  </aside>
+<script>/* script-dfn-panel */
+
         document.body.addEventListener("click", function(e) {
             var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
             // Find the dfn element or panel, if any, that was clicked on.
             var el = e.target;
             var target;
+            var hitALink = false;
             while(el.parentElement) {
-                if(el.tagName == "DFN") {
-                    target = "dfn";
-                    break;
+                if(el.tagName == "A") {
+                    // Clicking on a link in a <dfn> shouldn't summon the panel
+                    hitALink = true;
                 }
-                if(/H\d/.test(el.tagName) && el.getAttribute('data-dfn-type') != null) {
+                if(el.classList.contains("dfn-paneled")) {
                     target = "dfn";
                     break;
                 }
@@ -4409,15 +5430,29 @@ partial interface <a class="idl-code" data-link-type="interface" href="https://u
                     el.classList.remove("activated");
                 });
             }
-            if(target == "dfn") {
+            if(target == "dfn" && !hitALink) {
                 // open the panel
-                var dfnPanel = el.querySelector(".dfn-panel");
+                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
                 if(dfnPanel) {
+                    console.log(dfnPanel);
                     dfnPanel.classList.add("on");
+                    var rect = el.getBoundingClientRect();
+                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+                    dfnPanel.style.top = window.scrollY + rect.top + "px";
+                    var panelRect = dfnPanel.getBoundingClientRect();
+                    var panelWidth = panelRect.right - panelRect.left;
+                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                        // Reposition, because the panel is overflowing
+                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+                    }
+                } else {
+                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
                 }
             } else if(target == "dfn-panel") {
                 // Switch it to "activated" state, which pins it.
                 el.classList.add("activated");
+                el.style.left = null;
+                el.style.top = null;
             }
 
         });


### PR DESCRIPTION
In spec drafts circa 2011 a readAsBinaryString() method was present, predating Typed Array and readAsArrayBuffer() support. Per https://github.com/w3c/FileAPI/issues/39 this is supported by all major browsers and used in a variety of libraries, so we should accept it as a web-compat necessity and specify it.