### PR TITLE
Fix Web IDL extended attribute usage: [Clamp] now applies to types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -231,8 +231,8 @@ interface Blob {
   readonly attribute DOMString type;
 
   // slice Blob into byte-ranged chunks
-  Blob slice([Clamp] optional long long start,
-            [Clamp] optional long long end,
+  Blob slice(optional [Clamp] long long start,
+            optional [Clamp] long long end,
             optional DOMString contentType);
 };
 


### PR DESCRIPTION
https://github.com/heycam/webidl/pull/286 makes `[Clamp]`, `[EnforceRange]`, and `[TreatNullAs]` apply to types, this change updates this spec to conform.

See also: https://github.com/whatwg/html/pull/2580, https://github.com/whatwg/dom/pull/446


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/FileAPI/pull/116.html" title="Last updated on Feb 18, 2019, 9:59 AM UTC (885ee98)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/116/b056296...Manishearth:885ee98.html" title="Last updated on Feb 18, 2019, 9:59 AM UTC (885ee98)">Diff</a>