### PR TITLE
Add a link to web-platform-tests to the top of the spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11,6 +11,7 @@ ED: https://w3c.github.io/FileAPI/
 TR: http://www.w3.org/TR/FileAPI/
 Repository: w3c/FileAPI
 Previous Version: http://www.w3.org/TR/2012/WD-FileAPI-20121025/
+!Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/FileAPI>web-platform-tests FileAPI/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/FileAPI>ongoing work</a>)
 Abstract: This specification provides an API for representing file objects in web applications,
   as well as programmatically selecting them and accessing their data. This includes:
 


### PR DESCRIPTION
A few other specs that have something similar:
https://fetch.spec.whatwg.org/
https://w3c.github.io/IndexedDB/
https://notifications.spec.whatwg.org/
https://xhr.spec.whatwg.org/