### PR TITLE
Remove definition of Blob.close() and all related terms.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -205,14 +205,6 @@ and has a {{Blob/size}} attribute which is the total number of bytes in the byte
 and a {{Blob/type}} attribute,
 which is an ASCII-encoded string in lower case representing the media type of the <a>byte</a> sequence.
 
-A {{Blob}} must have a <dfn id="readabilityState" for="Blob">readability state</dfn>,
-which is one of <a><code>OPENED</code></a> or <a for="Blob/readability state"><code>CLOSED</code></a>.
-A {{Blob}} that refers to a <a>byte</a> sequence,
-including one of 0 bytes,
-is said to be in the <dfn id="dfn-openState" for="Blob/readability state"><code>OPENED</code></dfn> <a>readability state</a>.
-A {{Blob}} is said to be <dfn id="closed" for=Blob>closed</dfn> if its {{Blob/close()}} method has been called.
-A {{Blob}} that is <a for=Blob>closed</a> is said to be in the <dfn id="dfn-closedState" for="Blob/readability state"><code>CLOSED</code></dfn> <a>readability state</a>.
-
 Each {{Blob}} must have an internal <dfn id="snapshot-state" for=Blob>snapshot state</dfn>,
 which must be initially set to the state of the underlying storage,
 if any such underlying storage exists,
@@ -226,15 +218,11 @@ interface Blob {
 
   readonly attribute unsigned long long size;
   readonly attribute DOMString type;
-  readonly attribute boolean isClosed;
 
-  //slice Blob into byte-ranged chunks
-
+  // slice Blob into byte-ranged chunks
   Blob slice([Clamp] optional long long start,
             [Clamp] optional long long end,
             optional DOMString contentType);
-  void close();
-
 };
 
 dictionary BlobPropertyBag {
@@ -252,8 +240,7 @@ When the {{Blob()}} constructor is invoked,
 user agents must run the following steps:
 
 1. If invoked with zero parameters,
-  return a new {{Blob}} object with its <a>readability state</a> set to <a><code>OPENED</code></a>,
-  consisting of 0 bytes,
+  return a new {{Blob}} object consisting of 0 bytes,
   with {{Blob/size}} set to 0,
   and with {{Blob/type}} set to the empty string.
 
@@ -289,8 +276,7 @@ user agents must run the following steps:
     then set |t| to the empty string and return from these substeps.
   2. Convert every character in |t| to [=ASCII lowercase=].
 
-6. Return a {{Blob}} object with its <a>readability state</a> set to <a><code>OPENED</code></a>,
-  referring to |bytes| as its associated <a>byte</a> sequence,
+6. Return a {{Blob}} object referring to |bytes| as its associated <a>byte</a> sequence,
   with its {{Blob/size}} set to the length of |bytes|,
   and its {{Blob/type}} set to the value of |t| from the substeps above.
 
@@ -349,8 +335,6 @@ Attributes</h3>
   <dd>Returns the size of the <a>byte</a> sequence in number of bytes.
     On getting, conforming user agents must return the total number of bytes that can be read by a {{FileReader}} or {{FileReaderSync}} object,
     or 0 if the {{Blob}} has no bytes to be read.
-    If the {{Blob}} has a readability state of <a for="Blob/readability state"><code>CLOSED</code></a>
-    then {{Blob/size}} must return 0.
 
   <dt><dfn id="dfn-type">type</dfn>
   <dd>The ASCII-encoded string in lower case representing the media type of the {{Blob}}.
@@ -376,13 +360,6 @@ Attributes</h3>
     Note: Use of the {{Blob/type}} attribute informs the <a>encoding determination</a>
     and <a href="#processing-media-types">parsing the Content-Type header</a>
     when <a>dereferencing</a> <a>Blob URLs</a>.
-
-  <dt><dfn id="dfn-isClosed">isClosed</dfn>
-  <dd>The boolean value that indicates whether the {{Blob}} is in the <a for="Blob/readability state"><code>CLOSED</code></a> <a>readability state</a>.
-    On getting, user agents must return <code>false</code>
-    if the {{Blob}} is in the <a><code>OPENED</code></a> <a>readability state</a>,
-    and <code>true</code> if the {{Blob}} is in the <a for="Blob/readability state"><code>CLOSED</code></a> <a>readability state</a>
-    as a result of the {{Blob/close()}} method being called.
 </dl>
 
 
@@ -439,12 +416,6 @@ It must act as follows:
 6. Return a new {{Blob}} object |S| with the following characteristics:
 
   <ol type="a">
-    <li>|S| has a <a>readability state</a> equal to that of |O|'s <a>readability state</a>.
-
-      Note: The <a>readability state</a> of the <a>context object</a> is retained
-      by the {{Blob}} object returned by the {{Blob/slice()}} call;
-      this has implications on whether the returned {{Blob}} is actually usable
-      for <a>read operation</a>s or as a <a>Blob URL</a>.
     <li>|S| refers to |span| consecutive <a>byte</a>s from |O|,
       beginning with the <a>byte</a> at byte-order position |relativeStart|.
     <li>|S|.{{Blob/size}} = |span|.
@@ -482,19 +453,6 @@ It must act as follows:
     }
   </pre>
 </div>
-
-<h4 id="close-method">
-The close method</h4>
-
-The <dfn id="dfn-close" method for=Blob>close()</dfn> method is said to <a lt="closed" for=Blob>close</a> a {{Blob}},
-and must act as follows:
-
-1. If the <a>readability state</a> of the <a>context object</a> is <a for="Blob/readability state"><code>CLOSED</code></a>,
-  <a>terminate this algorithm</a>.
-2. Otherwise, set the <a>readability state</a> of the <a>context object</a> to <a for="Blob/readability state"><code>CLOSED</code></a>.
-3. If the <a>context object</a> has an entry in the <a>Blob URL Store</a>,
-  <a>remove the entry</a> that corresponds to the <a>context object</a>.
-
 
 <!--
 ████████ ████ ██       ████████
@@ -604,7 +562,6 @@ user agents must run the following steps:
     the {{FilePropertyBag/lastModified}} member could be a {{Date}} object [[ECMA-262]].
 
 4. Return a new {{File}} object |F| such that:
-  1. |F| has a <a>readability state</a> of <a><code>OPENED</code></a>.
   2. |F| refers to the |bytes| <a>byte</a> sequence.
   3. |F|.{{Blob/size}} is set to the number of total bytes in |bytes|.
   4. |F|.{{File/name}} is set to |n|.
@@ -791,9 +748,6 @@ run the following steps:
   Set the |length| on |s| to the {{Blob/size}} of |b|.
   While there are still bytes to be read in |b|,
   perform the following substeps:
-
-  Note: The algorithm assumes that invoking methods have checked for <a>readability state</a>.
-  A {{Blob}} in the <a for="Blob/readability state"><code>CLOSED</code></a> state must not have a <a>read operation</a> called on it.
 
   1. If the <a>synchronous flag</a> is set, follow the steps below:
     1. Let |bytes| be the byte sequence that results from reading a <a>chunk</a> from |b|.
@@ -1036,12 +990,6 @@ the user agent must run the steps below.
 
 1. If {{FileReader/readyState}} = {{FileReader/LOADING}}
   throw an {{InvalidStateError}} exception and <a>terminate this algorithm</a>.
-2. If the <code>blob</code> is in the <a for="Blob/readability state">CLOSED</a> <a>readability state</a>,
-  set the {{error!!attribute}} attribute of the <a>context object</a>
-  to return an {{InvalidStateError}} exception
-  and <a>fire a progress event</a> called {{error!!event}}
-  at the <a>context object</a>.
-  <a>Terminate this algorithm</a>.
 3. Otherwise set {{FileReader/readyState}} to {{FileReader/LOADING}}.
 4. Initiate an <a>annotated task read operation</a> using the <code>blob</code> argument as |input|
   and handle <a lt="queue a task">tasks queued</a> on the <a>file reading task source</a> per below.
@@ -1076,11 +1024,6 @@ When the <dfn method for=FileReader id="dfn-readAsText">readAsText(blob, label)<
 the user agent must run the steps below.
 
 1. If {{FileReader/readyState}} = {{FileReader/LOADING}} throw an {{InvalidStateError}} and <a>terminate this algorithm</a>.
-2. If the <code>blob</code> is in the <a for="Blob/readability state">CLOSED</a> <a>readability state</a>,
-  set the {{error!!attribute}} attribute of the <a>context object</a>
-  to return an {{InvalidStateError}} exception
-  and <a>fire a progress event</a> called {{error!!event}} at the <a>context object</a>.
-  <a>Terminate this algorithm</a>.
 3. Otherwise set {{FileReader/readyState}} to {{FileReader/LOADING}}.
 4. Initiate an <a>annotated task read operation</a> using the <code>blob</code> argument as |input|
   and handle <a lt="queue a task">tasks queued</a> on the <a>file reading task source</a> per below.
@@ -1106,11 +1049,6 @@ When the <dfn method for=FileReader id="dfn-readAsArrayBuffer">readAsArrayBuffer
 the user agent must run the steps below.
 
 1. If {{FileReader/readyState}} = {{FileReader/LOADING}} throw an {{InvalidStateError}} exception and <a>terminate this algorithm</a>.
-2. If the <code>blob</code> is in the <a for="Blob/readability state">CLOSED</a> <a>readability state</a>,
-  set the {{error!!attribute}} attribute of the <a>context object</a>
-  to return an {{InvalidStateError}} exception
-  and <a>fire a progress event</a> called {{error!!event}} at the <a>context object</a>.
-  <a>Terminate this algorithm</a>.
 3. Otherwise set {{FileReader/readyState}} to {{FileReader/LOADING}}.
 4. Initiate an <a>annotated task read operation</a> using the <code>blob</code> argument as |input|
   and handle <a lt="queue a task">tasks queued</a> on the <a>file reading task source</a> per below.
@@ -1135,11 +1073,6 @@ When the <dfn method for=FileReader id="dfn-readAsBinaryString">readAsBinaryStri
 the user agent must run the steps below.
 
 1. If {{FileReader/readyState}} = {{FileReader/LOADING}} throw an {{InvalidStateError}} exception and <a>terminate this algorithm</a>.
-2. If the <code>blob</code> is in the <a for="Blob/readability state">CLOSED</a> <a>readability state</a>,
-  set the {{error!!attribute}} attribute of the <a>context object</a>
-  to return an {{InvalidStateError}} exception
-  and <a>fire a progress event</a> called {{error!!event}} at the <a>context object</a>.
-  <a>Terminate this algorithm</a>.
 3. Otherwise set {{FileReader/readyState}} to {{FileReader/LOADING}}.
 4. Initiate an <a>annotated task read operation</a> using the <code>blob</code> argument as |input|
   and handle <a lt="queue a task">tasks queued</a> on the <a>file reading task source</a> per below.
@@ -1392,9 +1325,6 @@ the following steps must be followed:
 1. If {{FileReader/readyState}} = {{FileReader/LOADING}}
   throw an {{InvalidStateError}} exception
   and <a>terminate this algorithm</a>.
-2. If the <code>blob</code> has been closed through the {{Blob/close()}} method,
-  throw an {{InvalidStateError}} exception
-  and <a>terminate this algorithm</a>.
 3. Otherwise, initiate a <a>read operation</a> using the <code>blob</code> argument,
   and with the <a>synchronous flag</a> *set*.
   If the read operation returns failure,
@@ -1411,9 +1341,6 @@ When the <dfn method for=FileReaderSync id="dfn-readAsDataURLSync">readAsDataURL
 the following steps must be followed:
 
 1. If {{FileReader/readyState}} = {{FileReader/LOADING}}
-  throw an {{InvalidStateError}} exception
-  and <a>terminate this algorithm</a>.
-2. If the <code>blob</code> has been closed through the {{Blob/close()}} method,
   throw an {{InvalidStateError}} exception
   and <a>terminate this algorithm</a>.
 3. Otherwise, initiate a <a>read operation</a> using the <code>blob</code> argument,
@@ -1438,9 +1365,6 @@ the following steps must be followed:
 1. If {{FileReader/readyState}} = {{FileReader/LOADING}}
   throw an {{InvalidStateError}} exception
   and <a>terminate this algorithm</a>.
-2. If the <code>blob</code> has been closed through the {{Blob/close()}} method,
-  throw an {{InvalidStateError}} exception
-  and <a>terminate this algorithm</a>.
 3. Otherwise, initiate a <a>read operation</a> using the <code>blob</code> argument,
   and with the <a>synchronous flag</a> *set*.
   If the <a>read operation</a> returns failure,
@@ -1455,9 +1379,6 @@ When the <dfn method for=FileReaderSync id="dfn-readAsBinaryStringSync">readAsBi
 the following steps must be followed:
 
 1. If {{FileReader/readyState}} = {{FileReader/LOADING}}
-  throw an {{InvalidStateError}} exception
-  and <a>terminate this algorithm</a>.
-2. If the <code>blob</code> has been closed through the {{Blob/close()}} method,
   throw an {{InvalidStateError}} exception
   and <a>terminate this algorithm</a>.
 3. Otherwise, initiate a <a>read operation</a> using the <code>blob</code> argument,
@@ -1793,8 +1714,6 @@ Network errors are used when:
 
 * Any [=/request=] method other than GET is used.
 * The <a>Blob URL</a> does not have an entry in the <a>Blob URL Store</a>.
-* The Blob has been <a for=Blob>closed</a>;
-  this also results in the <a>Blob URL</a> not having an entry in the <a>Blob URL Store</a>.
 * A [=CORS protocol|cross-origin requests=] is made on a <a>Blob URL</a>.
 * A security error has occurred.
 
@@ -1869,25 +1788,16 @@ Methods and Parameters</h4>
   <dd>Returns a unique <a>Blob URL</a>.
     This method must act as follows:
 
-    1. If called with a {{Blob}} argument that has a <a>readability state</a> of <a for="Blob/readability state"><code>CLOSED</code></a>,
-      user agents must return the output of the <a>Serialization of a Blob URL</a> algorithm.
-
-      Note: No entry is added to the <a>Blob URL Store</a>;
-      consequently, when this <a>Blob URL</a> is <a>dereferenced</a>,
-      a <a>network error</a> occurs.
-
-    2. Otherwise, user agents must run the following sub-steps:
-      1. Let |url| be the result of the <a>Serialization of a Blob URL</a> algorithm.
-      2. <a>Add an entry to the Blob URL Store</a> for |url| and |blob|.
-      3. Return |url|.
+    1. Let |url| be the result of the <a>Serialization of a Blob URL</a> algorithm.
+    2. <a>Add an entry to the Blob URL Store</a> for |url| and |blob|.
+    3. Return |url|.
 
   <dt>The <dfn method for=URL id="dfn-revokeObjectURL">revokeObjectURL(url)</dfn> static method
   <dd>Revokes the <a>Blob URL</a> provided in the string {{url!!argument}}
     by removing the corresponding entry from the <a>Blob URL Store</a>.
     This method must act as follows:
 
-    1. If the {{url!!argument}} refers to a {{Blob}} that has a <a>readability state</a> of <a for="Blob/readability state"><code>CLOSED</code></a>
-      OR if the value provided for the {{url!!argument}} argument is not a <a>Blob URL</a>,
+    1. If the value provided for the {{url!!argument}} argument is not a <a>Blob URL</a>,
       OR if the value provided for the {{url!!argument}} argument does not have an entry in the <a>Blob URL Store</a>,
       this method call does nothing.
       User agents may display a message on the error console.

--- a/index.html
+++ b/index.html
@@ -1510,7 +1510,6 @@ These kinds of behaviors are defined in the appropriate affiliated specification
        <a href="#methodsandparams-blob"><span class="secno">3.3</span> <span class="content"> Methods and Parameters</span></a>
        <ol class="toc">
         <li><a href="#slice-method-algo"><span class="secno">3.3.1</span> <span class="content"> The slice method</span></a>
-        <li><a href="#close-method"><span class="secno">3.3.2</span> <span class="content"> The close method</span></a>
        </ol>
      </ol>
     <li>
@@ -1746,14 +1745,7 @@ this is the same time that is conceptually "<code>0</code>" in ECMA-262 <a data-
 and has a <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-1">size</a></code> attribute which is the total number of bytes in the byte sequence,
 and a <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-1">type</a></code> attribute,
 which is an ASCII-encoded string in lower case representing the media type of the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a> sequence.</p>
-   <p>A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-5">Blob</a></code> must have a <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-noexport="" id="readabilityState">readability state</dfn>,
-which is one of <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-1"><code>OPENED</code></a> or <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-1"><code>CLOSED</code></a>.
-A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-6">Blob</a></code> that refers to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a> sequence,
-including one of 0 bytes,
-is said to be in the <dfn class="dfn-paneled" data-dfn-for="Blob/readability state" data-dfn-type="dfn" data-noexport="" id="dfn-openState"><code>OPENED</code></dfn> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-1">readability state</a>.
-A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-7">Blob</a></code> is said to be <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-noexport="" id="closed">closed</dfn> if its <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-1">close()</a></code> method has been called.
-A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-8">Blob</a></code> that is <a data-link-type="dfn" href="#closed" id="ref-for-closed-1">closed</a> is said to be in the <dfn class="dfn-paneled" data-dfn-for="Blob/readability state" data-dfn-type="dfn" data-noexport="" id="dfn-closedState"><code>CLOSED</code></dfn> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-2">readability state</a>.</p>
-   <p>Each <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-9">Blob</a></code> must have an internal <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-noexport="" id="snapshot-state">snapshot state</dfn>,
+   <p>Each <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-5">Blob</a></code> must have an internal <dfn class="dfn-paneled" data-dfn-for="Blob" data-dfn-type="dfn" data-noexport="" id="snapshot-state">snapshot state</dfn>,
 which must be initially set to the state of the underlying storage,
 if any such underlying storage exists,
 and must be preserved through <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclone">StructuredClone</a>.
@@ -1764,22 +1756,18 @@ Further normative definition of <a data-link-type="dfn" href="#snapshot-state" i
 
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long" href="#dfn-size" id="ref-for-dfn-size-2">size</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dfn-type" id="ref-for-dfn-type-2">type</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dfn-isClosed" id="ref-for-dfn-isClosed-1">isClosed</a>;
 
-  //slice Blob into byte-ranged chunks
-
-  <a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-10">Blob</a> <a class="nv idl-code" data-link-type="method" href="#dfn-slice" id="ref-for-dfn-slice-1">slice</a>([<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Clamp">Clamp</a>] <span class="kt">optional</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-start" id="ref-for-dfn-start-1">start</a>,
+  // slice Blob into byte-ranged chunks
+  <a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-6">Blob</a> <a class="nv idl-code" data-link-type="method" href="#dfn-slice" id="ref-for-dfn-slice-1">slice</a>([<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Clamp">Clamp</a>] <span class="kt">optional</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-start" id="ref-for-dfn-start-1">start</a>,
             [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Clamp">Clamp</a>] <span class="kt">optional</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-end" id="ref-for-dfn-end-1">end</a>,
             <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-contentTypeBlob" id="ref-for-dfn-contentTypeBlob-1">contentType</a>);
-  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-close" id="ref-for-dfn-close-2">close</a>();
-
 };
 
 <span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dfn-BlobPropertyBag">BlobPropertyBag</dfn> {
   <span class="kt">DOMString</span> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dfn-BPtype" id="ref-for-dfn-BPtype-1">type</a> = "";
 };
 
-<span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#BufferSource">BufferSource</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-11">Blob</a> <span class="kt">or</span> <span class="kt">USVString</span>) <dfn class="nv dfn-paneled idl-code" data-dfn-type="typedef" data-export="" id="typedefdef-blobpart">BlobPart</dfn>;
+<span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#BufferSource">BufferSource</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-7">Blob</a> <span class="kt">or</span> <span class="kt">USVString</span>) <dfn class="nv dfn-paneled idl-code" data-dfn-type="typedef" data-export="" id="typedefdef-blobpart">BlobPart</dfn>;
 </pre>
    <h3 class="heading settled" data-level="3.1" id="constructorBlob"><span class="secno">3.1. </span><span class="content"> Constructors</span><a class="self-link" href="#constructorBlob"></a></h3>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-blob-blob" id="ref-for-dom-blob-blob-1">Blob()</a></code> constructor can be invoked with zero or more parameters.
@@ -1788,8 +1776,7 @@ user agents must run the following steps:</p>
    <ol>
     <li data-md="">
      <p>If invoked with zero parameters,
-return a new <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-12">Blob</a></code> object with its <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-3">readability state</a> set to <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-2"><code>OPENED</code></a>,
-consisting of 0 bytes,
+return a new <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-8">Blob</a></code> object consisting of 0 bytes,
 with <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-3">size</a></code> set to 0,
 and with <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-3">type</a></code> set to the empty string.</p>
     <li data-md="">
@@ -1809,16 +1796,16 @@ For 0 ≤ <var>i</var> &lt; <var>length</var>, repeat the following steps:</p>
          <p>Append the result of <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-encode">UTF-8 encoding</a> <var>s</var> to <var>bytes</var>.</p>
          <p class="note" role="note"><span>Note:</span> The algorithm from WebIDL <a data-link-type="biblio" href="#biblio-webidl">[WebIDL]</a> replaces unmatched surrogates in an invalid utf-16 string
 with U+FFFD replacement characters.
-Scenarios exist when the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-13">Blob</a></code> constructor may result in some data loss
+Scenarios exist when the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-9">Blob</a></code> constructor may result in some data loss
 due to lost or scrambled character sequences.</p>
        </ol>
       <li data-md="">
        <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#BufferSource">BufferSource</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">get
 a copy of the bytes held by the buffer source</a>, and append those bytes to <var>bytes</var>.</p>
       <li data-md="">
-       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-14">Blob</a></code>,
+       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-10">Blob</a></code>,
 append the bytes it represents to <var>bytes</var>.
-The <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-4">type</a></code> of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-15">Blob</a></code> array element is ignored and will not affect <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-5">type</a></code> of returned <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-16">Blob</a></code> object.</p>
+The <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-4">type</a></code> of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-11">Blob</a></code> array element is ignored and will not affect <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-5">type</a></code> of returned <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-12">Blob</a></code> object.</p>
      </ol>
     <li data-md="">
      <p>If the <code class="idl"><a data-link-type="idl" href="#dfn-BPtype" id="ref-for-dfn-BPtype-2">type</a></code> member of the optional <code>options</code> argument is provided
@@ -1833,8 +1820,7 @@ then set <var>t</var> to the empty string and return from these substeps.</p>
        <p>Convert every character in <var>t</var> to <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-lowercase">ASCII lowercase</a>.</p>
      </ol>
     <li data-md="">
-     <p>Return a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-17">Blob</a></code> object with its <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-4">readability state</a> set to <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-3"><code>OPENED</code></a>,
-referring to <var>bytes</var> as its associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a> sequence,
+     <p>Return a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-13">Blob</a></code> object referring to <var>bytes</var> as its associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a> sequence,
 with its <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-4">size</a></code> set to the length of <var>bytes</var>,
 and its <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-6">type</a></code> set to the value of <var>t</var> from the substeps above.</p>
    </ol>
@@ -1848,7 +1834,7 @@ and its <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-d
       <li data-md="">
        <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#BufferSource">BufferSource</a></code> elements.</p>
       <li data-md="">
-       <p><code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-18">Blob</a></code> elements.</p>
+       <p><code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-14">Blob</a></code> elements.</p>
       <li data-md="">
        <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> elements.</p>
      </ul>
@@ -1858,7 +1844,7 @@ and its <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-d
      <ul>
       <li data-md="">
        <p><dfn class="dfn-paneled idl-code" data-dfn-for="BlobPropertyBag" data-dfn-type="dict-member" data-export="" id="dfn-BPtype">type</dfn>,
-the ASCII-encoded string in lower case representing the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-19">Blob</a></code>.
+the ASCII-encoded string in lower case representing the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-15">Blob</a></code>.
 Normative conditions for this member are provided in the <a href="#constructorBlob">§3.1 Constructors</a>.</p>
      </ul>
    </dl>
@@ -1892,12 +1878,11 @@ Normative conditions for this member are provided in the <a href="#constructorBl
     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" id="dfn-size">size</dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long-long">unsigned long long</a>, readonly</span>
     <dd>Returns the size of the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a> sequence in number of bytes.
     On getting, conforming user agents must return the total number of bytes that can be read by a <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-2">FileReader</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-1">FileReaderSync</a></code> object,
-    or 0 if the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-20">Blob</a></code> has no bytes to be read.
-    If the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-21">Blob</a></code> has a readability state of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-2"><code>CLOSED</code></a> then <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-5">size</a></code> must return 0. 
+    or 0 if the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-16">Blob</a></code> has no bytes to be read. 
     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" id="dfn-type">type</dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
     <dd>
-     The ASCII-encoded string in lower case representing the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-22">Blob</a></code>.
-    On getting, user agents must return the type of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-23">Blob</a></code> as an ASCII-encoded string in lower case,
+     The ASCII-encoded string in lower case representing the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-17">Blob</a></code>.
+    On getting, user agents must return the type of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-18">Blob</a></code> as an ASCII-encoded string in lower case,
     such that when it is converted to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a> sequence,
     it is a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">parsable MIME type</a>,
     or the empty string – 0 bytes – if the type cannot be determined. 
@@ -1905,29 +1890,25 @@ Normative conditions for this member are provided in the <a href="#constructorBl
     and through the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-2">slice()</a></code> call;
     in these cases, further normative conditions for this attribute are in <a href="#constructorBlob">§3.1 Constructors</a>, <a href="#file-constructor">§4.1 Constructor</a>,
     and <a href="#slice-method-algo">§3.3.1 The slice method</a> respectively.
-    User agents can also determine the <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-8">type</a></code> of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-24">Blob</a></code>,
+    User agents can also determine the <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-8">type</a></code> of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-19">Blob</a></code>,
     especially if the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a> sequence is from an on-disk file;
     in this case, further normative conditions are in the <a data-link-type="dfn" href="#file-type-guidelines" id="ref-for-file-type-guidelines-1">file type guidelines</a>.</p>
-     <p class="note" role="note"><span>Note:</span> The type <var>t</var> of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-25">Blob</a></code> is considered a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">parsable MIME type</a>,
+     <p class="note" role="note"><span>Note:</span> The type <var>t</var> of a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-20">Blob</a></code> is considered a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">parsable MIME type</a>,
     if performing the <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">parse a MIME type</a> algorithm to a byte sequence converted from
     the ASCII-encoded string representing the Blob object’s type does not return undefined.</p>
      <p class="note" role="note"><span>Note:</span> Use of the <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-9">type</a></code> attribute informs the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-1">encoding determination</a> and <a href="#processing-media-types">parsing the Content-Type header</a> when <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-1">dereferencing</a> <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-1">Blob URLs</a>.</p>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="attribute" data-export="" id="dfn-isClosed">isClosed</dfn> , <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
-    <dd>The boolean value that indicates whether the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-26">Blob</a></code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-3"><code>CLOSED</code></a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-5">readability state</a>.
-    On getting, user agents must return <code>false</code> if the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-27">Blob</a></code> is in the <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-4"><code>OPENED</code></a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-6">readability state</a>,
-    and <code>true</code> if the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-28">Blob</a></code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-4"><code>CLOSED</code></a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-7">readability state</a> as a result of the <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-3">close()</a></code> method being called. 
    </dl>
    <h3 class="heading settled" data-level="3.3" id="methodsandparams-blob"><span class="secno">3.3. </span><span class="content"> Methods and Parameters</span><a class="self-link" href="#methodsandparams-blob"></a></h3>
    <h4 class="heading settled" data-level="3.3.1" id="slice-method-algo"><span class="secno">3.3.1. </span><span class="content"> The slice method</span><a class="self-link" href="#slice-method-algo"></a></h4>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="method" data-export="" data-lt="slice(start, end, contentType), slice(start, end), slice(start), slice()" id="dfn-slice">slice()</dfn> method
-returns a new <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-29">Blob</a></code> object with bytes ranging from
+returns a new <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-21">Blob</a></code> object with bytes ranging from
 the optional <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-2">start</a></code> parameter
 up to but not including the optional <code class="idl"><a data-link-type="idl" href="#dfn-end" id="ref-for-dfn-end-2">end</a></code> parameter,
 and with a <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-10">type</a></code> attribute that is the value of the optional <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-contentTypeBlob" id="ref-for-dfn-contentTypeBlob-2">contentType</a></code> parameter.
 It must act as follows:</p>
    <ol>
     <li data-md="">
-     <p>Let <var>O</var> be the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-30">Blob</a></code> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> on which the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-3">slice()</a></code> method is being called.</p>
+     <p>Let <var>O</var> be the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-22">Blob</a></code> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> on which the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-3">slice()</a></code> method is being called.</p>
     <li data-md="">
      <p>The optional <dfn class="dfn-paneled idl-code" data-dfn-for="Blob/slice(start, end, contentType)" data-dfn-type="argument" data-export="" id="dfn-start">start</dfn> parameter
 is a value for the start point of a <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-4">slice()</a></code> call,
@@ -1936,7 +1917,7 @@ with the zeroth position representing the first byte.
 User agents must process <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-5">slice()</a></code> with <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-3">start</a></code> normalized according to the following:</p>
      <ol type="a">
       <li>If the optional <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-4">start</a></code> parameter is not used as a parameter when making this call, let <var>relativeStart</var> be 0. 
-      <li>If <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-5">start</a></code> is negative, let <var>relativeStart</var> be <code>max((<code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-6">size</a></code> + <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-6">start</a></code>), 0)</code>. 
+      <li>If <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-5">start</a></code> is negative, let <var>relativeStart</var> be <code>max((<code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-5">size</a></code> + <code class="idl"><a data-link-type="idl" href="#dfn-start" id="ref-for-dfn-start-6">start</a></code>), 0)</code>. 
       <li>Else, let <var>relativeStart</var> be <code>min(start, size)</code>. 
      </ol>
     <li data-md="">
@@ -1944,7 +1925,7 @@ User agents must process <code class="idl"><a data-link-type="idl" href="#dfn-sl
 is a value for the end point of a <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-6">slice()</a></code> call.
 User agents must process <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-7">slice()</a></code> with <code class="idl"><a data-link-type="idl" href="#dfn-end" id="ref-for-dfn-end-3">end</a></code> normalized according to the following:</p>
      <ol type="a">
-      <li>If the optional <code class="idl"><a data-link-type="idl" href="#dfn-end" id="ref-for-dfn-end-4">end</a></code> parameter is not used as a parameter when making this call, let <var>relativeEnd</var> be <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-7">size</a></code>. 
+      <li>If the optional <code class="idl"><a data-link-type="idl" href="#dfn-end" id="ref-for-dfn-end-4">end</a></code> parameter is not used as a parameter when making this call, let <var>relativeEnd</var> be <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-6">size</a></code>. 
       <li>If <code class="idl"><a data-link-type="idl" href="#dfn-end" id="ref-for-dfn-end-5">end</a></code> is negative, let <var>relativeEnd</var> be <code>max((size + end), 0)</code>. 
       <li>Else, let <var>relativeEnd</var> be <code>min(end, size)</code>. 
      </ol>
@@ -1967,22 +1948,16 @@ then set <var>relativeContentType</var> to the empty string and return from thes
     <li data-md="">
      <p>Let <var>span</var> be <code>max((relativeEnd - relativeStart), 0)</code>.</p>
     <li data-md="">
-     <p>Return a new <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-31">Blob</a></code> object <var>S</var> with the following characteristics:</p>
+     <p>Return a new <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-23">Blob</a></code> object <var>S</var> with the following characteristics:</p>
      <ol type="a">
-      <li>
-       <var>S</var> has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-8">readability state</a> equal to that of <var>O</var>’s <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-9">readability state</a>. 
-       <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-10">readability state</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> is retained
-    by the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-32">Blob</a></code> object returned by the <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-9">slice()</a></code> call;
-    this has implications on whether the returned <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-33">Blob</a></code> is actually usable
-    for <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-1">read operation</a>s or as a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-2">Blob URL</a>.</p>
       <li><var>S</var> refers to <var>span</var> consecutive <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a>s from <var>O</var>,
     beginning with the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a> at byte-order position <var>relativeStart</var>. 
-      <li><var>S</var>.<code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-8">size</a></code> = <var>span</var>. 
+      <li><var>S</var>.<code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-7">size</a></code> = <var>span</var>. 
       <li><var>S</var>.<code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-11">type</a></code> = <var>relativeContentType</var>. 
      </ol>
    </ol>
    <div class="example" id="example-5fb7503c">
-    <a class="self-link" href="#example-5fb7503c"></a> The examples below illustrate the different types of <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-10">slice()</a></code> calls possible. Since the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-5">File</a></code> interface inherits from the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-34">Blob</a></code> interface, examples are based on the use of the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-6">File</a></code> interface. 
+    <a class="self-link" href="#example-5fb7503c"></a> The examples below illustrate the different types of <code class="idl"><a data-link-type="idl" href="#dfn-slice" id="ref-for-dfn-slice-9">slice()</a></code> calls possible. Since the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-5">File</a></code> interface inherits from the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-24">Blob</a></code> interface, examples are based on the use of the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-6">File</a></code> interface. 
 <pre class="lang-javascript highlight"><span class="c1">// obtain input element through DOM
 </span>
 <span class="kd">var</span> file <span class="o">=</span> document<span class="p">.</span>getElementById<span class="p">(</span><span class="s1">'file'</span><span class="p">)</span><span class="p">.</span>files<span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">;</span>
@@ -2009,19 +1984,8 @@ then set <var>relativeContentType</var> to the empty string and return from thes
 <span class="p">}</span>
 </pre>
    </div>
-   <h4 class="heading settled" data-level="3.3.2" id="close-method"><span class="secno">3.3.2. </span><span class="content"> The close method</span><a class="self-link" href="#close-method"></a></h4>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Blob" data-dfn-type="method" data-export="" id="dfn-close">close()</dfn> method is said to <a data-link-type="dfn" href="#closed" id="ref-for-closed-2">close</a> a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-35">Blob</a></code>,
-and must act as follows:</p>
-   <ol>
-    <li data-md="">
-     <p>If the <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-11">readability state</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> is <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-5"><code>CLOSED</code></a>, <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-1">terminate this algorithm</a>.</p>
-    <li data-md="">
-     <p>Otherwise, set the <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-12">readability state</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> to <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-6"><code>CLOSED</code></a>.</p>
-    <li data-md="">
-     <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> has an entry in the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-1">Blob URL Store</a>, <a data-link-type="dfn" href="#removeTheEntry" id="ref-for-removeTheEntry-1">remove the entry</a> that corresponds to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
-   </ol>
    <h2 class="heading settled" data-level="4" id="file"><span class="secno">4. </span><span class="content"> The File Interface</span><a class="self-link" href="#file"></a></h2>
-   <p>A <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-7">File</a></code> object is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-36">Blob</a></code> object with a <code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-1">name</a></code> attribute, which is a string;
+   <p>A <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-7">File</a></code> object is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-25">Blob</a></code> object with a <code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-1">name</a></code> attribute, which is a string;
 it can be created within the web application via a constructor,
 or is a reference to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a> sequence from a file from the underlying (OS) file system.</p>
    <p>If a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-8">File</a></code> object is a reference to a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a> sequence originating from a file on disk,
@@ -2051,7 +2015,7 @@ including statistical methods.</p>
              <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileName" id="ref-for-dfn-fileName-1">fileName</a>,
              <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dfn-FilePropertyBag" id="ref-for-dfn-FilePropertyBag-1">FilePropertyBag</a> <dfn class="nv idl-code" data-dfn-for="File/File(fileBits, fileName, options)" data-dfn-type="argument" data-export="" id="dom-file-file-filebits-filename-options-options">options<a class="self-link" href="#dom-file-file-filebits-filename-options-options"></a></dfn>),
 <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-file">File</dfn> : <a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-37">Blob</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-file">File</dfn> : <a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-26">Blob</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dfn-name" id="ref-for-dfn-name-2">name</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long long" href="#dfn-lastModified" id="ref-for-dfn-lastModified-1">lastModified</a>;
 };
@@ -2082,14 +2046,14 @@ For 0 ≤ i &lt; <var>length</var>, repeat the following steps:</p>
          <p>Append the result of <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-encode">UTF-8 encoding</a> <var>s</var> to <var>bytes</var>.</p>
        </ol>
        <p class="note" role="note"><span>Note:</span> The algorithm from WebIDL <a data-link-type="biblio" href="#biblio-webidl">[WebIDL]</a> replaces unmatched surrogates in an invalid utf-16 string with U+FFFD replacement characters.
-Scenarios exist when the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-38">Blob</a></code> constructor may result in some data loss due to lost or scrambled character sequences.</p>
+Scenarios exist when the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-27">Blob</a></code> constructor may result in some data loss due to lost or scrambled character sequences.</p>
       <li data-md="">
        <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#BufferSource">BufferSource</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">get
 a copy of the bytes held by the buffer source</a>, and append those bytes to <var>bytes</var>.</p>
       <li data-md="">
-       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-39">Blob</a></code>,
+       <p>If <var>element</var> is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-28">Blob</a></code>,
 append the bytes it represents to <var>bytes</var>.
-The <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-14">type</a></code> of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-40">Blob</a></code> argument must be ignored.</p>
+The <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-14">type</a></code> of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-29">Blob</a></code> argument must be ignored.</p>
      </ol>
     <li data-md="">
      <p>Let <var>n</var> be a new string of the same size as the <code class="idl"><a data-link-type="idl" href="#dfn-fileName" id="ref-for-dfn-fileName-2">fileName</a></code> argument to the constructor.
@@ -2120,13 +2084,11 @@ the <code class="idl"><a data-link-type="idl" href="#dfn-FPdate" id="ref-for-dfn
      </ol>
     <li data-md="">
      <p>Return a new <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-14">File</a></code> object <var>F</var> such that:</p>
-     <ol>
-      <li data-md="">
-       <p><var>F</var> has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-13">readability state</a> of <a data-link-type="dfn" href="#dfn-openState" id="ref-for-dfn-openState-5"><code>OPENED</code></a>.</p>
+     <ol start="2">
       <li data-md="">
        <p><var>F</var> refers to the <var>bytes</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a> sequence.</p>
       <li data-md="">
-       <p><var>F</var>.<code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-9">size</a></code> is set to the number of total bytes in <var>bytes</var>.</p>
+       <p><var>F</var>.<code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-8">size</a></code> is set to the number of total bytes in <var>bytes</var>.</p>
       <li data-md="">
        <p><var>F</var>.<code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-3">name</a></code> is set to <var>n</var>.</p>
       <li data-md="">
@@ -2145,7 +2107,7 @@ the <code class="idl"><a data-link-type="idl" href="#dfn-FPdate" id="ref-for-dfn
       <li data-md="">
        <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#BufferSource">BufferSource</a></code> elements.</p>
       <li data-md="">
-       <p><code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-41">Blob</a></code> elements, which includes <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-15">File</a></code> elements.</p>
+       <p><code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-30">Blob</a></code> elements, which includes <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-15">File</a></code> elements.</p>
       <li data-md="">
        <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> elements.</p>
      </ul>
@@ -2187,8 +2149,8 @@ normative conditions for this member are provided in <a href="#file-constructor"
    </dl>
    <p>The <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-18">File</a></code> interface is available on objects that expose an attribute of type <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-1">FileList</a></code>;
 these objects are defined in HTML <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.
-The <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-19">File</a></code> interface, which inherits from <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-42">Blob</a></code>, is immutable,
-and thus represents file data that can be read into memory at the time a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-2">read operation</a> is initiated.
+The <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-19">File</a></code> interface, which inherits from <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-31">Blob</a></code>, is immutable,
+and thus represents file data that can be read into memory at the time a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-1">read operation</a> is initiated.
 User agents must process reads on files that no longer exist at the time of read as <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-1">errors</a>,
 throwing a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception
 if using a <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-2">FileReaderSync</a></code> on a Web Worker <a data-link-type="biblio" href="#biblio-workers">[Workers]</a> or firing an <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-1">error</a></code> event
@@ -2199,14 +2161,14 @@ with the <code class="idl"><a class="idl-code" data-link-type="attribute" href="
 <span class="kd">var</span> date <span class="o">=</span> <span class="k">new</span> Date<span class="p">(</span>file<span class="p">.</span>lastModified<span class="p">)</span><span class="p">;</span>
 println<span class="p">(</span><span class="s2">"You selected the file "</span> <span class="o">+</span> file<span class="p">.</span>name <span class="o">+</span> <span class="s2">" which was modified on "</span> <span class="o">+</span> date<span class="p">.</span>toDateString<span class="p">(</span><span class="p">)</span> <span class="o">+</span> <span class="s2">"."</span><span class="p">)</span><span class="p">;</span>
 
-<span class="p">...</span>
+<span class="p">.</span><span class="p">.</span><span class="p">.</span>
 
 <span class="c1">// Generate a file with a specific last modified date
 </span>
 <span class="kd">var</span> d <span class="o">=</span> <span class="k">new</span> Date<span class="p">(</span><span class="mi">2013</span><span class="p">,</span> <span class="mi">12</span><span class="p">,</span> <span class="mi">5</span><span class="p">,</span> <span class="mi">16</span><span class="p">,</span> <span class="mi">23</span><span class="p">,</span> <span class="mi">45</span><span class="p">,</span> <span class="mi">600</span><span class="p">)</span><span class="p">;</span>
 <span class="kd">var</span> generatedFile <span class="o">=</span> <span class="k">new</span> File<span class="p">(</span><span class="p">[</span><span class="s2">"Rough Draft ...."</span><span class="p">]</span><span class="p">,</span> <span class="s2">"Draft1.txt"</span><span class="p">,</span> <span class="p">{</span>type<span class="o">:</span> <span class="s2">"text/plain"</span><span class="p">,</span> lastModified<span class="o">:</span> d<span class="p">}</span><span class="p">)</span>
 
-<span class="p">...</span>
+<span class="p">.</span><span class="p">.</span><span class="p">.</span>
 </pre>
    </div>
    <h2 class="heading settled" data-level="5" id="filelist-section"><span class="secno">5. </span><span class="content"> The FileList Interface</span><a class="self-link" href="#filelist-section"></a></h2>
@@ -2263,29 +2225,27 @@ which is what is being accessed in the above example.
 Other interfaces with a readonly attribute of type <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-10">FileList</a></code> include the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/interaction.html#datatransfer">DataTransfer</a></code> interface.</p>
    <h2 class="heading settled" data-level="6" id="reading-data-section"><span class="secno">6. </span><span class="content"> Reading Data</span><a class="self-link" href="#reading-data-section"></a></h2>
    <h3 class="heading settled" data-level="6.1" id="readOperationSection"><span class="secno">6.1. </span><span class="content"> The Read Operation</span><a class="self-link" href="#readOperationSection"></a></h3>
-   <p>The algorithm below defines a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-3">read operation</a>,
-which takes a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-43">Blob</a></code> and a <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-1">synchronous flag</a> as input,
+   <p>The algorithm below defines a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-2">read operation</a>,
+which takes a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-32">Blob</a></code> and a <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-1">synchronous flag</a> as input,
 and reads <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#byte">byte</a>s into a byte stream
-which is returned as the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-4">read operation</a>,
+which is returned as the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-3">read operation</a>,
 or else fails along with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-1">failure reason</a>.
-Methods in this specification invoke the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-5">read operation</a> with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-2">synchronous flag</a> either set or unset.</p>
+Methods in this specification invoke the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-4">read operation</a> with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-2">synchronous flag</a> either set or unset.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="synchronousFlag">synchronous flag</dfn> determines if a read operation is synchronous or asynchronous,
 and is <em>unset</em> by default.
 Methods may set it.
 If it is set,
-the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-6">read operation</a> takes place synchronously.
+the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-5">read operation</a> takes place synchronously.
 Otherwise, it takes place asynchronously.</p>
-   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="readOperation">read operation</dfn> on a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-44">Blob</a></code> and the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-3">synchronous flag</a>,
+   <p>To perform a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="readOperation">read operation</dfn> on a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-33">Blob</a></code> and the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-3">synchronous flag</a>,
 run the following steps:</p>
    <ol>
     <li data-md="">
-     <p>Let <var>s</var> be a a new <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a>, <var>b</var> be the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-45">Blob</a></code> to be read from,
+     <p>Let <var>s</var> be a a new <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a>, <var>b</var> be the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-34">Blob</a></code> to be read from,
 and <var>bytes</var> initially set to an empty byte sequence.
-Set the <var>length</var> on <var>s</var> to the <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-10">size</a></code> of <var>b</var>.
+Set the <var>length</var> on <var>s</var> to the <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-9">size</a></code> of <var>b</var>.
 While there are still bytes to be read in <var>b</var>,
 perform the following substeps:</p>
-     <p class="note" role="note"><span>Note:</span> The algorithm assumes that invoking methods have checked for <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-14">readability state</a>.
-A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-46">Blob</a></code> in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-7"><code>CLOSED</code></a> state must not have a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-7">read operation</a> called on it.</p>
      <ol>
       <li data-md="">
        <p>If the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-4">synchronous flag</a> is set, follow the steps below:</p>
@@ -2295,7 +2255,7 @@ A <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blo
 If a <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-2">file read error</a> occurs reading a <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> from <var>b</var>,
 return <var>s</var> with the error flag set,
 along with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-2">failure reason</a>,
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-2">terminate this algorithm</a>.</p>
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-1">terminate this algorithm</a>.</p>
          <p class="note" role="note"><span>Note:</span> Along with returning failure,
 the synchronous part of this algorithm must return the <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-3">failure reason</a> that occurred
 for <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throwing an exception</a> by synchronous methods
@@ -2308,7 +2268,7 @@ Reset <var>bytes</var> to the empty byte sequence
 and continue reading <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s as above.</p>
         <li data-md="">
          <p>When all the bytes of <var>b</var> have been read into <var>s</var>,
-return <var>s</var> and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-3">terminate this algorithm</a>.</p>
+return <var>s</var> and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-2">terminate this algorithm</a>.</p>
        </ol>
       <li data-md="">
        <p>Otherwise, the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-6">synchronous flag</a> is unset.
@@ -2317,7 +2277,7 @@ Return <var>s</var> and process the rest of this algorithm asynchronously.</p>
        <p>Let <var>bytes</var> be the byte sequence that results from reading a <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> from <var>b</var>.
 If a <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-3">file read error</a> occurs reading a <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> from <var>b</var>,
 set the error flag on <var>s</var>,
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-4">terminate this algorithm</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-4">failure reason</a>.</p>
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-3">terminate this algorithm</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-4">failure reason</a>.</p>
        <p class="note" role="note"><span>Note:</span> The asynchronous part of this algorithm must signal the <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-5">failure reason</a> that occurred
 for asynchronous error reporting by methods expecting <var>s</var> and which invoke this algorithm with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-7">synchronous flag</a> unset.</p>
       <li data-md="">
@@ -2328,39 +2288,39 @@ Reset <var>bytes</var> to the empty byte sequence
 and continue reading <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s as above.</p>
      </ol>
    </ol>
-   <p>To perform an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="task-read-operation">annotated task read operation</dfn> on a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-47">Blob</a></code> <var>b</var>,
+   <p>To perform an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="task-read-operation">annotated task read operation</dfn> on a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-35">Blob</a></code> <var>b</var>,
 perform the steps below:</p>
    <ol>
     <li data-md="">
-     <p>Perform a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-8">read operation</a> on <var>b</var> with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-8">synchronous flag</a> unset,
+     <p>Perform a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-6">read operation</a> on <var>b</var> with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-8">synchronous flag</a> unset,
 along with the additional steps below.</p>
     <li data-md="">
-     <p>If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-9">read operation</a> terminates with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-6">failure reason</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read-error">process read error</dfn> with the <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-7">failure reason</a> and terminate this algorithm.</p>
+     <p>If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-7">read operation</a> terminates with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-6">failure reason</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read-error">process read error</dfn> with the <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-7">failure reason</a> and terminate this algorithm.</p>
     <li data-md="">
-     <p>When the first <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> is being pushed to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> during the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-10">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read">process read</dfn>.</p>
+     <p>When the first <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> is being pushed to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> during the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-8">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read">process read</dfn>.</p>
     <li data-md="">
-     <p>Once the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> from the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-11">read operation</a> has at least one <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> read into it,
+     <p>Once the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> from the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-9">read operation</a> has at least one <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> read into it,
 or there are no <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s left to read from <var>b</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read-data">process read data</dfn>.
 Keep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queuing tasks</a> to <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-1">process read data</a> for every <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a> read or every 50ms,
 whichever is <em>least frequent</em>.</p>
     <li data-md="">
-     <p>When all of the <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s from <var>b</var> are read into the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> from the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-12">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read-EOF">process read EOF</dfn>.</p>
+     <p>When all of the <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#chunk">chunk</a>s from <var>b</var> are read into the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> <var>s</var> from the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-10">read operation</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="process-read-EOF">process read EOF</dfn>.</p>
    </ol>
    <p>Use the <a data-link-type="dfn" href="#fileReadingTaskSource" id="ref-for-fileReadingTaskSource-1">file reading task source</a> for all these tasks.</p>
    <h3 class="heading settled" data-level="6.2" id="blobreader-task-source"><span class="secno">6.2. </span><span class="content"> The File Reading Task Source</span><a class="self-link" href="#blobreader-task-source"></a></h3>
    <p>This specification defines a new generic <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fileReadingTaskSource">file reading task source</dfn>,
 which is used for all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">tasks that are queued</a> in this specification
-to read byte sequences associated with <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-48">Blob</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-27">File</a></code> objects.
+to read byte sequences associated with <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-36">Blob</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-27">File</a></code> objects.
 It is to be used for features that trigger in response to asynchronously reading binary data.</p>
    <h3 class="heading settled" data-level="6.3" id="APIASynch"><span class="secno">6.3. </span><span class="content"> The FileReader API</span><a class="self-link" href="#APIASynch"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="constructor" data-export="" data-lt="FileReader()" id="dom-filereader-filereader">Constructor</dfn>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-filereader">FileReader</dfn>: <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
 
   // async read methods
-  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-1">readAsArrayBuffer</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-49">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-1">blob</a>);
-  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsBinaryString" id="ref-for-dfn-readAsBinaryString-1">readAsBinaryString</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-50">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-2">blob</a>);
-  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsText" id="ref-for-dfn-readAsText-1">readAsText</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-51">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-3">blob</a>, <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-label" id="ref-for-dfn-label-1">label</a>);
-  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-1">readAsDataURL</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-52">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-4">blob</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-1">readAsArrayBuffer</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-37">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-1">blob</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsBinaryString" id="ref-for-dfn-readAsBinaryString-1">readAsBinaryString</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-38">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-2">blob</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsText" id="ref-for-dfn-readAsText-1">readAsText</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-39">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-3">blob</a>, <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-label" id="ref-for-dfn-label-1">label</a>);
+  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-1">readAsDataURL</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-40">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-4">blob</a>);
 
   <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-abort" id="ref-for-dfn-abort-2">abort</a>();
 
@@ -2434,14 +2394,14 @@ which must be one of the following values:</p>
     This is the default state of a newly minted <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-8">FileReader</a></code> object,
     until one of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-3">read methods</a> have been called on it. 
     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" id="dfn-loading">LOADING</dfn> (numeric value 1) 
-    <dd>A <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-28">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-53">Blob</a></code> is being read.
+    <dd>A <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-28">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-41">Blob</a></code> is being read.
     One of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-4">read methods</a> is being processed,
     and no error has occurred during the read. 
     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="const" data-export="" id="dfn-done">DONE</dfn> (numeric value 2) 
-    <dd>The entire <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-29">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-54">Blob</a></code> has been read into memory,
+    <dd>The entire <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-29">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-42">Blob</a></code> has been read into memory,
     OR a <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-5">file read error</a> occurred,
     OR the read was aborted using <code class="idl"><a data-link-type="idl" href="#dfn-abort" id="ref-for-dfn-abort-3">abort()</a></code>.
-    The <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-9">FileReader</a></code> is no longer reading a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-30">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-55">Blob</a></code>.
+    The <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-9">FileReader</a></code> is no longer reading a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-30">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-43">Blob</a></code>.
     If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-2">readyState</a></code> is set to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-2">DONE</a></code> it means at least one of the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-5">read methods</a> have been called on this <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-10">FileReader</a></code>. 
    </dl>
    <h4 class="heading settled" data-level="6.3.4" id="reading-a-file"><span class="secno">6.3.4. </span><span class="content"> Reading a File or Blob</span><a class="self-link" href="#reading-a-file"></a></h4>
@@ -2453,7 +2413,7 @@ when <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-fo
    <p>(<code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-3">FileReaderSync</a></code> makes available several <a data-link-type="dfn" href="#read-method-sync" id="ref-for-read-method-sync-1">synchronous read methods</a>.
   Collectively, the sync and async read methods of <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-13">FileReader</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-4">FileReaderSync</a></code> are referred to as just <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="read method" data-noexport="" id="read-method">read methods</dfn>.)</p>
    <h5 class="heading settled" data-level="6.3.4.1" id="filedata-attr"><span class="secno">6.3.4.1. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-2">result</a></code> attribute</span><a class="self-link" href="#filedata-attr"></a></h5>
-   <p>On getting, the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-result">result</dfn> attribute returns a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-56">Blob</a></code>'s data
+   <p>On getting, the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="attribute" data-export="" id="dfn-result">result</dfn> attribute returns a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-44">Blob</a></code>'s data
 as a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, or as an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a></code>, or <code>null</code>,
 depending on the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-6">read method</a> that has been called on the <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-14">FileReader</a></code>,
 and any errors that may have occurred.</p>
@@ -2466,26 +2426,26 @@ if the <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-
 then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-4">result</a></code> attribute must return <code>null</code>.</p>
     <li data-md="">
      <p>On getting,
-if an error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-31">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-57">Blob</a></code> has occurred
+if an error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-31">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-45">Blob</a></code> has occurred
 (using <em>any</em> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-7">read method</a>)
 then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-5">result</a></code> attribute must return <code>null</code>.</p>
     <li data-md="">
      <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-3">readAsDataURL()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-8">read method</a> is used,
-the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-6">result</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> that is a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a> encoding of the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-32">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-58">Blob</a></code>'s data.</p>
+the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-6">result</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> that is a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a> encoding of the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-32">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-46">Blob</a></code>'s data.</p>
     <li data-md="">
      <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsBinaryString" id="ref-for-dfn-readAsBinaryString-3">readAsBinaryString()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-9">read method</a> is called
-and no error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-33">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-59">Blob</a></code> has occurred,
-then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-7">result</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> representing the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-34">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-60">Blob</a></code>'s data as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="binary-string">binary string</dfn>,
+and no error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-33">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-47">Blob</a></code> has occurred,
+then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-7">result</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> representing the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-34">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-48">Blob</a></code>'s data as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="binary-string">binary string</dfn>,
 in which every byte is represented by a code unit of equal value [0...255].</p>
     <li data-md="">
      <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-3">readAsText()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-10">read method</a> is called
-and no error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-35">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-61">Blob</a></code> has occurred,
+and no error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-35">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-49">Blob</a></code> has occurred,
 then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-8">result</a></code> attribute must return a string
-representing the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-36">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-62">Blob</a></code>'s data as a text string,
+representing the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-36">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-50">Blob</a></code>'s data as a text string,
 and should decode the string into memory in the format specified by the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-2">encoding determination</a> as a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>.</p>
     <li data-md="">
      <p>On getting, if the <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-3">readAsArrayBuffer()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-11">read method</a> is called
-and no error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-37">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-63">Blob</a></code> has occurred,
+and no error in reading the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-37">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-51">Blob</a></code> has occurred,
 then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-9">result</a></code> attribute must return an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a></code> object.</p>
    </ul>
    <h5 class="heading settled" data-level="6.3.4.2" id="readAsDataURL"><span class="secno">6.3.4.2. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURL" id="ref-for-dfn-readAsDataURL-4">readAsDataURL()</a></code> method</span><a class="self-link" href="#readAsDataURL"></a></h5>
@@ -2493,11 +2453,7 @@ then the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-fo
 the user agent must run the steps below.</p>
    <ol>
     <li data-md="">
-     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-5">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-3">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-5">terminate this algorithm</a>.</p>
-    <li data-md="">
-     <p>If the <code>blob</code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-8">CLOSED</a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-15">readability state</a>,
-set the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-3">error</a></code> attribute of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> to return an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-1">fire a progress event</a> called <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-3">error</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-6">Terminate this algorithm</a>.</p>
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-5">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-3">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-4">terminate this algorithm</a>.</p>
     <li data-md="">
      <p>Otherwise set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-6">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-4">LOADING</a></code>.</p>
     <li data-md="">
@@ -2506,16 +2462,16 @@ and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-pro
      <p>To <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-1">process read error</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-8">failure reason</a>,
 proceed to <a href="#dfn-error-steps">§6.3.4.6 Error Steps</a>.</p>
     <li data-md="">
-     <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-1">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-2">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-2">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-1">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-1">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-2">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
-     <p>To <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-2">process read data</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-3">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-2">progress</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     <p>To <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-2">process read data</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-2">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-2">progress</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
      <p>To <a data-link-type="dfn" href="#process-read-EOF" id="ref-for-process-read-EOF-1">process read EOF</a> run these substeps:</p>
      <ol>
       <li data-md="">
        <p>Set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-7">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-3">DONE</a></code>.</p>
       <li data-md="">
-       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-10">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-13">read operation</a> as a DataURL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a>;
+       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-10">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-11">read operation</a> as a DataURL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a>;
 on getting, the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-11">result</a></code> attribute returns the <code>blob</code> as a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a>.</p>
        <ul>
         <li data-md="">
@@ -2526,13 +2482,13 @@ in keeping with the Data URL specification <a data-link-type="biblio" href="#bib
 Data URLs that do not have media-types <a data-link-type="biblio" href="#biblio-rfc2046">[RFC2046]</a> must be treated as plain text by conforming user agents. <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a>.</p>
        </ul>
       <li data-md="">
-       <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-4">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-2">load</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+       <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-3">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-2">load</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
       <li data-md="">
-       <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-8">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-5">LOADING</a></code> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-5">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-2">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
+       <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-8">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-5">LOADING</a></code> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-4">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-2">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
 If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-9">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-6">LOADING</a></code> do NOT fire <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-3">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
      </ol>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-7">Terminate this algorithm</a>.</p>
+     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-5">Terminate this algorithm</a>.</p>
    </ol>
    <h5 class="heading settled" data-level="6.3.4.3" id="readAsDataText"><span class="secno">6.3.4.3. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-4">readAsText()</a></code> method</span><a class="self-link" href="#readAsDataText"></a></h5>
    <p>The <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-5">readAsText()</a></code> method can be called with an optional parameter, <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader/readAsText(blob, label), FileReader/readAsText(), FileReaderSync/readAsText(blob, label)" data-dfn-type="argument" data-export="" id="dfn-label">label</dfn>,
@@ -2542,11 +2498,7 @@ if provided, it must be used as part of the <a data-link-type="dfn" href="#encod
 the user agent must run the steps below.</p>
    <ol>
     <li data-md="">
-     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-10">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-7">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-8">terminate this algorithm</a>.</p>
-    <li data-md="">
-     <p>If the <code>blob</code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-9">CLOSED</a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-16">readability state</a>,
-set the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-4">error</a></code> attribute of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> to return an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-6">fire a progress event</a> called <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-4">error</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-9">Terminate this algorithm</a>.</p>
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-10">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-7">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-6">terminate this algorithm</a>.</p>
     <li data-md="">
      <p>Otherwise set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-11">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-8">LOADING</a></code>.</p>
     <li data-md="">
@@ -2555,36 +2507,32 @@ and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-pro
      <p>To <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-2">process read error</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-9">failure reason</a>,
 proceed to the <a href="#dfn-error-steps">§6.3.4.6 Error Steps</a>.</p>
     <li data-md="">
-     <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-2">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-7">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-3">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-2">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-5">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-3">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
-     <p>To <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-3">process read data</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-8">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-3">progress</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     <p>To <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-3">process read data</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-6">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-3">progress</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
      <p>To <a data-link-type="dfn" href="#process-read-EOF" id="ref-for-process-read-EOF-2">process read EOF</a> run these substeps:</p>
      <ol>
       <li data-md="">
        <p>Set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-12">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-4">DONE</a></code></p>
       <li data-md="">
-       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-12">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-14">read operation</a>,
+       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-12">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-12">read operation</a>,
 represented as a string in a format determined by the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-4">encoding determination</a>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-9">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-3">load</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+       <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-7">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-3">load</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
       <li data-md="">
-       <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-13">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-9">LOADING</a></code> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-10">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-4">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
+       <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-13">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-9">LOADING</a></code> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-8">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-4">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
 If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-14">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-10">LOADING</a></code> do NOT fire <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-5">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
      </ol>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-10">Terminate this algorithm</a>.</p>
+     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-7">Terminate this algorithm</a>.</p>
    </ol>
    <h5 class="heading settled" data-level="6.3.4.4" id="readAsArrayBuffer"><span class="secno">6.3.4.4. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-4">readAsArrayBuffer()</a></code> method</span><a class="self-link" href="#readAsArrayBuffer"></a></h5>
    <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" id="dfn-readAsArrayBuffer">readAsArrayBuffer(blob)</dfn> method is called,
 the user agent must run the steps below.</p>
    <ol>
     <li data-md="">
-     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-15">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-11">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-11">terminate this algorithm</a>.</p>
-    <li data-md="">
-     <p>If the <code>blob</code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-10">CLOSED</a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-17">readability state</a>,
-set the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-5">error</a></code> attribute of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> to return an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-11">fire a progress event</a> called <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-5">error</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-12">Terminate this algorithm</a>.</p>
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-15">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-11">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-8">terminate this algorithm</a>.</p>
     <li data-md="">
      <p>Otherwise set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-16">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-12">LOADING</a></code>.</p>
     <li data-md="">
@@ -2593,35 +2541,31 @@ and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-pro
      <p>To <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-3">process read error</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-10">failure reason</a>,
 proceed to the <a href="#dfn-error-steps">§6.3.4.6 Error Steps</a>.</p>
     <li data-md="">
-     <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-3">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-12">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-4">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-3">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-9">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-4">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
-     <p>To <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-4">process read data</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-13">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-4">progress</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     <p>To <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-4">process read data</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-10">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-4">progress</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
      <p>To <a data-link-type="dfn" href="#process-read-EOF" id="ref-for-process-read-EOF-3">process read EOF</a> run these substeps:</p>
      <ol>
       <li data-md="">
        <p>Set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-17">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-5">DONE</a></code></p>
       <li data-md="">
-       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-13">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-15">read operation</a> as an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a></code> object.</p>
+       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-13">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-13">read operation</a> as an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a></code> object.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-14">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-4">load</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+       <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-11">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-4">load</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
       <li data-md="">
-       <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-18">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-13">LOADING</a></code> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-15">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-6">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
+       <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-18">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-13">LOADING</a></code> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-12">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-6">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
 If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-19">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-14">LOADING</a></code> do NOT fire <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-7">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
      </ol>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-13">Terminate this algorithm</a>.</p>
+     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-9">Terminate this algorithm</a>.</p>
    </ol>
    <h5 class="heading settled" data-level="6.3.4.5" id="readAsBinaryString"><span class="secno">6.3.4.5. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsBinaryString" id="ref-for-dfn-readAsBinaryString-4">readAsBinaryString()</a></code> method</span><a class="self-link" href="#readAsBinaryString"></a></h5>
    <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" id="dfn-readAsBinaryString">readAsBinaryString(blob)</dfn> method is called,
 the user agent must run the steps below.</p>
    <ol>
     <li data-md="">
-     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-20">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-15">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-14">terminate this algorithm</a>.</p>
-    <li data-md="">
-     <p>If the <code>blob</code> is in the <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-11">CLOSED</a> <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-18">readability state</a>,
-set the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-6">error</a></code> attribute of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> to return an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-16">fire a progress event</a> called <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-6">error</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-15">Terminate this algorithm</a>.</p>
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-20">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-15">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-10">terminate this algorithm</a>.</p>
     <li data-md="">
      <p>Otherwise set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-21">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-16">LOADING</a></code>.</p>
     <li data-md="">
@@ -2630,24 +2574,24 @@ and <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-pro
      <p>To <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-4">process read error</a> with a <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-11">failure reason</a>,
 proceed to the <a href="#dfn-error-steps">§6.3.4.6 Error Steps</a>.</p>
     <li data-md="">
-     <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-4">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-17">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-5">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     <p>To <a data-link-type="dfn" href="#process-read" id="ref-for-process-read-4">process read</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-13">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-5">loadstart</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
-     <p>To <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-5">process read data</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-18">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-5">progress</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     <p>To <a data-link-type="dfn" href="#process-read-data" id="ref-for-process-read-data-5">process read data</a> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-14">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-5">progress</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
      <p>To <a data-link-type="dfn" href="#process-read-EOF" id="ref-for-process-read-EOF-4">process read EOF</a> run these substeps:</p>
      <ol>
       <li data-md="">
        <p>Set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-22">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-6">DONE</a></code></p>
       <li data-md="">
-       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-14">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-16">read operation</a> as a <a data-link-type="dfn" href="#binary-string" id="ref-for-binary-string-1">binary string</a>.</p>
+       <p>Set the <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-14">result</a></code> attribute to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-body">body</a> returned by the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-14">read operation</a> as a <a data-link-type="dfn" href="#binary-string" id="ref-for-binary-string-1">binary string</a>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-19">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-5">load</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+       <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-15">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-5">load</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
       <li data-md="">
-       <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-23">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-17">LOADING</a></code> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-20">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-8">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
+       <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-23">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-17">LOADING</a></code> <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-16">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-8">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
 If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-24">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-18">LOADING</a></code> do NOT fire <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-9">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
      </ol>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-16">Terminate this algorithm</a>.</p>
+     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-11">Terminate this algorithm</a>.</p>
    </ol>
    <div class="note" role="note"> The use of <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBuffer" id="ref-for-dfn-readAsArrayBuffer-5">readAsArrayBuffer()</a></code> is preferred over <code class="idl"><a data-link-type="idl" href="#dfn-readAsBinaryString" id="ref-for-dfn-readAsBinaryString-5">readAsBinaryString()</a></code>, which is provided for backwards
   compatibility. </div>
@@ -2657,44 +2601,44 @@ If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-
     <li data-md="">
      <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-25">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-7">DONE</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-15">result</a></code> to null if it is not already set to null.</p>
     <li data-md="">
-     <p>Set the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-7">error</a></code> attribute on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>;
-on getting, the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-8">error</a></code> attribute must be a a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> object
-that corresponds to the <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-13">failure reason</a>. <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-21">Fire a progress event</a> called <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-7">error</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+     <p>Set the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-3">error</a></code> attribute on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>;
+on getting, the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-4">error</a></code> attribute must be a a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> object
+that corresponds to the <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-13">failure reason</a>. <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-17">Fire a progress event</a> called <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-3">error</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
-     <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-26">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-19">LOADING</a></code>, <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-22">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-10">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
+     <p>Unless <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-26">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-19">LOADING</a></code>, <a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-18">fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-10">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.
 If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-27">readyState</a></code> is <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-20">LOADING</a></code> do NOT fire <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-11">loadend</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-17">Terminate the algorithm</a> for any <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-12">read method</a>.</p>
+     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-12">Terminate the algorithm</a> for any <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-12">read method</a>.</p>
    </ol>
    <h5 class="heading settled" data-level="6.3.4.7" id="abort"><span class="secno">6.3.4.7. </span><span class="content"> The abort() method</span><a class="self-link" href="#abort"></a></h5>
    <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReader" data-dfn-type="method" data-export="" id="dfn-abort">abort()</dfn> method is called,
 the user agent must run the steps below:</p>
    <ol>
     <li data-md="">
-     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-28">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-empty" id="ref-for-dfn-empty-3">EMPTY</a></code> or if <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-29">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-8">DONE</a></code> set <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-16">result</a></code> to <code>null</code> and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-18">terminate this algorithm</a>.</p>
+     <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-28">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-empty" id="ref-for-dfn-empty-3">EMPTY</a></code> or if <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-29">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-8">DONE</a></code> set <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-16">result</a></code> to <code>null</code> and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-13">terminate this algorithm</a>.</p>
     <li data-md="">
      <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-30">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-21">LOADING</a></code> set <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-31">readyState</a></code> to <code class="idl"><a data-link-type="idl" href="#dfn-done" id="ref-for-dfn-done-9">DONE</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-result" id="ref-for-dfn-result-17">result</a></code> to <code>null</code>.</p>
     <li data-md="">
      <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> from the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> on the <a data-link-type="dfn" href="#fileReadingTaskSource" id="ref-for-fileReadingTaskSource-6">file reading task source</a> in an affiliated <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">task queue</a>,
 then remove those <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> from that task queue.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-19">Terminate the algorithm</a> for the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-13">read method</a> being processed.</p>
+     <p><a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-14">Terminate the algorithm</a> for the <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-13">read method</a> being processed.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-23">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-2">abort</a></code>.</p>
+     <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-19">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-2">abort</a></code>.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-24">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-12">loadend</a></code>.</p>
+     <p><a data-link-type="dfn" href="#fire-a-progress-event" id="ref-for-fire-a-progress-event-20">Fire a progress event</a> called <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-12">loadend</a></code>.</p>
    </ol>
    <h5 class="heading settled" data-level="6.3.4.8" id="blobAndFileParams"><span class="secno">6.3.4.8. </span><span class="content"> Blob Parameters</span><a class="self-link" href="#blobAndFileParams"></a></h5>
    <p>The <a data-link-type="dfn" href="#asynchronous-read-methods" id="ref-for-asynchronous-read-methods-1">asynchronous read methods</a>,
-the <a data-link-type="dfn" href="#read-method-sync" id="ref-for-read-method-sync-2">synchronous read methods</a>, and <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-1">createObjectURL()</a></code></code> take a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-64">Blob</a></code> parameter.
+the <a data-link-type="dfn" href="#read-method-sync" id="ref-for-read-method-sync-2">synchronous read methods</a>, and <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-1">createObjectURL()</a></code></code> take a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-52">Blob</a></code> parameter.
 This section defines this parameter.</p>
    <dl>
     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="FileReader/readAsArrayBuffer(blob), FileReader/readAsBinaryString(blob), FileReader/readAsText(blob, label), FileReader/readAsText(), FileReader/readAsDataURL(blob), URL/createObjectURL(blob), FileReaderSync/readAsArrayBuffer(blob), FileReaderSync/readAsBinaryString(blob), FileReaderSync/readAsText(blob, label), FileReaderSync/readAsDataURL(blob)" data-dfn-type="argument" data-export="" id="dfn-fileBlob">blob</dfn> 
-    <dd>This is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-65">Blob</a></code> argument
-    and must be a reference to a single <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-38">File</a></code> in a <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-11">FileList</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-66">Blob</a></code> argument not obtained from the underlying OS file system. 
+    <dd>This is a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-53">Blob</a></code> argument
+    and must be a reference to a single <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-38">File</a></code> in a <code class="idl"><a data-link-type="idl" href="#dfn-filelist" id="ref-for-dfn-filelist-11">FileList</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-54">Blob</a></code> argument not obtained from the underlying OS file system. 
    </dl>
    <h3 class="heading settled" data-level="6.4" id="enctype"><span class="secno">6.4. </span><span class="content"> Determining Encoding</span><a class="self-link" href="#enctype"></a></h3>
-   <p>When reading <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-67">Blob</a></code> objects using the <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-6">readAsText()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-14">read method</a>,
+   <p>When reading <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-55">Blob</a></code> objects using the <code class="idl"><a data-link-type="idl" href="#dfn-readAsText" id="ref-for-dfn-readAsText-6">readAsText()</a></code> <a data-link-type="dfn" href="#read-method" id="ref-for-read-method-14">read method</a>,
 the following <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="encoding-determination">encoding determination</dfn> steps must be followed:</p>
    <ol>
     <li data-md="">
@@ -2785,7 +2729,7 @@ UNLESS any of the following are true:</p>
       <li data-md="">
        <p>the event handler function for a <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-6">load</a></code> event initiates a new read</p>
       <li data-md="">
-       <p>the event handler function for a <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-8">error</a></code> event initiates a new read.</p>
+       <p>the event handler function for a <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-4">error</a></code> event initiates a new read.</p>
      </ul>
      <p class="note" role="note"><span>Note:</span> The events <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-7">loadstart</a></code> and <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-14">loadend</a></code> are not coupled in a one-to-one manner.</p>
      <div class="example" id="example-89381d0d">
@@ -2795,7 +2739,7 @@ UNLESS any of the following are true:</p>
 </span>reader<span class="p">.</span>readAsText<span class="p">(</span>file<span class="p">)</span><span class="p">;</span>
 reader<span class="p">.</span>onload <span class="o">=</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span><span class="p">{</span>reader<span class="p">.</span>readAsText<span class="p">(</span>alternateFile<span class="p">)</span><span class="p">;</span><span class="p">}</span>
 
-<span class="p">...</span><span class="p">.</span><span class="p">.</span>
+<span class="p">.</span><span class="p">.</span><span class="p">.</span><span class="p">.</span><span class="p">.</span>
 
 <span class="c1">//... the loadend event must not fire for the first read
 </span>
@@ -2811,26 +2755,26 @@ reader<span class="p">.</span>onabort <span class="o">=</span> <span class="kd">
     <li data-md="">
      <p>No <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-7">progress</a></code> event fires before <code class="idl"><a data-link-type="idl" href="#dfn-loadstart-event" id="ref-for-dfn-loadstart-event-8">loadstart</a></code>.</p>
     <li data-md="">
-     <p>No <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-8">progress</a></code> event fires after any one of <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-3">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-7">load</a></code>, and <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-9">error</a></code> have fired.
-At most one of <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-4">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-8">load</a></code>, and <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-10">error</a></code> fire for a given read.</p>
+     <p>No <code class="idl"><a data-link-type="idl" href="#dfn-progress-event" id="ref-for-dfn-progress-event-8">progress</a></code> event fires after any one of <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-3">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-7">load</a></code>, and <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-5">error</a></code> have fired.
+At most one of <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-4">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-8">load</a></code>, and <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-6">error</a></code> fire for a given read.</p>
     <li data-md="">
-     <p>No <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-5">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-9">load</a></code>, or <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-11">error</a></code> event fires after <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-15">loadend</a></code>.</p>
+     <p>No <code class="idl"><a data-link-type="idl" href="#dfn-abort-event" id="ref-for-dfn-abort-event-5">abort</a></code>, <code class="idl"><a data-link-type="idl" href="#dfn-load-event" id="ref-for-dfn-load-event-9">load</a></code>, or <code class="idl"><a class="idl-code" data-link-type="event" href="#dfn-error-event" id="ref-for-dfn-error-event-7">error</a></code> event fires after <code class="idl"><a data-link-type="idl" href="#dfn-loadend-event" id="ref-for-dfn-loadend-event-15">loadend</a></code>.</p>
    </ol>
    <h3 class="heading settled" data-level="6.6" id="readingOnThreads"><span class="secno">6.6. </span><span class="content"> Reading on Threads</span><a class="self-link" href="#readingOnThreads"></a></h3>
-   <p>Web Workers allow for the use of synchronous <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-39">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-68">Blob</a></code> read APIs,
+   <p>Web Workers allow for the use of synchronous <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-39">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-56">Blob</a></code> read APIs,
 since such reads on threads do not block the main thread.
 This section defines a synchronous API, which can be used within Workers [[Web Workers]].
 Workers can avail of both the asynchronous API (the <code class="idl"><a data-link-type="idl" href="#dfn-filereader" id="ref-for-dfn-filereader-19">FileReader</a></code> object) <em>and</em> the synchronous API (the <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-6">FileReaderSync</a></code> object).</p>
    <h4 class="heading settled" data-level="6.6.1" id="FileReaderSync"><span class="secno">6.6.1. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-FileReaderSync" id="ref-for-dfn-FileReaderSync-7">FileReaderSync</a></code> API</span><a class="self-link" href="#FileReaderSync"></a></h4>
-   <p>This interface  provides methods to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="synchronous read method" data-noexport="" id="read-method-sync">synchronously read</dfn> <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-40">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-69">Blob</a></code> objects into memory.</p>
+   <p>This interface  provides methods to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="synchronous read method" data-noexport="" id="read-method-sync">synchronously read</dfn> <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-40">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-57">Blob</a></code> objects into memory.</p>
 <pre class="idl highlight def">[<dfn class="nv dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="constructor" data-export="" data-lt="FileReaderSync()" id="dom-filereadersync-filereadersync">Constructor</dfn>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">DedicatedWorker</span>,<span class="n">SharedWorker</span>)]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="dfn-FileReaderSync">FileReaderSync</dfn> {
   // Synchronously return strings
 
-  <span class="kt">ArrayBuffer</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsArrayBufferSync" id="ref-for-dfn-readAsArrayBufferSync-1">readAsArrayBuffer</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-70">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-6">blob</a>);
-  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsBinaryStringSync" id="ref-for-dfn-readAsBinaryStringSync-1">readAsBinaryString</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-71">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-7">blob</a>);
-  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsTextSync" id="ref-for-dfn-readAsTextSync-2">readAsText</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-72">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-8">blob</a>, <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-label" id="ref-for-dfn-label-4">label</a>);
-  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsDataURLSync" id="ref-for-dfn-readAsDataURLSync-1">readAsDataURL</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-73">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-9">blob</a>);
+  <span class="kt">ArrayBuffer</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsArrayBufferSync" id="ref-for-dfn-readAsArrayBufferSync-1">readAsArrayBuffer</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-58">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-6">blob</a>);
+  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsBinaryStringSync" id="ref-for-dfn-readAsBinaryStringSync-1">readAsBinaryString</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-59">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-7">blob</a>);
+  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsTextSync" id="ref-for-dfn-readAsTextSync-2">readAsText</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-60">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-8">blob</a>, <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-label" id="ref-for-dfn-label-4">label</a>);
+  <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-readAsDataURLSync" id="ref-for-dfn-readAsDataURLSync-1">readAsDataURL</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-61">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-9">blob</a>);
 };
 </pre>
    <h5 class="heading settled" data-level="6.6.1.1" id="filereadersyncConstrctr"><span class="secno">6.6.1.1. </span><span class="content"> Constructors</span><a class="self-link" href="#filereadersyncConstrctr"></a></h5>
@@ -2844,19 +2788,15 @@ the following steps must be followed:</p>
    <ol>
     <li data-md="">
      <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-32">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-22">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-20">terminate this algorithm</a>.</p>
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-15">terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>If the <code>blob</code> has been closed through the <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-4">close()</a></code> method,
-throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-21">terminate this algorithm</a>.</p>
-    <li data-md="">
-     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-17">read operation</a> using the <code>blob</code> argument,
+     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-15">read operation</a> using the <code>blob</code> argument,
 and with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-9">synchronous flag</a> <em>set</em>.
 If the read operation returns failure,
-throw the appropriate exception as defined in <a href="#dfn-error-codes">§7.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-22">Terminate this algorithm</a>.</p>
+throw the appropriate exception as defined in <a href="#dfn-error-codes">§7.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-16">Terminate this algorithm</a>.</p>
     <li data-md="">
      <p>If no error has occurred,
-return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-18">read operation</a> represented as a string
+return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-16">read operation</a> represented as a string
 in a format determined through the <a data-link-type="dfn" href="#encoding-determination" id="ref-for-encoding-determination-5">encoding determination</a> algorithm.</p>
    </ol>
    <h5 class="heading settled" data-level="6.6.1.3" id="readAsDataURLSync-section"><span class="secno">6.6.1.3. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsDataURLSync" id="ref-for-dfn-readAsDataURLSync-2">readAsDataURL()</a></code> method</span><a class="self-link" href="#readAsDataURLSync-section"></a></h5>
@@ -2865,18 +2805,14 @@ the following steps must be followed:</p>
    <ol>
     <li data-md="">
      <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-33">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-23">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-23">terminate this algorithm</a>.</p>
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-17">terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>If the <code>blob</code> has been closed through the <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-5">close()</a></code> method,
-throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-24">terminate this algorithm</a>.</p>
-    <li data-md="">
-     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-19">read operation</a> using the <code>blob</code> argument,
+     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-17">read operation</a> using the <code>blob</code> argument,
 and with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-10">synchronous flag</a> <em>set</em>.
-If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-20">read operation</a> returns failure,
-throw the appropriate exception as defined in <a href="#dfn-error-codes">§7.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-25">Terminate this algorithm</a>.</p>
+If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-18">read operation</a> returns failure,
+throw the appropriate exception as defined in <a href="#dfn-error-codes">§7.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-18">Terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-21">read operation</a> as a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a> subject to the considerations below:</p>
+     <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-19">read operation</a> as a Data URL <a data-link-type="biblio" href="#biblio-rfc2397">[RFC2397]</a> subject to the considerations below:</p>
      <ul>
       <li data-md="">
        <p>Use the <code>blob</code>’s <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-20">type</a></code> attribute as part of the Data URL if it is available
@@ -2892,18 +2828,14 @@ the following steps must be followed:</p>
    <ol>
     <li data-md="">
      <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-34">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-24">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-26">terminate this algorithm</a>.</p>
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-19">terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>If the <code>blob</code> has been closed through the <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-6">close()</a></code> method,
-throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-27">terminate this algorithm</a>.</p>
-    <li data-md="">
-     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-22">read operation</a> using the <code>blob</code> argument,
+     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-20">read operation</a> using the <code>blob</code> argument,
 and with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-11">synchronous flag</a> <em>set</em>.
-If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-23">read operation</a> returns failure,
-throw the appropriate exception as defined in <a href="#dfn-error-codes">§7.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-28">Terminate this algorithm</a>.</p>
+If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-21">read operation</a> returns failure,
+throw the appropriate exception as defined in <a href="#dfn-error-codes">§7.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-20">Terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-24">read operation</a> as an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a></code>.</p>
+     <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-22">read operation</a> as an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a></code>.</p>
    </ol>
    <h5 class="heading settled" data-level="6.6.1.5" id="readAsBinaryStringSyncSection"><span class="secno">6.6.1.5. </span><span class="content"> The <code class="idl"><a data-link-type="idl" href="#dfn-readAsBinaryStringSync" id="ref-for-dfn-readAsBinaryStringSync-2">readAsBinaryString()</a></code> method</span><a class="self-link" href="#readAsBinaryStringSyncSection"></a></h5>
    <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="FileReaderSync" data-dfn-type="method" data-export="" id="dfn-readAsBinaryStringSync">readAsBinaryString(blob)</dfn> method is called,
@@ -2911,18 +2843,14 @@ the following steps must be followed:</p>
    <ol>
     <li data-md="">
      <p>If <code class="idl"><a data-link-type="idl" href="#dfn-readyState" id="ref-for-dfn-readyState-35">readyState</a></code> = <code class="idl"><a data-link-type="idl" href="#dfn-loading" id="ref-for-dfn-loading-25">LOADING</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-29">terminate this algorithm</a>.</p>
+and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-21">terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>If the <code>blob</code> has been closed through the <code class="idl"><a data-link-type="idl" href="#dfn-close" id="ref-for-dfn-close-7">close()</a></code> method,
-throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception
-and <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-30">terminate this algorithm</a>.</p>
-    <li data-md="">
-     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-25">read operation</a> using the <code>blob</code> argument,
+     <p>Otherwise, initiate a <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-23">read operation</a> using the <code>blob</code> argument,
 and with the <a data-link-type="dfn" href="#synchronousFlag" id="ref-for-synchronousFlag-12">synchronous flag</a> <em>set</em>.
-If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-26">read operation</a> returns failure,
-throw the appropriate exception as defined in <a href="#dfn-error-codes">§7.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-31">Terminate this algorithm</a>.</p>
+If the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-24">read operation</a> returns failure,
+throw the appropriate exception as defined in <a href="#dfn-error-codes">§7.1 Throwing an Exception or Returning an Error</a>. <a data-link-type="dfn" href="#terminate-an-algorithm" id="ref-for-terminate-an-algorithm-22">Terminate this algorithm</a>.</p>
     <li data-md="">
-     <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-27">read operation</a> as an <a data-link-type="dfn" href="#binary-string" id="ref-for-binary-string-2">binary string</a>.</p>
+     <p>If no error has occurred, return the <var>result</var> of the <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-25">read operation</a> as an <a data-link-type="dfn" href="#binary-string" id="ref-for-binary-string-2">binary string</a>.</p>
    </ol>
    <div class="note" role="note"> The use of <code class="idl"><a data-link-type="idl" href="#dfn-readAsArrayBufferSync" id="ref-for-dfn-readAsArrayBufferSync-3">readAsArrayBuffer()</a></code> is preferred over <code class="idl"><a data-link-type="idl" href="#dfn-readAsBinaryStringSync" id="ref-for-dfn-readAsBinaryStringSync-3">readAsBinaryString()</a></code>, which is provided for
   backwards compatibility. </div>
@@ -2931,14 +2859,14 @@ throw the appropriate exception as defined in <a href="#dfn-error-codes">§7.1 T
 The list below of potential error conditions is <em>informative</em>.</p>
    <ul>
     <li data-md="">
-     <p>The <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-41">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-74">Blob</a></code> being accessed may not exist
+     <p>The <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-41">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-62">Blob</a></code> being accessed may not exist
 at the time one of the <a data-link-type="dfn" href="#asynchronous-read-methods" id="ref-for-asynchronous-read-methods-2">asynchronous read methods</a> or <a data-link-type="dfn" href="#read-method-sync" id="ref-for-read-method-sync-3">synchronous read methods</a> are called.
 This may be due to it having been moved or deleted after a reference to it was acquired
 (e.g. concurrent modification with another application).
 See <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>.</p>
     <li data-md="">
-     <p>A <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-42">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-75">Blob</a></code> may be unreadable.
-This may be due to permission problems that occur after a reference to a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-43">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-76">Blob</a></code> has been acquired
+     <p>A <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-42">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-63">Blob</a></code> may be unreadable.
+This may be due to permission problems that occur after a reference to a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-43">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-64">Blob</a></code> has been acquired
 (e.g. concurrent lock with another application).
 Additionally, the <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-6">snapshot state</a> may have changed.
 See <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code>.</p>
@@ -2952,8 +2880,8 @@ See <a href="#security-discussion">§9 Security and Privacy Considerations</a> a
    </ul>
    <h3 class="heading settled" data-level="7.1" id="dfn-error-codes"><span class="secno">7.1. </span><span class="content"> Throwing an Exception or Returning an Error</span><a class="self-link" href="#dfn-error-codes"></a></h3>
    <p><em>This section is normative.</em></p>
-   <p>Error conditions can arise when reading a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-44">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-77">Blob</a></code>.</p>
-   <p>The <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-28">read operation</a> can terminate due to error conditions when reading a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-45">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-78">Blob</a></code>;
+   <p>Error conditions can arise when reading a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-44">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-65">Blob</a></code>.</p>
+   <p>The <a data-link-type="dfn" href="#readOperation" id="ref-for-readOperation-26">read operation</a> can terminate due to error conditions when reading a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-45">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-66">Blob</a></code>;
 the particular error condition that causes a read operation to return failure
 or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="#process-read-error" id="ref-for-process-read-error-6">process read error</a> is called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="failureReason">failure reason</dfn>.</p>
    <p>Synchronous read methods <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> exceptions of the type in the table below
@@ -2971,9 +2899,9 @@ or otherwise return null.</p>
      <tr>
       <td><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> 
       <td>
-       If the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-46">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-79">Blob</a></code> resource could not be found at the time the read was processed,
+       If the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-46">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-67">Blob</a></code> resource could not be found at the time the read was processed,
         this is the <dfn data-dfn-type="dfn" data-noexport="" id="NotFoundFR">NotFound<a class="self-link" href="#NotFoundFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-16">failure reason</a>. 
-       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-9">error</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception
+       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-5">error</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception
         and synchronous read methods must <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception.</p>
      <tr>
       <td><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> 
@@ -2983,9 +2911,9 @@ or otherwise return null.</p>
         <li data-md="">
          <p>it is determined that certain files are unsafe for access within a Web application, this is the <dfn data-dfn-type="dfn" data-noexport="" id="UnsafeFileFR">UnsafeFile<a class="self-link" href="#UnsafeFileFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-17">failure reason</a>.</p>
         <li data-md="">
-         <p>it is determined that too many read calls are being made on <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-47">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-80">Blob</a></code> resources, this is the <dfn data-dfn-type="dfn" data-noexport="" id="TooManyReadsFR">TooManyReads<a class="self-link" href="#TooManyReadsFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-18">failure reason</a>.</p>
+         <p>it is determined that too many read calls are being made on <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-47">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-68">Blob</a></code> resources, this is the <dfn data-dfn-type="dfn" data-noexport="" id="TooManyReadsFR">TooManyReads<a class="self-link" href="#TooManyReadsFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-18">failure reason</a>.</p>
        </ul>
-       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-10">error</a></code> attribute may return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> exception
+       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-6">error</a></code> attribute may return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> exception
         and synchronous read methods may <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> exception.</p>
        <p>This is a security error to be used in situations not covered by any other <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-19">failure reason</a>.</p>
      <tr>
@@ -2994,19 +2922,19 @@ or otherwise return null.</p>
        If: 
        <ul>
         <li data-md="">
-         <p>the <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-7">snapshot state</a> of a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-48">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-81">Blob</a></code> does not match the state of the underlying storage,
+         <p>the <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-7">snapshot state</a> of a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-48">File</a></code> or a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-69">Blob</a></code> does not match the state of the underlying storage,
 this is the <dfn data-dfn-type="dfn" data-noexport="" id="SnapshotStateFR">SnapshotState<a class="self-link" href="#SnapshotStateFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-20">failure reason</a>.</p>
         <li data-md="">
-         <p>the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-49">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-82">Blob</a></code> cannot be read,
+         <p>the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-49">File</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-70">Blob</a></code> cannot be read,
 typically due due to permission problems that occur after a <a data-link-type="dfn" href="#snapshot-state" id="ref-for-snapshot-state-8">snapshot state</a> has been established
 (e.g. concurrent lock on the underlying storage with another application)
 then this is the <dfn data-dfn-type="dfn" data-noexport="" id="FileLockFR">FileLock<a class="self-link" href="#FileLockFR"></a></dfn> <a data-link-type="dfn" href="#failureReason" id="ref-for-failureReason-21">failure reason</a>.</p>
        </ul>
-       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-11">error</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code> exception
+       <p>For asynchronous read methods the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dfn-error" id="ref-for-dfn-error-7">error</a></code> attribute must return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code> exception
         and synchronous read methods must <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code> exception.</p>
    </table>
    <h2 class="heading settled" data-level="8" id="url"><span class="secno">8. </span><span class="content"> A URL for Blob and File reference</span><a class="self-link" href="#url"></a></h2>
-   <p>This section defines a scheme for a URL used to refer to <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-83">Blob</a></code> objects (and <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-50">File</a></code> objects).</p>
+   <p>This section defines a scheme for a URL used to refer to <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-71">Blob</a></code> objects (and <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-50">File</a></code> objects).</p>
    <h3 class="heading settled" data-level="8.1" id="use-cases-scheme"><span class="secno">8.1. </span><span class="content"> Requirements for a New Scheme</span><a class="self-link" href="#use-cases-scheme"></a></h3>
    <p>This specification defines a scheme with URLs of the sort: <code>blob:550e8400-e29b-41d4-a716-446655440000#aboutABBA</code>.
 This section provides some requirements and is an informative discussion.</p>
@@ -3022,19 +2950,19 @@ so that web applications can respond to scenarios where the resource is not foun
     <li data-md="">
      <p>This scheme should have an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> policy and a <a data-link-type="dfn" href="#lifeTime" id="ref-for-lifeTime-1">lifetime</a> stipulation,
 to allow safe access to binary data from web applications.</p>
-     <p>URLs in this scheme should be used as a references to "in-memory" <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-84">Blob</a></code>s,
+     <p>URLs in this scheme should be used as a references to "in-memory" <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-72">Blob</a></code>s,
 and also be re-used elsewhere on the platform to refer to binary resources
 (e.g. for video-conferencing <a data-link-type="biblio" href="#biblio-webrtc">[WebRTC]</a>).
 URLs in this scheme are designed for impermanence,
 since they will be typically used to access "in memory" resources.</p>
     <li data-md="">
      <p>Developers should have the ability to revoke URLs in this scheme,
-so that they no longer refer to <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-85">Blob</a></code> objects.
+so that they no longer refer to <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-73">Blob</a></code> objects.
 This includes scenarios where file references are no longer needed by a program,
-but also other uses of <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-86">Blob</a></code> objects.
-Consider a scenario where a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-87">Blob</a></code> object can be exported from a drawing program
+but also other uses of <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-74">Blob</a></code> objects.
+Consider a scenario where a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-75">Blob</a></code> object can be exported from a drawing program
 which uses the canvas element and API <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.
-A snapshot of the drawing can be created by exporting a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-88">Blob</a></code>.
+A snapshot of the drawing can be created by exporting a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-76">Blob</a></code>.
 This scheme can be used with the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> <a data-link-type="biblio" href="#biblio-html">[HTML]</a> element to display the snapshot;
 if the user deletes the snapshot,
 any reference to the snapshot in memory via a URL should be invalid,
@@ -3052,7 +2980,7 @@ One broad consideration in determining what scheme to use is providing something
     <li data-md="">
      <p>HTTP could be repurposed for the use cases mentioned above;
 it already comes with well-defined request-response semantics that are already used by web applications.
-But <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-89">Blob</a></code> resources are typically "in-memory" resident
+But <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-77">Blob</a></code> resources are typically "in-memory" resident
 (e.g. after a file has been read into memory),
 and are thus unlike "traditional" HTTP resources that are dereferenced via DNS.
 While some user agents automatically "proxy" the underlying file system on the local machine via an HTTP server
@@ -3080,18 +3008,18 @@ In theory, URLs make no guarantee about what sort of resource is obtained when t
 that is left to content labeling and media type.
 But in practice, the name of the scheme creates an expectation about both the resource
 and the protocol of the request-response transaction.
-Choosing a name that clarifies the primary use case—<wbr>namely, access to memory-resident <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-90">Blob</a></code> resources—<wbr>is a worthwhile compromise,
+Choosing a name that clarifies the primary use case—<wbr>namely, access to memory-resident <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-78">Blob</a></code> resources—<wbr>is a worthwhile compromise,
 and favors clarity, familiarity, and consistency across the web platform.</p>
    </ul>
    <h3 class="heading settled" data-level="8.3" id="DefinitionOfScheme"><span class="secno">8.3. </span><span class="content"> The Blob URL</span><a class="self-link" href="#DefinitionOfScheme"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="blob-url">Blob URL</dfn> is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> with a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a> of <code>blob</code>,
-a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host">host</a> of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> of the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-3">Blob URL</a>,
+a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host">host</a> of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> of the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-2">Blob URL</a>,
 a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a> with one entry comprised of a UUID <a data-link-type="biblio" href="#biblio-rfc4122">[RFC4122]</a> (see <a href="#ABNFUUID">An ABNF for UUID</a>),
-and an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-object">object</a> of the associated <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-91">Blob</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-51">File</a></code>.
+and an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-object">object</a> of the associated <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-79">Blob</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-51">File</a></code>.
 A Blob URL may contain an optional <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment">fragment</a>.
 The Blob URL is serialized as a string according to the <a data-link-type="dfn" href="#unicodeBlobURL" id="ref-for-unicodeBlobURL-1">Serialization of a Blob URL</a> algorithm.</p>
    <p>A <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment">fragment</a>, if used,
-has a distinct interpretation depending on the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-92">Blob</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-52">File</a></code> resource in question
+has a distinct interpretation depending on the media type of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-80">Blob</a></code> or <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-52">File</a></code> resource in question
 (see <a href="#fragmentDiscussion">§8.3.3 Discussion of Fragment Identifier</a>).</p>
 <pre>blob = scheme ":" origin "/" UUID [fragIdentifier]
 
@@ -3105,7 +3033,7 @@ scheme = "blob"
 </pre>
    <div class="example" id="example-3011c08e"><a class="self-link" href="#example-3011c08e"></a> An example of a Blob URL might be <code>blob:https://example.org/9115d58c-bcda-ff47-86e5-083e9a215304</code>. </div>
    <h4 class="heading settled" data-level="8.3.1" id="originOfBlobURL"><span class="secno">8.3.1. </span><span class="content"> Origin of Blob URLs</span><a class="self-link" href="#originOfBlobURL"></a></h4>
-   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-4">Blob URLs</a> are created using <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-2">createObjectURL()</a></code></code>,
+   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-3">Blob URLs</a> are created using <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-2">createObjectURL()</a></code></code>,
 and are revoked using <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-1">revokeObjectURL()</a></code></code>.
 The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="origin of a Blob URL|Blob URL’s origin" data-noexport="" id="origin-of-a-blob-url">origin of a Blob URL</dfn> must be the same as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> specified by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a> at the time the method that created it was called.</p>
    <p class="issue" id="issue-4a4344c2"><a class="self-link" href="#issue-4a4344c2"></a> there is currently some confusion between the generic definition of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin of a URL</a> and the specific definition of the <a data-link-type="dfn" href="#origin-of-a-blob-url" id="ref-for-origin-of-a-blob-url-1">origin of a Blob URL</a>. This is
@@ -3146,7 +3074,7 @@ to <var>result</var>.</p>
    </ol>
    <h4 class="heading settled" data-level="8.3.3" id="fragmentDiscussion"><span class="secno">8.3.3. </span><span class="content"> Discussion of Fragment Identifier</span><a class="self-link" href="#fragmentDiscussion"></a></h4>
    <p>The <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment">fragment</a>’s resolution and processing directives depend on the media type <a data-link-type="biblio" href="#biblio-rfc2046">[RFC2046]</a> of a potentially retrieved representation,
-even though such a retrieval is only performed if the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-5">Blob URL</a> is <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-2">dereferenced</a>.
+even though such a retrieval is only performed if the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-4">Blob URL</a> is <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-2">dereferenced</a>.
 For example, in an HTML file <a data-link-type="biblio" href="#biblio-html">[HTML]</a> the fragment could be used to refer to an anchor within the file.
 If the user agent does not recognize the media type of the resource,
 OR if a fragment is not meaningful within the resource,
@@ -3158,8 +3086,8 @@ only the <code>blob</code> <a data-link-type="dfn" href="https://url.spec.whatwg
 The <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-4">createObjectURL()</a></code></code> method does not generate a fragment.</p>
    <h3 class="heading settled" data-level="8.4" id="requestResponseModel"><span class="secno">8.4. </span><span class="content"> Dereferencing Model for Blob URLs</span><a class="self-link" href="#requestResponseModel"></a></h3>
    <p><em>This section is informative.</em></p>
-   <p class="note" role="note"><span>Note:</span> The <a data-link-type="biblio" href="#biblio-url">[URL]</a> and <a data-link-type="biblio" href="#biblio-fetch">[Fetch]</a> specifications should be considered normative for parsing and fetching <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-6">Blob URLs</a>.</p>
-   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-7">Blob URLs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="dereference" data-noexport="" id="dereference">dereferenced</dfn> when the user agent retrieves the resource identified by the Blob URL
+   <p class="note" role="note"><span>Note:</span> The <a data-link-type="biblio" href="#biblio-url">[URL]</a> and <a data-link-type="biblio" href="#biblio-fetch">[Fetch]</a> specifications should be considered normative for parsing and fetching <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-5">Blob URLs</a>.</p>
+   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-6">Blob URLs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="dereference" data-noexport="" id="dereference">dereferenced</dfn> when the user agent retrieves the resource identified by the Blob URL
 and returns it to the requesting entity.
 This section provides guidance on <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">requests</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">responses</a></p>
    <p>Only <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">requests</a> with GET <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a> are supported.
@@ -3169,14 +3097,14 @@ Specifically, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#conce
 and no <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network errors</a> are generated.</p>
    <h4 class="heading settled" data-level="8.4.2" id="processing-media-types"><span class="secno">8.4.2. </span><span class="content"> Response Headers</span><a class="self-link" href="#processing-media-types"></a></h4>
    <p>Along with <a href="#TwoHundredOK">200 OK</a> responses,
-user agents use a Content-Type header <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a> that is equal to the value of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-93">Blob</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-22">type</a></code> attribute,
+user agents use a Content-Type header <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a> that is equal to the value of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-81">Blob</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-22">type</a></code> attribute,
 if it is not the empty string.</p>
    <p>Along with <a href="#TwoHundredOK">200 OK</a> responses,
-user agents use a Content-Length header <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a> that is equal to the value of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-94">Blob</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-11">size</a></code> attribute.</p>
+user agents use a Content-Length header <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a> that is equal to the value of the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-82">Blob</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-size" id="ref-for-dfn-size-10">size</a></code> attribute.</p>
    <p>If a Content-Type header <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a> is provided,
 then user agents obtain and process that media type
 in a manner consistent with the Mime Sniffing specification <a data-link-type="biblio" href="#biblio-mimesniff">[MIMESNIFF]</a>.</p>
-   <p>If a resource identified with a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-8">Blob URL</a> is a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-53">File</a></code> object,
+   <p>If a resource identified with a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-7">Blob URL</a> is a <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-53">File</a></code> object,
 user agents use that file’s <code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-4">name</a></code> attribute,
 as if the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> had a <code>Content-Disposition</code> header
 with the filename parameter set to the <code class="idl"><a data-link-type="idl" href="#dfn-file" id="ref-for-dfn-file-54">File</a></code>'s <code class="idl"><a data-link-type="idl" href="#dfn-name" id="ref-for-dfn-name-5">name</a></code> attribute <a data-link-type="biblio" href="#biblio-rfc6266">[RFC6266]</a>.</p>
@@ -3190,19 +3118,16 @@ Network errors are used when:</p>
     <li data-md="">
      <p>Any <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> method other than GET is used.</p>
     <li data-md="">
-     <p>The <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-9">Blob URL</a> does not have an entry in the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-2">Blob URL Store</a>.</p>
+     <p>The <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-8">Blob URL</a> does not have an entry in the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-1">Blob URL Store</a>.</p>
     <li data-md="">
-     <p>The Blob has been <a data-link-type="dfn" href="#closed" id="ref-for-closed-3">closed</a>;
-this also results in the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-10">Blob URL</a> not having an entry in the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-3">Blob URL Store</a>.</p>
-    <li data-md="">
-     <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-protocol">cross-origin requests</a> is made on a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-11">Blob URL</a>.</p>
+     <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-protocol">cross-origin requests</a> is made on a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-9">Blob URL</a>.</p>
     <li data-md="">
      <p>A security error has occurred.</p>
    </ul>
    <h4 class="heading settled" data-level="8.4.4" id="ProtocolExamples"><span class="secno">8.4.4. </span><span class="content"> Sample Request and Response Headers</span><a class="self-link" href="#ProtocolExamples"></a></h4>
    <p><em>This section is informative.</em></p>
-   <p>This section provides sample exchanges between web applications and user agents using <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-12">Blob URLs</a>.
-A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> can be triggered using HTML markup of the sort <code class="lang-markup highlight"><span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"blob:http://example.org:8080/550e8400-e29b-41d4-a716-446655440000"</span><span class="p">></span></code>.
+   <p>This section provides sample exchanges between web applications and user agents using <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-10">Blob URLs</a>.
+A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> can be triggered using HTML markup of the sort <code class="lang-markup highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"blob:http://example.org:8080/550e8400-e29b-41d4-a716-446655440000"</span><span class="nt">></span></code>.
 These examples merely illustrate the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>;
 web developers are not likely to interact with all the headers,
 but the <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-xmlhttprequest-getallresponseheaders">getAllResponseHeaders()</a></code> method of <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest">XMLHttpRequest</a></code>, if used,
@@ -3211,7 +3136,7 @@ will show relevant <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#
     <a class="self-link" href="#example-2129ccb8"></a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">Requests</a> could look like this: 
 <pre>GET http://example.org:8080/550e8400-e29b-41d4-a716-446655440000
 </pre>
-    <p>If the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-95">Blob</a></code> has an affiliated media type <a data-link-type="biblio" href="#biblio-rfc2046">[RFC2046]</a> represented by its <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-23">type</a></code> attribute,
+    <p>If the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-83">Blob</a></code> has an affiliated media type <a data-link-type="biblio" href="#biblio-rfc2046">[RFC2046]</a> represented by its <code class="idl"><a data-link-type="idl" href="#dfn-type" id="ref-for-dfn-type-23">type</a></code> attribute,
   then the response message should include the Content-Type header from RFC7231 <a data-link-type="biblio" href="#biblio-rfc7231">[RFC7231]</a>.
   See <a href="#processing-media-types">§8.4.2 Response Headers</a>.</p>
     <p>Example response:</p>
@@ -3221,19 +3146,19 @@ Content-Length: 21897
 
 ....
 </pre>
-    <p>If there is a <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-7">file read error</a> associated with the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-96">Blob</a></code>,
+    <p>If there is a <a data-link-type="dfn" href="#file-error-read" id="ref-for-file-error-read-7">file read error</a> associated with the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-84">Blob</a></code>,
   then a user agent acts as if a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> has occurred.</p>
    </div>
    <h3 class="heading settled" data-level="8.5" id="creating-revoking"><span class="secno">8.5. </span><span class="content"> Creating and Revoking a Blob URL</span><a class="self-link" href="#creating-revoking"></a></h3>
-   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-13">Blob URLs</a> are created and revoked using methods exposed on the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url">URL</a></code> object,
+   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-11">Blob URLs</a> are created and revoked using methods exposed on the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url">URL</a></code> object,
 supported by global objects <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> <a data-link-type="biblio" href="#biblio-html">[HTML]</a> and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> [[Web Workers]].
-Revocation of a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-14">Blob URL</a> decouples the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-15">Blob URL</a> from the resource it refers to,
+Revocation of a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-12">Blob URL</a> decouples the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-13">Blob URL</a> from the resource it refers to,
 and if it is dereferenced after it is revoked,
 user agents must act as if a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> has occurred.
-This section describes a supplemental interface to the URL specification <a data-link-type="biblio" href="#biblio-url">[URL]</a> and presents methods for <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-16">Blob URL</a> creation and revocation.</p>
+This section describes a supplemental interface to the URL specification <a data-link-type="biblio" href="#biblio-url">[URL]</a> and presents methods for <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-14">Blob URL</a> creation and revocation.</p>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">DedicatedWorker</span>,<span class="n">SharedWorker</span>)]
 <span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://url.spec.whatwg.org/#url">URL</a> {
-  <span class="kt">static</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-5">createObjectURL</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-97">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-10">blob</a>);
+  <span class="kt">static</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="method" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-5">createObjectURL</a>(<a class="n" data-link-type="idl-name" href="#dfn-Blob" id="ref-for-dfn-Blob-85">Blob</a> <a class="nv idl-code" data-link-type="argument" href="#dfn-fileBlob" id="ref-for-dfn-fileBlob-10">blob</a>);
   <span class="kt">static</span> <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-2">revokeObjectURL</a>(<span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-1">url</a>);
 };
 </pre>
@@ -3246,61 +3171,51 @@ and must NOT evaluate to true otherwise.</p>
    <dl>
     <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" id="dfn-createObjectURL">createObjectURL(blob)</dfn> static method 
     <dd>
-     Returns a unique <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-17">Blob URL</a>.
+     Returns a unique <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-15">Blob URL</a>.
     This method must act as follows: 
      <ol>
       <li data-md="">
-       <p>If called with a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-98">Blob</a></code> argument that has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-19">readability state</a> of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-12"><code>CLOSED</code></a>,
-user agents must return the output of the <a data-link-type="dfn" href="#unicodeBlobURL" id="ref-for-unicodeBlobURL-2">Serialization of a Blob URL</a> algorithm.</p>
-       <p class="note" role="note"><span>Note:</span> No entry is added to the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-4">Blob URL Store</a>;
-consequently, when this <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-18">Blob URL</a> is <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-3">dereferenced</a>,
-a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> occurs.</p>
+       <p>Let <var>url</var> be the result of the <a data-link-type="dfn" href="#unicodeBlobURL" id="ref-for-unicodeBlobURL-2">Serialization of a Blob URL</a> algorithm.</p>
       <li data-md="">
-       <p>Otherwise, user agents must run the following sub-steps:</p>
-       <ol>
-        <li data-md="">
-         <p>Let <var>url</var> be the result of the <a data-link-type="dfn" href="#unicodeBlobURL" id="ref-for-unicodeBlobURL-3">Serialization of a Blob URL</a> algorithm.</p>
-        <li data-md="">
-         <p><a data-link-type="dfn" href="#add-an-entry" id="ref-for-add-an-entry-1">Add an entry to the Blob URL Store</a> for <var>url</var> and <var>blob</var>.</p>
-        <li data-md="">
-         <p>Return <var>url</var>.</p>
-       </ol>
+       <p><a data-link-type="dfn" href="#add-an-entry" id="ref-for-add-an-entry-1">Add an entry to the Blob URL Store</a> for <var>url</var> and <var>blob</var>.</p>
+      <li data-md="">
+       <p>Return <var>url</var>.</p>
      </ol>
     <dt>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL" data-dfn-type="method" data-export="" id="dfn-revokeObjectURL">revokeObjectURL(url)</dfn> static method 
     <dd>
-     Revokes the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-19">Blob URL</a> provided in the string <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-2">url</a></code> by removing the corresponding entry from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-5">Blob URL Store</a>.
+     Revokes the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-16">Blob URL</a> provided in the string <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-2">url</a></code> by removing the corresponding entry from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-2">Blob URL Store</a>.
     This method must act as follows: 
      <ol>
       <li data-md="">
-       <p>If the <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-3">url</a></code> refers to a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-99">Blob</a></code> that has a <a data-link-type="dfn" href="#readabilityState" id="ref-for-readabilityState-20">readability state</a> of <a data-link-type="dfn" href="#dfn-closedState" id="ref-for-dfn-closedState-13"><code>CLOSED</code></a> OR if the value provided for the <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-4">url</a></code> argument is not a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-20">Blob URL</a>,
-OR if the value provided for the <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-5">url</a></code> argument does not have an entry in the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-6">Blob URL Store</a>,
+       <p>If the value provided for the <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-3">url</a></code> argument is not a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-17">Blob URL</a>,
+OR if the value provided for the <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-4">url</a></code> argument does not have an entry in the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-3">Blob URL Store</a>,
 this method call does nothing.
 User agents may display a message on the error console.</p>
       <li data-md="">
-       <p>Otherwise, user agents must <a data-link-type="dfn" href="#removeTheEntry" id="ref-for-removeTheEntry-2">remove the entry</a> from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-7">Blob URL Store</a> for <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-6">url</a></code>.</p>
-       <p class="note" role="note"><span>Note:</span> Subsequent attemps to dereference <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-7">url</a></code> result in a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>,
-since the entry has been removed from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-8">Blob URL Store</a>.</p>
+       <p>Otherwise, user agents must <a data-link-type="dfn" href="#removeTheEntry" id="ref-for-removeTheEntry-1">remove the entry</a> from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-4">Blob URL Store</a> for <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-5">url</a></code>.</p>
+       <p class="note" role="note"><span>Note:</span> Subsequent attemps to dereference <code class="idl"><a class="idl-code" data-link-type="argument" href="#dfn-urlarg" id="ref-for-dfn-urlarg-6">url</a></code> result in a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>,
+since the entry has been removed from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-5">Blob URL Store</a>.</p>
      </ol>
      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="URL/revokeObjectURL(url)" data-dfn-type="argument" data-export="" id="dfn-urlarg">url</dfn> argument to the <code class="idl"><a data-link-type="idl" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-3">revokeObjectURL()</a></code> method
-    is a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-21">Blob URL</a> string.</p>
+    is a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-18">Blob URL</a> string.</p>
      <div class="example" id="example-a97f8a33">
       <a class="self-link" href="#example-a97f8a33"></a> In the example below, <code>window1</code> and <code>window2</code> are separate,
       but in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>; <code>window2</code> could be an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code> inside <code>window1</code>. 
 <pre class="lang-javascript highlight">myurl <span class="o">=</span> window1<span class="p">.</span>URL<span class="p">.</span>createObjectURL<span class="p">(</span>myblob<span class="p">)</span><span class="p">;</span>
 window2<span class="p">.</span>URL<span class="p">.</span>revokeObjectURL<span class="p">(</span>myurl<span class="p">)</span><span class="p">;</span>
 </pre>
-      <p>Since <code>window1</code> and <code>window2</code> are in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a> and share the same <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-9">Blob URL Store</a>,
+      <p>Since <code>window1</code> and <code>window2</code> are in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a> and share the same <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-6">Blob URL Store</a>,
       the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-4">revokeObjectURL()</a></code></code> call
       ensures that subsequent dereferencing of <code>myurl</code> results in a the user agent acting as if a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> has occurred.</p>
      </div>
    </dl>
    <h4 class="heading settled" data-level="8.5.2" id="examplesOfCreationRevocation"><span class="secno">8.5.2. </span><span class="content"> Examples of Blob URL Creation and Revocation</span><a class="self-link" href="#examplesOfCreationRevocation"></a></h4>
-   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-22">Blob URL</a>s are strings that are used to <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-4">dereference</a> <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-100">Blob</a></code> objects,
+   <p><a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-19">Blob URL</a>s are strings that are used to <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-3">dereference</a> <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-86">Blob</a></code> objects,
 and can persist for as long as the <code>document</code> from which they were minted
 using <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-6">createObjectURL()</a></code></code>—<wbr>see <a href="#lifeTime" id="ref-for-lifeTime-2">§8.6 Lifetime of Blob URLs</a>.</p>
-   <p>This section gives sample usage of creation and revocation of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-23">Blob URL</a>s with explanations.</p>
+   <p>This section gives sample usage of creation and revocation of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-20">Blob URL</a>s with explanations.</p>
    <div class="example" id="example-1c236228">
-    <a class="self-link" href="#example-1c236228"></a> In the example below, two <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> elements <a data-link-type="biblio" href="#biblio-html">[HTML]</a> refer to the same <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-24">Blob URL</a>: 
+    <a class="self-link" href="#example-1c236228"></a> In the example below, two <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> elements <a data-link-type="biblio" href="#biblio-html">[HTML]</a> refer to the same <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-21">Blob URL</a>: 
 <pre class="lang-javascript highlight">url <span class="o">=</span> URL<span class="p">.</span>createObjectURL<span class="p">(</span>blob<span class="p">)</span><span class="p">;</span>
 img1<span class="p">.</span>src <span class="o">=</span> url<span class="p">;</span>
 img2<span class="p">.</span>src <span class="o">=</span> url<span class="p">;</span>
@@ -3328,22 +3243,22 @@ img2<span class="p">.</span>src <span class="o">=</span> blobURLref<span class="
 <span class="p">}</span>
 </pre>
    </div>
-   <p>The example above allows multiple references to a single <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-25">Blob URL</a>,
-and the web developer then revokes the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-26">Blob URL</a> string after both image objects have been loaded.
-While not restricting number of uses of the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-27">Blob URL</a> offers more flexibility,
+   <p>The example above allows multiple references to a single <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-22">Blob URL</a>,
+and the web developer then revokes the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-23">Blob URL</a> string after both image objects have been loaded.
+While not restricting number of uses of the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-24">Blob URL</a> offers more flexibility,
 it increases the likelihood of leaks;
 developers should pair it with a corresponding call to <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-revokeObjectURL" id="ref-for-dfn-revokeObjectURL-6">revokeObjectURL()</a></code></code>.</p>
    <h3 class="heading settled dfn-paneled" data-dfn-for="blob url" data-dfn-type="dfn" data-export="" data-level="8.6" data-lt="lifetime|lifetime stipulation" id="lifeTime"><span class="secno">8.6. </span><span class="content"> Lifetime of Blob URLs</span></h3>
-   <p>A global object which exposes <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-7">createObjectURL()</a></code></code> must maintain a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="BlobURLStore">Blob URL Store</dfn> which is a list of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-28">Blob URLs</a> created by the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-8">createObjectURL()</a></code></code> method,
-and the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-101">Blob</a></code> resource that each refers to.</p>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="add an entry|add the entry|add an entry to the Blob URL Store|add the entry to the Blob URL Store" data-noexport="" id="add-an-entry">add an entry to the Blob URL Store</dfn> for a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-29">Blob URL</a> and a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-102">Blob</a></code> input,
-the user-agent must add the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-30">Blob URL</a> and a reference to the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-103">Blob</a></code> it refers to to the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-10">Blob URL Store</a>.</p>
-   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="remove an entry|remove the entry|remove an entry from the Blob URL Store|remove the entry from the Blob URL Store" data-noexport="" id="removeTheEntry">remove an entry from the Blob URL Store</dfn> for a given <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-31">Blob URL</a> or for a given <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-104">Blob</a></code>,
-user agents must remove the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-32">Blob URL</a> and the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-105">Blob</a></code> it refers to from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-11">Blob URL Store</a>.
-Subsequent attempts to <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-5">dereference</a> this URL must result in a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
+   <p>A global object which exposes <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-7">createObjectURL()</a></code></code> must maintain a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="BlobURLStore">Blob URL Store</dfn> which is a list of <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-25">Blob URLs</a> created by the <code>URL.<code class="idl"><a data-link-type="idl" href="#dfn-createObjectURL" id="ref-for-dfn-createObjectURL-8">createObjectURL()</a></code></code> method,
+and the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-87">Blob</a></code> resource that each refers to.</p>
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="add an entry|add the entry|add an entry to the Blob URL Store|add the entry to the Blob URL Store" data-noexport="" id="add-an-entry">add an entry to the Blob URL Store</dfn> for a <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-26">Blob URL</a> and a <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-88">Blob</a></code> input,
+the user-agent must add the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-27">Blob URL</a> and a reference to the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-89">Blob</a></code> it refers to to the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-7">Blob URL Store</a>.</p>
+   <p>When this specification says to <dfn class="dfn-paneled" data-dfn-for="blob url store" data-dfn-type="dfn" data-lt="remove an entry|remove the entry|remove an entry from the Blob URL Store|remove the entry from the Blob URL Store" data-noexport="" id="removeTheEntry">remove an entry from the Blob URL Store</dfn> for a given <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-28">Blob URL</a> or for a given <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-90">Blob</a></code>,
+user agents must remove the <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-29">Blob URL</a> and the <code class="idl"><a data-link-type="idl" href="#dfn-Blob" id="ref-for-dfn-Blob-91">Blob</a></code> it refers to from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-8">Blob URL Store</a>.
+Subsequent attempts to <a data-link-type="dfn" href="#dereference" id="ref-for-dereference-4">dereference</a> this URL must result in a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
    <p>This specification adds an additional <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unloading-document-cleanup-steps">unloading document cleanup step</a>:
-user agents must remove all <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-33">Blob URLs</a> from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-12">Blob URL Store</a> within that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">document</a>.</p>
-   <p class="note" role="note"><span>Note:</span> User agents are free to garbage collect resources removed from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-13">Blob URL Store</a>.</p>
+user agents must remove all <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-30">Blob URLs</a> from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-9">Blob URL Store</a> within that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">document</a>.</p>
+   <p class="note" role="note"><span>Note:</span> User agents are free to garbage collect resources removed from the <a data-link-type="dfn" href="#BlobURLStore" id="ref-for-BlobURLStore-10">Blob URL Store</a>.</p>
    <h2 class="heading settled" data-level="9" id="security-discussion"><span class="secno">9. </span><span class="content"> Security and Privacy Considerations</span><a class="self-link" href="#security-discussion"></a></h2>
    <p><em>This section is informative.</em></p>
    <p>This specification allows web content to read files from the underlying file system,
@@ -3362,7 +3277,7 @@ and a user agent may prevent file access to any selections by making the <code c
     <li data-md="">
      <p><dfn data-dfn-type="dfn" data-noexport="" id="sensitive-files">System-sensitive files<a class="self-link" href="#sensitive-files"></a></dfn> (e.g. files in /usr/bin, password files, and other native operating system executables)
 typically should not be exposed to web content,
-and should not be accessed via <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-34">Blob URLs</a>.
+and should not be accessed via <a data-link-type="dfn" href="#blob-url" id="ref-for-blob-url-31">Blob URLs</a>.
 User agents may <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> exception for synchronous read methods,
 or return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> exception for asynchronous reads.</p>
    </ul>
@@ -3530,9 +3445,6 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <li><a href="#blob-url">Blob URL</a><span>, in §8.3</span>
    <li><a href="#origin-of-a-blob-url">Blob URL’s origin</a><span>, in §8.3.1</span>
    <li><a href="#BlobURLStore">Blob URL Store</a><span>, in §8.6</span>
-   <li><a href="#dfn-close">close()</a><span>, in §3.3.2</span>
-   <li><a href="#closed">closed</a><span>, in §3</span>
-   <li><a href="#dfn-closedState">CLOSED</a><span>, in §3</span>
    <li><a href="#dfn-createObjectURL">createObjectURL(blob)</a><span>, in §8.5.1</span>
    <li><a href="#dereference">dereference</a><span>, in §8.4</span>
    <li><a href="#dfn-done">DONE</a><span>, in §6.3.3</span>
@@ -3559,7 +3471,6 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <li><a href="#fileReadingTaskSource">file reading task source</a><span>, in §6.2</span>
    <li><a href="#file-type-guidelines">file type guidelines</a><span>, in §4</span>
    <li><a href="#fire-a-progress-event">fire a progress event</a><span>, in §6.5</span>
-   <li><a href="#dfn-isClosed">isClosed</a><span>, in §3.2</span>
    <li><a href="#dfn-item">item(index)</a><span>, in §5.2</span>
    <li>
     lastModified
@@ -3582,7 +3493,6 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <li><a href="#dfn-onloadend">onloadend</a><span>, in §6.3.2</span>
    <li><a href="#dfn-onloadstart">onloadstart</a><span>, in §6.3.2</span>
    <li><a href="#dfn-onprogress">onprogress</a><span>, in §6.3.2</span>
-   <li><a href="#dfn-openState">OPENED</a><span>, in §3</span>
    <li><a href="#origin-of-a-blob-url">origin of a Blob URL</a><span>, in §8.3.1</span>
    <li><a href="#selection-looping">Preventing selection looping</a><span>, in §9</span>
    <li><a href="#dfn-processing-equivalence">processing equivalence</a><span>, in §Unnumbered section</span>
@@ -3591,7 +3501,6 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
    <li><a href="#process-read-EOF">process read EOF</a><span>, in §6.1</span>
    <li><a href="#process-read-error">process read error</a><span>, in §6.1</span>
    <li><a href="#dfn-progress-event">progress</a><span>, in §6.5.1</span>
-   <li><a href="#readabilityState">readability state</a><span>, in §3</span>
    <li>
     readAsArrayBuffer(blob)
     <ul>
@@ -3753,7 +3662,6 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
      <li><a href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a>
      <li><a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>
      <li><a href="https://heycam.github.io/webidl/#idl-USVString">USVString</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">get a copy of the buffer source</a>
      <li><a href="https://heycam.github.io/webidl/#idl-long-long">long long</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-supported-property-indices">supported property indices</a>
@@ -3834,15 +3742,11 @@ sub-delims    = "!" / "$" / "&amp;" / "'" / "(" / ")" /
 
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long" href="#dfn-size">size</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dfn-type">type</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dfn-isClosed">isClosed</a>;
 
-  //slice Blob into byte-ranged chunks
-
+  // slice Blob into byte-ranged chunks
   <a class="n" data-link-type="idl-name" href="#dfn-Blob">Blob</a> <a class="nv idl-code" data-link-type="method" href="#dfn-slice">slice</a>([<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Clamp">Clamp</a>] <span class="kt">optional</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-start">start</a>,
             [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Clamp">Clamp</a>] <span class="kt">optional</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-end">end</a>,
             <span class="kt">optional</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="argument" href="#dfn-contentTypeBlob">contentType</a>);
-  <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dfn-close">close</a>();
-
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dfn-BlobPropertyBag">BlobPropertyBag</a> {
@@ -3930,30 +3834,28 @@ tracked in <a href="https://github.com/w3c/FileAPI/issues/63">issue #63</a> and 
   <aside class="dfn-panel" data-for="terminate-an-algorithm">
    <b><a href="#terminate-an-algorithm">#terminate-an-algorithm</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-terminate-an-algorithm-1">3.3.2. 
-The close method</a>
-    <li><a href="#ref-for-terminate-an-algorithm-2">6.1. 
-The Read Operation</a> <a href="#ref-for-terminate-an-algorithm-3">(2)</a> <a href="#ref-for-terminate-an-algorithm-4">(3)</a>
-    <li><a href="#ref-for-terminate-an-algorithm-5">6.3.4.2. 
-The readAsDataURL() method</a> <a href="#ref-for-terminate-an-algorithm-6">(2)</a> <a href="#ref-for-terminate-an-algorithm-7">(3)</a>
-    <li><a href="#ref-for-terminate-an-algorithm-8">6.3.4.3. 
-The readAsText() method</a> <a href="#ref-for-terminate-an-algorithm-9">(2)</a> <a href="#ref-for-terminate-an-algorithm-10">(3)</a>
-    <li><a href="#ref-for-terminate-an-algorithm-11">6.3.4.4. 
-The readAsArrayBuffer() method</a> <a href="#ref-for-terminate-an-algorithm-12">(2)</a> <a href="#ref-for-terminate-an-algorithm-13">(3)</a>
-    <li><a href="#ref-for-terminate-an-algorithm-14">6.3.4.5. 
-The readAsBinaryString() method</a> <a href="#ref-for-terminate-an-algorithm-15">(2)</a> <a href="#ref-for-terminate-an-algorithm-16">(3)</a>
-    <li><a href="#ref-for-terminate-an-algorithm-17">6.3.4.6. 
+    <li><a href="#ref-for-terminate-an-algorithm-1">6.1. 
+The Read Operation</a> <a href="#ref-for-terminate-an-algorithm-2">(2)</a> <a href="#ref-for-terminate-an-algorithm-3">(3)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-4">6.3.4.2. 
+The readAsDataURL() method</a> <a href="#ref-for-terminate-an-algorithm-5">(2)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-6">6.3.4.3. 
+The readAsText() method</a> <a href="#ref-for-terminate-an-algorithm-7">(2)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-8">6.3.4.4. 
+The readAsArrayBuffer() method</a> <a href="#ref-for-terminate-an-algorithm-9">(2)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-10">6.3.4.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-terminate-an-algorithm-11">(2)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-12">6.3.4.6. 
 Error Steps</a>
-    <li><a href="#ref-for-terminate-an-algorithm-18">6.3.4.7. 
-The abort() method</a> <a href="#ref-for-terminate-an-algorithm-19">(2)</a>
-    <li><a href="#ref-for-terminate-an-algorithm-20">6.6.1.2. 
-The readAsText() method</a> <a href="#ref-for-terminate-an-algorithm-21">(2)</a> <a href="#ref-for-terminate-an-algorithm-22">(3)</a>
-    <li><a href="#ref-for-terminate-an-algorithm-23">6.6.1.3. 
-The readAsDataURL() method</a> <a href="#ref-for-terminate-an-algorithm-24">(2)</a> <a href="#ref-for-terminate-an-algorithm-25">(3)</a>
-    <li><a href="#ref-for-terminate-an-algorithm-26">6.6.1.4. 
-The readAsArrayBuffer() method</a> <a href="#ref-for-terminate-an-algorithm-27">(2)</a> <a href="#ref-for-terminate-an-algorithm-28">(3)</a>
-    <li><a href="#ref-for-terminate-an-algorithm-29">6.6.1.5. 
-The readAsBinaryString() method</a> <a href="#ref-for-terminate-an-algorithm-30">(2)</a> <a href="#ref-for-terminate-an-algorithm-31">(3)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-13">6.3.4.7. 
+The abort() method</a> <a href="#ref-for-terminate-an-algorithm-14">(2)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-15">6.6.1.2. 
+The readAsText() method</a> <a href="#ref-for-terminate-an-algorithm-16">(2)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-17">6.6.1.3. 
+The readAsDataURL() method</a> <a href="#ref-for-terminate-an-algorithm-18">(2)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-19">6.6.1.4. 
+The readAsArrayBuffer() method</a> <a href="#ref-for-terminate-an-algorithm-20">(2)</a>
+    <li><a href="#ref-for-terminate-an-algorithm-21">6.6.1.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-terminate-an-algorithm-22">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="UnixEpoch">
@@ -3963,82 +3865,6 @@ The readAsBinaryString() method</a> <a href="#ref-for-terminate-an-algorithm-30"
 Constructor</a> <a href="#ref-for-UnixEpoch-2">(2)</a>
     <li><a href="#ref-for-UnixEpoch-3">4.2. 
 Attributes</a> <a href="#ref-for-UnixEpoch-4">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="readabilityState">
-   <b><a href="#readabilityState">#readabilityState</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-readabilityState-1">3. 
-The Blob Interface and Binary Data</a> <a href="#ref-for-readabilityState-2">(2)</a>
-    <li><a href="#ref-for-readabilityState-3">3.1. 
-Constructors</a> <a href="#ref-for-readabilityState-4">(2)</a>
-    <li><a href="#ref-for-readabilityState-5">3.2. 
-Attributes</a> <a href="#ref-for-readabilityState-6">(2)</a> <a href="#ref-for-readabilityState-7">(3)</a>
-    <li><a href="#ref-for-readabilityState-8">3.3.1. 
-The slice method</a> <a href="#ref-for-readabilityState-9">(2)</a> <a href="#ref-for-readabilityState-10">(3)</a>
-    <li><a href="#ref-for-readabilityState-11">3.3.2. 
-The close method</a> <a href="#ref-for-readabilityState-12">(2)</a>
-    <li><a href="#ref-for-readabilityState-13">4.1. 
-Constructor</a>
-    <li><a href="#ref-for-readabilityState-14">6.1. 
-The Read Operation</a>
-    <li><a href="#ref-for-readabilityState-15">6.3.4.2. 
-The readAsDataURL() method</a>
-    <li><a href="#ref-for-readabilityState-16">6.3.4.3. 
-The readAsText() method</a>
-    <li><a href="#ref-for-readabilityState-17">6.3.4.4. 
-The readAsArrayBuffer() method</a>
-    <li><a href="#ref-for-readabilityState-18">6.3.4.5. 
-The readAsBinaryString() method</a>
-    <li><a href="#ref-for-readabilityState-19">8.5.1. 
-Methods and Parameters</a> <a href="#ref-for-readabilityState-20">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dfn-openState">
-   <b><a href="#dfn-openState">#dfn-openState</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dfn-openState-1">3. 
-The Blob Interface and Binary Data</a>
-    <li><a href="#ref-for-dfn-openState-2">3.1. 
-Constructors</a> <a href="#ref-for-dfn-openState-3">(2)</a>
-    <li><a href="#ref-for-dfn-openState-4">3.2. 
-Attributes</a>
-    <li><a href="#ref-for-dfn-openState-5">4.1. 
-Constructor</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="closed">
-   <b><a href="#closed">#closed</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-closed-1">3. 
-The Blob Interface and Binary Data</a>
-    <li><a href="#ref-for-closed-2">3.3.2. 
-The close method</a>
-    <li><a href="#ref-for-closed-3">8.4.3. 
-Network Errors</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dfn-closedState">
-   <b><a href="#dfn-closedState">#dfn-closedState</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dfn-closedState-1">3. 
-The Blob Interface and Binary Data</a>
-    <li><a href="#ref-for-dfn-closedState-2">3.2. 
-Attributes</a> <a href="#ref-for-dfn-closedState-3">(2)</a> <a href="#ref-for-dfn-closedState-4">(3)</a>
-    <li><a href="#ref-for-dfn-closedState-5">3.3.2. 
-The close method</a> <a href="#ref-for-dfn-closedState-6">(2)</a>
-    <li><a href="#ref-for-dfn-closedState-7">6.1. 
-The Read Operation</a>
-    <li><a href="#ref-for-dfn-closedState-8">6.3.4.2. 
-The readAsDataURL() method</a>
-    <li><a href="#ref-for-dfn-closedState-9">6.3.4.3. 
-The readAsText() method</a>
-    <li><a href="#ref-for-dfn-closedState-10">6.3.4.4. 
-The readAsArrayBuffer() method</a>
-    <li><a href="#ref-for-dfn-closedState-11">6.3.4.5. 
-The readAsBinaryString() method</a>
-    <li><a href="#ref-for-dfn-closedState-12">8.5.1. 
-Methods and Parameters</a> <a href="#ref-for-dfn-closedState-13">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="snapshot-state">
@@ -4069,67 +3895,63 @@ Constructor Parameters</a>
     <li><a href="#ref-for-dfn-Blob-1">1. 
 Introduction</a> <a href="#ref-for-dfn-Blob-2">(2)</a> <a href="#ref-for-dfn-Blob-3">(3)</a>
     <li><a href="#ref-for-dfn-Blob-4">3. 
-The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-Blob-5">(2)</a> <a href="#ref-for-dfn-Blob-6">(3)</a> <a href="#ref-for-dfn-Blob-7">(4)</a> <a href="#ref-for-dfn-Blob-8">(5)</a> <a href="#ref-for-dfn-Blob-9">(6)</a> <a href="#ref-for-dfn-Blob-10">(7)</a> <a href="#ref-for-dfn-Blob-11">(8)</a>
-    <li><a href="#ref-for-dfn-Blob-12">3.1. 
-Constructors</a> <a href="#ref-for-dfn-Blob-13">(2)</a> <a href="#ref-for-dfn-Blob-14">(3)</a> <a href="#ref-for-dfn-Blob-15">(4)</a> <a href="#ref-for-dfn-Blob-16">(5)</a> <a href="#ref-for-dfn-Blob-17">(6)</a>
-    <li><a href="#ref-for-dfn-Blob-18">3.1.1. 
-Constructor Parameters</a> <a href="#ref-for-dfn-Blob-19">(2)</a>
-    <li><a href="#ref-for-dfn-Blob-20">3.2. 
-Attributes</a> <a href="#ref-for-dfn-Blob-21">(2)</a> <a href="#ref-for-dfn-Blob-22">(3)</a> <a href="#ref-for-dfn-Blob-23">(4)</a> <a href="#ref-for-dfn-Blob-24">(5)</a> <a href="#ref-for-dfn-Blob-25">(6)</a> <a href="#ref-for-dfn-Blob-26">(7)</a> <a href="#ref-for-dfn-Blob-27">(8)</a> <a href="#ref-for-dfn-Blob-28">(9)</a>
-    <li><a href="#ref-for-dfn-Blob-29">3.3.1. 
-The slice method</a> <a href="#ref-for-dfn-Blob-30">(2)</a> <a href="#ref-for-dfn-Blob-31">(3)</a> <a href="#ref-for-dfn-Blob-32">(4)</a> <a href="#ref-for-dfn-Blob-33">(5)</a> <a href="#ref-for-dfn-Blob-34">(6)</a>
-    <li><a href="#ref-for-dfn-Blob-35">3.3.2. 
-The close method</a>
-    <li><a href="#ref-for-dfn-Blob-36">4. 
-The File Interface</a> <a href="#ref-for-dfn-Blob-37">(2)</a>
-    <li><a href="#ref-for-dfn-Blob-38">4.1. 
-Constructor</a> <a href="#ref-for-dfn-Blob-39">(2)</a> <a href="#ref-for-dfn-Blob-40">(3)</a>
-    <li><a href="#ref-for-dfn-Blob-41">4.1.1. 
+The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-Blob-5">(2)</a> <a href="#ref-for-dfn-Blob-6">(3)</a> <a href="#ref-for-dfn-Blob-7">(4)</a>
+    <li><a href="#ref-for-dfn-Blob-8">3.1. 
+Constructors</a> <a href="#ref-for-dfn-Blob-9">(2)</a> <a href="#ref-for-dfn-Blob-10">(3)</a> <a href="#ref-for-dfn-Blob-11">(4)</a> <a href="#ref-for-dfn-Blob-12">(5)</a> <a href="#ref-for-dfn-Blob-13">(6)</a>
+    <li><a href="#ref-for-dfn-Blob-14">3.1.1. 
+Constructor Parameters</a> <a href="#ref-for-dfn-Blob-15">(2)</a>
+    <li><a href="#ref-for-dfn-Blob-16">3.2. 
+Attributes</a> <a href="#ref-for-dfn-Blob-17">(2)</a> <a href="#ref-for-dfn-Blob-18">(3)</a> <a href="#ref-for-dfn-Blob-19">(4)</a> <a href="#ref-for-dfn-Blob-20">(5)</a>
+    <li><a href="#ref-for-dfn-Blob-21">3.3.1. 
+The slice method</a> <a href="#ref-for-dfn-Blob-22">(2)</a> <a href="#ref-for-dfn-Blob-23">(3)</a> <a href="#ref-for-dfn-Blob-24">(4)</a>
+    <li><a href="#ref-for-dfn-Blob-25">4. 
+The File Interface</a> <a href="#ref-for-dfn-Blob-26">(2)</a>
+    <li><a href="#ref-for-dfn-Blob-27">4.1. 
+Constructor</a> <a href="#ref-for-dfn-Blob-28">(2)</a> <a href="#ref-for-dfn-Blob-29">(3)</a>
+    <li><a href="#ref-for-dfn-Blob-30">4.1.1. 
 Constructor Parameters</a>
-    <li><a href="#ref-for-dfn-Blob-42">4.2. 
+    <li><a href="#ref-for-dfn-Blob-31">4.2. 
 Attributes</a>
-    <li><a href="#ref-for-dfn-Blob-43">6.1. 
-The Read Operation</a> <a href="#ref-for-dfn-Blob-44">(2)</a> <a href="#ref-for-dfn-Blob-45">(3)</a> <a href="#ref-for-dfn-Blob-46">(4)</a> <a href="#ref-for-dfn-Blob-47">(5)</a>
-    <li><a href="#ref-for-dfn-Blob-48">6.2. 
+    <li><a href="#ref-for-dfn-Blob-32">6.1. 
+The Read Operation</a> <a href="#ref-for-dfn-Blob-33">(2)</a> <a href="#ref-for-dfn-Blob-34">(3)</a> <a href="#ref-for-dfn-Blob-35">(4)</a>
+    <li><a href="#ref-for-dfn-Blob-36">6.2. 
 The File Reading Task Source</a>
-    <li><a href="#ref-for-dfn-Blob-49">6.3. 
-The FileReader API</a> <a href="#ref-for-dfn-Blob-50">(2)</a> <a href="#ref-for-dfn-Blob-51">(3)</a> <a href="#ref-for-dfn-Blob-52">(4)</a>
-    <li><a href="#ref-for-dfn-Blob-53">6.3.3. 
-FileReader States</a> <a href="#ref-for-dfn-Blob-54">(2)</a> <a href="#ref-for-dfn-Blob-55">(3)</a>
-    <li><a href="#ref-for-dfn-Blob-56">6.3.4.1. 
-The result attribute</a> <a href="#ref-for-dfn-Blob-57">(2)</a> <a href="#ref-for-dfn-Blob-58">(3)</a> <a href="#ref-for-dfn-Blob-59">(4)</a> <a href="#ref-for-dfn-Blob-60">(5)</a> <a href="#ref-for-dfn-Blob-61">(6)</a> <a href="#ref-for-dfn-Blob-62">(7)</a> <a href="#ref-for-dfn-Blob-63">(8)</a>
-    <li><a href="#ref-for-dfn-Blob-64">6.3.4.8. 
-Blob Parameters</a> <a href="#ref-for-dfn-Blob-65">(2)</a> <a href="#ref-for-dfn-Blob-66">(3)</a>
-    <li><a href="#ref-for-dfn-Blob-67">6.4. 
+    <li><a href="#ref-for-dfn-Blob-37">6.3. 
+The FileReader API</a> <a href="#ref-for-dfn-Blob-38">(2)</a> <a href="#ref-for-dfn-Blob-39">(3)</a> <a href="#ref-for-dfn-Blob-40">(4)</a>
+    <li><a href="#ref-for-dfn-Blob-41">6.3.3. 
+FileReader States</a> <a href="#ref-for-dfn-Blob-42">(2)</a> <a href="#ref-for-dfn-Blob-43">(3)</a>
+    <li><a href="#ref-for-dfn-Blob-44">6.3.4.1. 
+The result attribute</a> <a href="#ref-for-dfn-Blob-45">(2)</a> <a href="#ref-for-dfn-Blob-46">(3)</a> <a href="#ref-for-dfn-Blob-47">(4)</a> <a href="#ref-for-dfn-Blob-48">(5)</a> <a href="#ref-for-dfn-Blob-49">(6)</a> <a href="#ref-for-dfn-Blob-50">(7)</a> <a href="#ref-for-dfn-Blob-51">(8)</a>
+    <li><a href="#ref-for-dfn-Blob-52">6.3.4.8. 
+Blob Parameters</a> <a href="#ref-for-dfn-Blob-53">(2)</a> <a href="#ref-for-dfn-Blob-54">(3)</a>
+    <li><a href="#ref-for-dfn-Blob-55">6.4. 
 Determining Encoding</a>
-    <li><a href="#ref-for-dfn-Blob-68">6.6. 
+    <li><a href="#ref-for-dfn-Blob-56">6.6. 
 Reading on Threads</a>
-    <li><a href="#ref-for-dfn-Blob-69">6.6.1. 
-The FileReaderSync API</a> <a href="#ref-for-dfn-Blob-70">(2)</a> <a href="#ref-for-dfn-Blob-71">(3)</a> <a href="#ref-for-dfn-Blob-72">(4)</a> <a href="#ref-for-dfn-Blob-73">(5)</a>
-    <li><a href="#ref-for-dfn-Blob-74">7. 
-Errors and Exceptions</a> <a href="#ref-for-dfn-Blob-75">(2)</a> <a href="#ref-for-dfn-Blob-76">(3)</a>
-    <li><a href="#ref-for-dfn-Blob-77">7.1. 
-Throwing an Exception or Returning an Error</a> <a href="#ref-for-dfn-Blob-78">(2)</a> <a href="#ref-for-dfn-Blob-79">(3)</a> <a href="#ref-for-dfn-Blob-80">(4)</a> <a href="#ref-for-dfn-Blob-81">(5)</a> <a href="#ref-for-dfn-Blob-82">(6)</a>
-    <li><a href="#ref-for-dfn-Blob-83">8. 
+    <li><a href="#ref-for-dfn-Blob-57">6.6.1. 
+The FileReaderSync API</a> <a href="#ref-for-dfn-Blob-58">(2)</a> <a href="#ref-for-dfn-Blob-59">(3)</a> <a href="#ref-for-dfn-Blob-60">(4)</a> <a href="#ref-for-dfn-Blob-61">(5)</a>
+    <li><a href="#ref-for-dfn-Blob-62">7. 
+Errors and Exceptions</a> <a href="#ref-for-dfn-Blob-63">(2)</a> <a href="#ref-for-dfn-Blob-64">(3)</a>
+    <li><a href="#ref-for-dfn-Blob-65">7.1. 
+Throwing an Exception or Returning an Error</a> <a href="#ref-for-dfn-Blob-66">(2)</a> <a href="#ref-for-dfn-Blob-67">(3)</a> <a href="#ref-for-dfn-Blob-68">(4)</a> <a href="#ref-for-dfn-Blob-69">(5)</a> <a href="#ref-for-dfn-Blob-70">(6)</a>
+    <li><a href="#ref-for-dfn-Blob-71">8. 
 A URL for Blob and File reference</a>
-    <li><a href="#ref-for-dfn-Blob-84">8.1. 
-Requirements for a New Scheme</a> <a href="#ref-for-dfn-Blob-85">(2)</a> <a href="#ref-for-dfn-Blob-86">(3)</a> <a href="#ref-for-dfn-Blob-87">(4)</a> <a href="#ref-for-dfn-Blob-88">(5)</a>
-    <li><a href="#ref-for-dfn-Blob-89">8.2. 
-Discussion of Existing Schemes</a> <a href="#ref-for-dfn-Blob-90">(2)</a>
-    <li><a href="#ref-for-dfn-Blob-91">8.3. 
-The Blob URL</a> <a href="#ref-for-dfn-Blob-92">(2)</a>
-    <li><a href="#ref-for-dfn-Blob-93">8.4.2. 
-Response Headers</a> <a href="#ref-for-dfn-Blob-94">(2)</a>
-    <li><a href="#ref-for-dfn-Blob-95">8.4.4. 
-Sample Request and Response Headers</a> <a href="#ref-for-dfn-Blob-96">(2)</a>
-    <li><a href="#ref-for-dfn-Blob-97">8.5. 
+    <li><a href="#ref-for-dfn-Blob-72">8.1. 
+Requirements for a New Scheme</a> <a href="#ref-for-dfn-Blob-73">(2)</a> <a href="#ref-for-dfn-Blob-74">(3)</a> <a href="#ref-for-dfn-Blob-75">(4)</a> <a href="#ref-for-dfn-Blob-76">(5)</a>
+    <li><a href="#ref-for-dfn-Blob-77">8.2. 
+Discussion of Existing Schemes</a> <a href="#ref-for-dfn-Blob-78">(2)</a>
+    <li><a href="#ref-for-dfn-Blob-79">8.3. 
+The Blob URL</a> <a href="#ref-for-dfn-Blob-80">(2)</a>
+    <li><a href="#ref-for-dfn-Blob-81">8.4.2. 
+Response Headers</a> <a href="#ref-for-dfn-Blob-82">(2)</a>
+    <li><a href="#ref-for-dfn-Blob-83">8.4.4. 
+Sample Request and Response Headers</a> <a href="#ref-for-dfn-Blob-84">(2)</a>
+    <li><a href="#ref-for-dfn-Blob-85">8.5. 
 Creating and Revoking a Blob URL</a>
-    <li><a href="#ref-for-dfn-Blob-98">8.5.1. 
-Methods and Parameters</a> <a href="#ref-for-dfn-Blob-99">(2)</a>
-    <li><a href="#ref-for-dfn-Blob-100">8.5.2. 
+    <li><a href="#ref-for-dfn-Blob-86">8.5.2. 
 Examples of Blob URL Creation and Revocation</a>
-    <li><a href="#ref-for-dfn-Blob-101">8.6. 
-Lifetime of Blob URLs</a> <a href="#ref-for-dfn-Blob-102">(2)</a> <a href="#ref-for-dfn-Blob-103">(3)</a> <a href="#ref-for-dfn-Blob-104">(4)</a> <a href="#ref-for-dfn-Blob-105">(5)</a>
+    <li><a href="#ref-for-dfn-Blob-87">8.6. 
+Lifetime of Blob URLs</a> <a href="#ref-for-dfn-Blob-88">(2)</a> <a href="#ref-for-dfn-Blob-89">(3)</a> <a href="#ref-for-dfn-Blob-90">(4)</a> <a href="#ref-for-dfn-Blob-91">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-BlobPropertyBag">
@@ -4181,15 +4003,13 @@ Constructor</a> <a href="#ref-for-dfn-BPtype-5">(2)</a>
 The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-size-2">(2)</a>
     <li><a href="#ref-for-dfn-size-3">3.1. 
 Constructors</a> <a href="#ref-for-dfn-size-4">(2)</a>
-    <li><a href="#ref-for-dfn-size-5">3.2. 
-Attributes</a>
-    <li><a href="#ref-for-dfn-size-6">3.3.1. 
-The slice method</a> <a href="#ref-for-dfn-size-7">(2)</a> <a href="#ref-for-dfn-size-8">(3)</a>
-    <li><a href="#ref-for-dfn-size-9">4.1. 
+    <li><a href="#ref-for-dfn-size-5">3.3.1. 
+The slice method</a> <a href="#ref-for-dfn-size-6">(2)</a> <a href="#ref-for-dfn-size-7">(3)</a>
+    <li><a href="#ref-for-dfn-size-8">4.1. 
 Constructor</a>
-    <li><a href="#ref-for-dfn-size-10">6.1. 
+    <li><a href="#ref-for-dfn-size-9">6.1. 
 The Read Operation</a>
-    <li><a href="#ref-for-dfn-size-11">8.4.2. 
+    <li><a href="#ref-for-dfn-size-10">8.4.2. 
 Response Headers</a>
    </ul>
   </aside>
@@ -4220,13 +4040,6 @@ Response Headers</a>
 Sample Request and Response Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-isClosed">
-   <b><a href="#dfn-isClosed">#dfn-isClosed</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dfn-isClosed-1">3. 
-The Blob Interface and Binary Data</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="dfn-slice">
    <b><a href="#dfn-slice">#dfn-slice</a></b><b>Referenced in:</b>
    <ul>
@@ -4235,7 +4048,7 @@ The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dfn-slice-2">3.2. 
 Attributes</a>
     <li><a href="#ref-for-dfn-slice-3">3.3.1. 
-The slice method</a> <a href="#ref-for-dfn-slice-4">(2)</a> <a href="#ref-for-dfn-slice-5">(3)</a> <a href="#ref-for-dfn-slice-6">(4)</a> <a href="#ref-for-dfn-slice-7">(5)</a> <a href="#ref-for-dfn-slice-8">(6)</a> <a href="#ref-for-dfn-slice-9">(7)</a> <a href="#ref-for-dfn-slice-10">(8)</a>
+The slice method</a> <a href="#ref-for-dfn-slice-4">(2)</a> <a href="#ref-for-dfn-slice-5">(3)</a> <a href="#ref-for-dfn-slice-6">(4)</a> <a href="#ref-for-dfn-slice-7">(5)</a> <a href="#ref-for-dfn-slice-8">(6)</a> <a href="#ref-for-dfn-slice-9">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-start">
@@ -4263,23 +4076,6 @@ The slice method</a> <a href="#ref-for-dfn-end-3">(2)</a> <a href="#ref-for-dfn-
 The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dfn-contentTypeBlob-2">3.3.1. 
 The slice method</a> <a href="#ref-for-dfn-contentTypeBlob-3">(2)</a> <a href="#ref-for-dfn-contentTypeBlob-4">(3)</a> <a href="#ref-for-dfn-contentTypeBlob-5">(4)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dfn-close">
-   <b><a href="#dfn-close">#dfn-close</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dfn-close-1">3. 
-The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-close-2">(2)</a>
-    <li><a href="#ref-for-dfn-close-3">3.2. 
-Attributes</a>
-    <li><a href="#ref-for-dfn-close-4">6.6.1.2. 
-The readAsText() method</a>
-    <li><a href="#ref-for-dfn-close-5">6.6.1.3. 
-The readAsDataURL() method</a>
-    <li><a href="#ref-for-dfn-close-6">6.6.1.4. 
-The readAsArrayBuffer() method</a>
-    <li><a href="#ref-for-dfn-close-7">6.6.1.5. 
-The readAsBinaryString() method</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="file-type-guidelines">
@@ -4459,29 +4255,27 @@ The readAsBinaryString() method</a>
   <aside class="dfn-panel" data-for="readOperation">
    <b><a href="#readOperation">#readOperation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-readOperation-1">3.3.1. 
-The slice method</a>
-    <li><a href="#ref-for-readOperation-2">4.2. 
+    <li><a href="#ref-for-readOperation-1">4.2. 
 Attributes</a>
-    <li><a href="#ref-for-readOperation-3">6.1. 
-The Read Operation</a> <a href="#ref-for-readOperation-4">(2)</a> <a href="#ref-for-readOperation-5">(3)</a> <a href="#ref-for-readOperation-6">(4)</a> <a href="#ref-for-readOperation-7">(5)</a> <a href="#ref-for-readOperation-8">(6)</a> <a href="#ref-for-readOperation-9">(7)</a> <a href="#ref-for-readOperation-10">(8)</a> <a href="#ref-for-readOperation-11">(9)</a> <a href="#ref-for-readOperation-12">(10)</a>
-    <li><a href="#ref-for-readOperation-13">6.3.4.2. 
+    <li><a href="#ref-for-readOperation-2">6.1. 
+The Read Operation</a> <a href="#ref-for-readOperation-3">(2)</a> <a href="#ref-for-readOperation-4">(3)</a> <a href="#ref-for-readOperation-5">(4)</a> <a href="#ref-for-readOperation-6">(5)</a> <a href="#ref-for-readOperation-7">(6)</a> <a href="#ref-for-readOperation-8">(7)</a> <a href="#ref-for-readOperation-9">(8)</a> <a href="#ref-for-readOperation-10">(9)</a>
+    <li><a href="#ref-for-readOperation-11">6.3.4.2. 
 The readAsDataURL() method</a>
-    <li><a href="#ref-for-readOperation-14">6.3.4.3. 
+    <li><a href="#ref-for-readOperation-12">6.3.4.3. 
 The readAsText() method</a>
-    <li><a href="#ref-for-readOperation-15">6.3.4.4. 
+    <li><a href="#ref-for-readOperation-13">6.3.4.4. 
 The readAsArrayBuffer() method</a>
-    <li><a href="#ref-for-readOperation-16">6.3.4.5. 
+    <li><a href="#ref-for-readOperation-14">6.3.4.5. 
 The readAsBinaryString() method</a>
-    <li><a href="#ref-for-readOperation-17">6.6.1.2. 
-The readAsText() method</a> <a href="#ref-for-readOperation-18">(2)</a>
-    <li><a href="#ref-for-readOperation-19">6.6.1.3. 
-The readAsDataURL() method</a> <a href="#ref-for-readOperation-20">(2)</a> <a href="#ref-for-readOperation-21">(3)</a>
-    <li><a href="#ref-for-readOperation-22">6.6.1.4. 
-The readAsArrayBuffer() method</a> <a href="#ref-for-readOperation-23">(2)</a> <a href="#ref-for-readOperation-24">(3)</a>
-    <li><a href="#ref-for-readOperation-25">6.6.1.5. 
-The readAsBinaryString() method</a> <a href="#ref-for-readOperation-26">(2)</a> <a href="#ref-for-readOperation-27">(3)</a>
-    <li><a href="#ref-for-readOperation-28">7.1. 
+    <li><a href="#ref-for-readOperation-15">6.6.1.2. 
+The readAsText() method</a> <a href="#ref-for-readOperation-16">(2)</a>
+    <li><a href="#ref-for-readOperation-17">6.6.1.3. 
+The readAsDataURL() method</a> <a href="#ref-for-readOperation-18">(2)</a> <a href="#ref-for-readOperation-19">(3)</a>
+    <li><a href="#ref-for-readOperation-20">6.6.1.4. 
+The readAsArrayBuffer() method</a> <a href="#ref-for-readOperation-21">(2)</a> <a href="#ref-for-readOperation-22">(3)</a>
+    <li><a href="#ref-for-readOperation-23">6.6.1.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-readOperation-24">(2)</a> <a href="#ref-for-readOperation-25">(3)</a>
+    <li><a href="#ref-for-readOperation-26">7.1. 
 Throwing an Exception or Returning an Error</a>
    </ul>
   </aside>
@@ -4919,17 +4713,17 @@ The readAsText() method</a>
    <b><a href="#fire-a-progress-event">#fire-a-progress-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-progress-event-1">6.3.4.2. 
-The readAsDataURL() method</a> <a href="#ref-for-fire-a-progress-event-2">(2)</a> <a href="#ref-for-fire-a-progress-event-3">(3)</a> <a href="#ref-for-fire-a-progress-event-4">(4)</a> <a href="#ref-for-fire-a-progress-event-5">(5)</a>
-    <li><a href="#ref-for-fire-a-progress-event-6">6.3.4.3. 
-The readAsText() method</a> <a href="#ref-for-fire-a-progress-event-7">(2)</a> <a href="#ref-for-fire-a-progress-event-8">(3)</a> <a href="#ref-for-fire-a-progress-event-9">(4)</a> <a href="#ref-for-fire-a-progress-event-10">(5)</a>
-    <li><a href="#ref-for-fire-a-progress-event-11">6.3.4.4. 
-The readAsArrayBuffer() method</a> <a href="#ref-for-fire-a-progress-event-12">(2)</a> <a href="#ref-for-fire-a-progress-event-13">(3)</a> <a href="#ref-for-fire-a-progress-event-14">(4)</a> <a href="#ref-for-fire-a-progress-event-15">(5)</a>
-    <li><a href="#ref-for-fire-a-progress-event-16">6.3.4.5. 
-The readAsBinaryString() method</a> <a href="#ref-for-fire-a-progress-event-17">(2)</a> <a href="#ref-for-fire-a-progress-event-18">(3)</a> <a href="#ref-for-fire-a-progress-event-19">(4)</a> <a href="#ref-for-fire-a-progress-event-20">(5)</a>
-    <li><a href="#ref-for-fire-a-progress-event-21">6.3.4.6. 
-Error Steps</a> <a href="#ref-for-fire-a-progress-event-22">(2)</a>
-    <li><a href="#ref-for-fire-a-progress-event-23">6.3.4.7. 
-The abort() method</a> <a href="#ref-for-fire-a-progress-event-24">(2)</a>
+The readAsDataURL() method</a> <a href="#ref-for-fire-a-progress-event-2">(2)</a> <a href="#ref-for-fire-a-progress-event-3">(3)</a> <a href="#ref-for-fire-a-progress-event-4">(4)</a>
+    <li><a href="#ref-for-fire-a-progress-event-5">6.3.4.3. 
+The readAsText() method</a> <a href="#ref-for-fire-a-progress-event-6">(2)</a> <a href="#ref-for-fire-a-progress-event-7">(3)</a> <a href="#ref-for-fire-a-progress-event-8">(4)</a>
+    <li><a href="#ref-for-fire-a-progress-event-9">6.3.4.4. 
+The readAsArrayBuffer() method</a> <a href="#ref-for-fire-a-progress-event-10">(2)</a> <a href="#ref-for-fire-a-progress-event-11">(3)</a> <a href="#ref-for-fire-a-progress-event-12">(4)</a>
+    <li><a href="#ref-for-fire-a-progress-event-13">6.3.4.5. 
+The readAsBinaryString() method</a> <a href="#ref-for-fire-a-progress-event-14">(2)</a> <a href="#ref-for-fire-a-progress-event-15">(3)</a> <a href="#ref-for-fire-a-progress-event-16">(4)</a>
+    <li><a href="#ref-for-fire-a-progress-event-17">6.3.4.6. 
+Error Steps</a> <a href="#ref-for-fire-a-progress-event-18">(2)</a>
+    <li><a href="#ref-for-fire-a-progress-event-19">6.3.4.7. 
+The abort() method</a> <a href="#ref-for-fire-a-progress-event-20">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-loadstart-event">
@@ -4984,18 +4778,10 @@ Summary of Event Invariants</a> <a href="#ref-for-dfn-abort-event-4">(2)</a> <a 
 Attributes</a>
     <li><a href="#ref-for-dfn-error-event-2">6.3.2. 
 Event Handler Content Attributes</a>
-    <li><a href="#ref-for-dfn-error-event-3">6.3.4.2. 
-The readAsDataURL() method</a>
-    <li><a href="#ref-for-dfn-error-event-4">6.3.4.3. 
-The readAsText() method</a>
-    <li><a href="#ref-for-dfn-error-event-5">6.3.4.4. 
-The readAsArrayBuffer() method</a>
-    <li><a href="#ref-for-dfn-error-event-6">6.3.4.5. 
-The readAsBinaryString() method</a>
-    <li><a href="#ref-for-dfn-error-event-7">6.3.4.6. 
+    <li><a href="#ref-for-dfn-error-event-3">6.3.4.6. 
 Error Steps</a>
-    <li><a href="#ref-for-dfn-error-event-8">6.5.2. 
-Summary of Event Invariants</a> <a href="#ref-for-dfn-error-event-9">(2)</a> <a href="#ref-for-dfn-error-event-10">(3)</a> <a href="#ref-for-dfn-error-event-11">(4)</a>
+    <li><a href="#ref-for-dfn-error-event-4">6.5.2. 
+Summary of Event Invariants</a> <a href="#ref-for-dfn-error-event-5">(2)</a> <a href="#ref-for-dfn-error-event-6">(3)</a> <a href="#ref-for-dfn-error-event-7">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-load-event">
@@ -5154,18 +4940,10 @@ Throwing an Exception or Returning an Error</a> <a href="#ref-for-failureReason-
 Attributes</a>
     <li><a href="#ref-for-dfn-error-2">6.3. 
 The FileReader API</a>
-    <li><a href="#ref-for-dfn-error-3">6.3.4.2. 
-The readAsDataURL() method</a>
-    <li><a href="#ref-for-dfn-error-4">6.3.4.3. 
-The readAsText() method</a>
-    <li><a href="#ref-for-dfn-error-5">6.3.4.4. 
-The readAsArrayBuffer() method</a>
-    <li><a href="#ref-for-dfn-error-6">6.3.4.5. 
-The readAsBinaryString() method</a>
-    <li><a href="#ref-for-dfn-error-7">6.3.4.6. 
-Error Steps</a> <a href="#ref-for-dfn-error-8">(2)</a>
-    <li><a href="#ref-for-dfn-error-9">7.1. 
-Throwing an Exception or Returning an Error</a> <a href="#ref-for-dfn-error-10">(2)</a> <a href="#ref-for-dfn-error-11">(3)</a>
+    <li><a href="#ref-for-dfn-error-3">6.3.4.6. 
+Error Steps</a> <a href="#ref-for-dfn-error-4">(2)</a>
+    <li><a href="#ref-for-dfn-error-5">7.1. 
+Throwing an Exception or Returning an Error</a> <a href="#ref-for-dfn-error-6">(2)</a> <a href="#ref-for-dfn-error-7">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="blob-url">
@@ -5173,31 +4951,29 @@ Throwing an Exception or Returning an Error</a> <a href="#ref-for-dfn-error-10">
    <ul>
     <li><a href="#ref-for-blob-url-1">3.2. 
 Attributes</a>
-    <li><a href="#ref-for-blob-url-2">3.3.1. 
-The slice method</a>
-    <li><a href="#ref-for-blob-url-3">8.3. 
+    <li><a href="#ref-for-blob-url-2">8.3. 
 The Blob URL</a>
-    <li><a href="#ref-for-blob-url-4">8.3.1. 
+    <li><a href="#ref-for-blob-url-3">8.3.1. 
 Origin of Blob URLs</a>
-    <li><a href="#ref-for-blob-url-5">8.3.3. 
+    <li><a href="#ref-for-blob-url-4">8.3.3. 
 Discussion of Fragment Identifier</a>
-    <li><a href="#ref-for-blob-url-6">8.4. 
-Dereferencing Model for Blob URLs</a> <a href="#ref-for-blob-url-7">(2)</a>
-    <li><a href="#ref-for-blob-url-8">8.4.2. 
+    <li><a href="#ref-for-blob-url-5">8.4. 
+Dereferencing Model for Blob URLs</a> <a href="#ref-for-blob-url-6">(2)</a>
+    <li><a href="#ref-for-blob-url-7">8.4.2. 
 Response Headers</a>
-    <li><a href="#ref-for-blob-url-9">8.4.3. 
-Network Errors</a> <a href="#ref-for-blob-url-10">(2)</a> <a href="#ref-for-blob-url-11">(3)</a>
-    <li><a href="#ref-for-blob-url-12">8.4.4. 
+    <li><a href="#ref-for-blob-url-8">8.4.3. 
+Network Errors</a> <a href="#ref-for-blob-url-9">(2)</a>
+    <li><a href="#ref-for-blob-url-10">8.4.4. 
 Sample Request and Response Headers</a>
-    <li><a href="#ref-for-blob-url-13">8.5. 
-Creating and Revoking a Blob URL</a> <a href="#ref-for-blob-url-14">(2)</a> <a href="#ref-for-blob-url-15">(3)</a> <a href="#ref-for-blob-url-16">(4)</a>
-    <li><a href="#ref-for-blob-url-17">8.5.1. 
-Methods and Parameters</a> <a href="#ref-for-blob-url-18">(2)</a> <a href="#ref-for-blob-url-19">(3)</a> <a href="#ref-for-blob-url-20">(4)</a> <a href="#ref-for-blob-url-21">(5)</a>
-    <li><a href="#ref-for-blob-url-22">8.5.2. 
-Examples of Blob URL Creation and Revocation</a> <a href="#ref-for-blob-url-23">(2)</a> <a href="#ref-for-blob-url-24">(3)</a> <a href="#ref-for-blob-url-25">(4)</a> <a href="#ref-for-blob-url-26">(5)</a> <a href="#ref-for-blob-url-27">(6)</a>
-    <li><a href="#ref-for-blob-url-28">8.6. 
-Lifetime of Blob URLs</a> <a href="#ref-for-blob-url-29">(2)</a> <a href="#ref-for-blob-url-30">(3)</a> <a href="#ref-for-blob-url-31">(4)</a> <a href="#ref-for-blob-url-32">(5)</a> <a href="#ref-for-blob-url-33">(6)</a>
-    <li><a href="#ref-for-blob-url-34">9. 
+    <li><a href="#ref-for-blob-url-11">8.5. 
+Creating and Revoking a Blob URL</a> <a href="#ref-for-blob-url-12">(2)</a> <a href="#ref-for-blob-url-13">(3)</a> <a href="#ref-for-blob-url-14">(4)</a>
+    <li><a href="#ref-for-blob-url-15">8.5.1. 
+Methods and Parameters</a> <a href="#ref-for-blob-url-16">(2)</a> <a href="#ref-for-blob-url-17">(3)</a> <a href="#ref-for-blob-url-18">(4)</a>
+    <li><a href="#ref-for-blob-url-19">8.5.2. 
+Examples of Blob URL Creation and Revocation</a> <a href="#ref-for-blob-url-20">(2)</a> <a href="#ref-for-blob-url-21">(3)</a> <a href="#ref-for-blob-url-22">(4)</a> <a href="#ref-for-blob-url-23">(5)</a> <a href="#ref-for-blob-url-24">(6)</a>
+    <li><a href="#ref-for-blob-url-25">8.6. 
+Lifetime of Blob URLs</a> <a href="#ref-for-blob-url-26">(2)</a> <a href="#ref-for-blob-url-27">(3)</a> <a href="#ref-for-blob-url-28">(4)</a> <a href="#ref-for-blob-url-29">(5)</a> <a href="#ref-for-blob-url-30">(6)</a>
+    <li><a href="#ref-for-blob-url-31">9. 
 Security and Privacy Considerations</a>
    </ul>
   </aside>
@@ -5214,7 +4990,7 @@ Origin of Blob URLs</a>
     <li><a href="#ref-for-unicodeBlobURL-1">8.3. 
 The Blob URL</a>
     <li><a href="#ref-for-unicodeBlobURL-2">8.5.1. 
-Methods and Parameters</a> <a href="#ref-for-unicodeBlobURL-3">(2)</a>
+Methods and Parameters</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dereference">
@@ -5224,11 +5000,9 @@ Methods and Parameters</a> <a href="#ref-for-unicodeBlobURL-3">(2)</a>
 Attributes</a>
     <li><a href="#ref-for-dereference-2">8.3.3. 
 Discussion of Fragment Identifier</a>
-    <li><a href="#ref-for-dereference-3">8.5.1. 
-Methods and Parameters</a>
-    <li><a href="#ref-for-dereference-4">8.5.2. 
+    <li><a href="#ref-for-dereference-3">8.5.2. 
 Examples of Blob URL Creation and Revocation</a>
-    <li><a href="#ref-for-dereference-5">8.6. 
+    <li><a href="#ref-for-dereference-4">8.6. 
 Lifetime of Blob URLs</a>
    </ul>
   </aside>
@@ -5270,7 +5044,7 @@ Examples of Blob URL Creation and Revocation</a> <a href="#ref-for-dfn-revokeObj
     <li><a href="#ref-for-dfn-urlarg-1">8.5. 
 Creating and Revoking a Blob URL</a>
     <li><a href="#ref-for-dfn-urlarg-2">8.5.1. 
-Methods and Parameters</a> <a href="#ref-for-dfn-urlarg-3">(2)</a> <a href="#ref-for-dfn-urlarg-4">(3)</a> <a href="#ref-for-dfn-urlarg-5">(4)</a> <a href="#ref-for-dfn-urlarg-6">(5)</a> <a href="#ref-for-dfn-urlarg-7">(6)</a>
+Methods and Parameters</a> <a href="#ref-for-dfn-urlarg-3">(2)</a> <a href="#ref-for-dfn-urlarg-4">(3)</a> <a href="#ref-for-dfn-urlarg-5">(4)</a> <a href="#ref-for-dfn-urlarg-6">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="lifeTime">
@@ -5285,14 +5059,12 @@ Examples of Blob URL Creation and Revocation</a>
   <aside class="dfn-panel" data-for="BlobURLStore">
    <b><a href="#BlobURLStore">#BlobURLStore</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-BlobURLStore-1">3.3.2. 
-The close method</a>
-    <li><a href="#ref-for-BlobURLStore-2">8.4.3. 
-Network Errors</a> <a href="#ref-for-BlobURLStore-3">(2)</a>
-    <li><a href="#ref-for-BlobURLStore-4">8.5.1. 
-Methods and Parameters</a> <a href="#ref-for-BlobURLStore-5">(2)</a> <a href="#ref-for-BlobURLStore-6">(3)</a> <a href="#ref-for-BlobURLStore-7">(4)</a> <a href="#ref-for-BlobURLStore-8">(5)</a> <a href="#ref-for-BlobURLStore-9">(6)</a>
-    <li><a href="#ref-for-BlobURLStore-10">8.6. 
-Lifetime of Blob URLs</a> <a href="#ref-for-BlobURLStore-11">(2)</a> <a href="#ref-for-BlobURLStore-12">(3)</a> <a href="#ref-for-BlobURLStore-13">(4)</a>
+    <li><a href="#ref-for-BlobURLStore-1">8.4.3. 
+Network Errors</a>
+    <li><a href="#ref-for-BlobURLStore-2">8.5.1. 
+Methods and Parameters</a> <a href="#ref-for-BlobURLStore-3">(2)</a> <a href="#ref-for-BlobURLStore-4">(3)</a> <a href="#ref-for-BlobURLStore-5">(4)</a> <a href="#ref-for-BlobURLStore-6">(5)</a>
+    <li><a href="#ref-for-BlobURLStore-7">8.6. 
+Lifetime of Blob URLs</a> <a href="#ref-for-BlobURLStore-8">(2)</a> <a href="#ref-for-BlobURLStore-9">(3)</a> <a href="#ref-for-BlobURLStore-10">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="add-an-entry">
@@ -5305,9 +5077,7 @@ Methods and Parameters</a>
   <aside class="dfn-panel" data-for="removeTheEntry">
    <b><a href="#removeTheEntry">#removeTheEntry</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-removeTheEntry-1">3.3.2. 
-The close method</a>
-    <li><a href="#ref-for-removeTheEntry-2">8.5.1. 
+    <li><a href="#ref-for-removeTheEntry-1">8.5.1. 
 Methods and Parameters</a>
    </ul>
   </aside>


### PR DESCRIPTION
As discussed in #10, the utility of the close() method is unclear, and
properly specifying it would add a large amount of complexity.

By removing closing entirely, this fixes #10, fixes #17 and fixes #18.

References to readability state and blobs being closed in other specs (in particular HTML) will be removed in follow-up changes.