### PR TITLE
Add simpler reading methods to Blob interface.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -569,56 +569,46 @@ It must act as follows:
   </pre>
 </div>
 
-<h4 id="stream-method-algo">
-The stream method</h4>
+### The {{Blob/stream()}} method ### {#stream-method-algo}
 
-The <dfn method for=Blob>stream()</dfn> method returns the contents
-of the blob as a {{ReadableStream}}.
-
-It must return the result of [=getting a stream for a Blob=] for the [=context object=].
+The <dfn method for=Blob>stream()</dfn> method, when invoked, must return
+the result of [=getting a stream for a Blob=] for the [=context object=].
 
 To <dfn lt="get a stream for a Blob|getting a stream for a Blob">get a stream for a {{Blob}}</dfn>
 |blob|, run the following steps:
 
 1. Let |stream| be the result of [=construct a ReadableStream object|constructing=] a
    {{ReadableStream}} object.
-1. Return |stream| and run the following steps [=in parallel=]:
+1. Run the following steps [=in parallel=]:
   1. While not all bytes of |blob| have been read:
     1. Let |bytes| be the byte sequence that results from reading a [=chunk=] from |blob|.
     1. If a [=file read error=] occured while reading |bytes|, [$ReadableStream/error$]
        |stream| with a [=failure reason=] and abort these steps.
     1. [=ReadableStream/Enqueue=] |bytes| into |stream|.
 
-    Issue: We need to specify more concretely what reading from a Blob actually does, and what
-    possible errors can happen.
+    Issue: We need to specify more concretely what reading from a Blob actually does,
+    and what possible errors can happen.
+1. Return |stream|.
 
-<h4 id="text-method-algo">
-The text method</h4>
+### The {{Blob/text()}} method ### {#text-method-algo}
 
-The <dfn method for=Blob>text()</dfn> method returns the contents
-of the blob as a {{USVString}}.
-
-It must act as follows:
+The <dfn method for=Blob>text()</dfn> method, when invoked, must run these steps:
 
 1. Let |stream| be the the result of [=getting a stream for a Blob=] for the [=context object=].
-1. Let |reader| be the result of [=getting a reader=] from |stream|.
+1. Let |reader| be the result of [=get a reader|getting a reader=] from |stream|.
    If that threw an exception, return a new promise rejected with that exception.
-1. Let |promise| be the result of [=reading all bytes=] from |stream| with |reader|.
+1. Let |promise| be the result of [=read all bytes|reading all bytes=] from |stream| with |reader|.
 1. Return the result of transforming |promise| by a fulfillment handler that returns the result of
    running [=UTF-8 decode=] on its first argument.
 
-<h4 id="arraybuffer-method-algo">
-The arrayBuffer method</h4>
+### The {{Blob/arrayBuffer()}} method ### {#arraybuffer-method-algo}
 
-The <dfn method for=Blob>arrayBuffer()</dfn> method returns the contents
-of the blob as an {{ArrayBuffer}}.
-
-It must act as follows:
+The <dfn method for=Blob>arrayBuffer()</dfn> method, when invoked, must run these steps:
 
 1. Let |stream| be the the result of [=getting a stream for a Blob=] for the [=context object=].
-1. Let |reader| be the result of [=getting a reader=] from |stream|.
+1. Let |reader| be the result of [=get a reader|getting a reader=] from |stream|.
    If that threw an exception, return a new promise rejected with that exception.
-1. Let |promise| be the result of [=reading all bytes=] from |stream| with |reader|.
+1. Let |promise| be the result of [=read all bytes|reading all bytes=] from |stream| with |reader|.
 1. Return the result of transforming |promise| by a fulfillment handler that returns
    a new {{ArrayBuffer} whose contents are its first argument.
 

--- a/index.bs
+++ b/index.bs
@@ -65,6 +65,9 @@ spec: url
     text: url; for:/
   type: interface
     text: URL
+spec: fetch
+  type:interface
+    text:ReadableStream
 </pre>
 
 <pre class="anchors">
@@ -215,7 +218,7 @@ which must be initially set to the state of the underlying storage,
 if any such underlying storage exists.
 Further normative definition of <a>snapshot state</a> can be found for {{File}}s.
 
-<pre class="idl">
+<xmp class="idl">
 [Constructor(optional sequence&lt;BlobPart> blobParts,
              optional BlobPropertyBag options),
  Exposed=(Window,Worker), Serializable]
@@ -228,6 +231,11 @@ interface Blob {
   Blob slice(optional [Clamp] long long start,
             optional [Clamp] long long end,
             optional DOMString contentType);
+
+  // read from the Blob.
+  ReadableStream stream();
+  Promise<USVString> text();
+  Promise<ArrayBuffer> arrayBuffer();
 };
 
 enum EndingType { "transparent", "native" };
@@ -238,7 +246,7 @@ dictionary BlobPropertyBag {
 };
 
 typedef (BufferSource or Blob or USVString) BlobPart;
-</pre>
+</xmp>
 
 {{Blob}} objects are [=serializable objects=]. Their [=serialization steps=],
 given |value| and |serialized|, are:
@@ -560,6 +568,59 @@ It must act as follows:
     }
   </pre>
 </div>
+
+<h4 id="stream-method-algo">
+The stream method</h4>
+
+The <dfn method for=Blob>stream()</dfn> method returns the contents
+of the blob as a {{ReadableStream}}.
+
+It must return the result of [=getting a stream for a Blob=] for the [=context object=].
+
+To <dfn lt="getting a stream for a Blob|getting a stream for a Blob">get a stream for a {{Blob}}</dfn>
+|blob|, run the following steps:
+
+1. Let |stream| be the result of [=construct a ReadableStream object|constructing=] a
+   {{ReadableStream}} object.
+1. Return |stream| and run the following steps [=in parallel=]:
+  1. While not all bytes of |blob| have been read:
+    1. Let |bytes| be the byte sequence that results from reading a [=chunk=] from |blob|.
+    1. If a [=file read error=] occured while reading |bytes|, [$ReadableStream/error$]
+       |stream| with a [=failure reason=] and abort these steps.
+    1. [=ReadableStream/Enqueue=] |bytes| into |stream|.
+
+    Issue: We need to specify more concretely what reading from a Blob actually does, and what
+    possible errors can happen.
+
+<h4 id="text-method-algo">
+The text method</h4>
+
+The <dfn method for=Blob>text()</dfn> method returns the contents
+of the blob as a {{USVString}}.
+
+It must act as follows:
+
+1. Let |stream| be the the result of [=getting a stream for a Blob=] for the [=context object=].
+1. Let |reader| be the result of [=getting a reader=] from |stream|.
+   If that threw an exception, return a new promise rejected with that exception.
+1. Let |promise| be the result of [=reading all bytes=] from |stream| with |reader|.
+1. Return the result of transforming |promise| by a fulfillment handler that returns the result of
+   running [=UTF-8 decode=] on its first argument.
+
+<h4 id="arraybuffer-method-algo">
+The arrayBuffer method</h4>
+
+The <dfn method for=Blob>arrayBuffer()</dfn> method returns the contents
+of the blob as an {{ArrayBuffer}}.
+
+It must act as follows:
+
+1. Let |stream| be the the result of [=getting a stream for a Blob=] for the [=context object=].
+1. Let |reader| be the result of [=getting a reader=] from |stream|.
+   If that threw an exception, return a new promise rejected with that exception.
+1. Let |promise| be the result of [=reading all bytes=] from |stream| with |reader|.
+1. Return the result of transforming |promise| by a fulfillment handler that returns
+   a new {{ArrayBuffer} whose contents are its first argument.
 
 <!--
 ████████ ████ ██       ████████

--- a/index.bs
+++ b/index.bs
@@ -577,7 +577,7 @@ of the blob as a {{ReadableStream}}.
 
 It must return the result of [=getting a stream for a Blob=] for the [=context object=].
 
-To <dfn lt="getting a stream for a Blob|getting a stream for a Blob">get a stream for a {{Blob}}</dfn>
+To <dfn lt="get a stream for a Blob|getting a stream for a Blob">get a stream for a {{Blob}}</dfn>
 |blob|, run the following steps:
 
 1. Let |stream| be the result of [=construct a ReadableStream object|constructing=] a

--- a/index.bs
+++ b/index.bs
@@ -233,9 +233,9 @@ interface Blob {
             optional DOMString contentType);
 
   // read from the Blob.
-  ReadableStream stream();
-  Promise<USVString> text();
-  Promise<ArrayBuffer> arrayBuffer();
+  [NewObject] ReadableStream stream();
+  [NewObject] Promise<USVString> text();
+  [NewObject] Promise<ArrayBuffer> arrayBuffer();
 };
 
 enum EndingType { "transparent", "native" };
@@ -586,7 +586,7 @@ The <dfn method for=Blob>text()</dfn> method, when invoked, must run these steps
    running [=UTF-8 decode=] on its first argument.
 
 Note: This is different from the behavior of {{FileReader/readAsText()}} to align better
-with the behavior of {{Body/text()|Body.text()}}. Specifically this method will always
+with the behavior of {{Body/text()|Fetch's text()}}. Specifically this method will always
 use UTF-8 as encoding, while {{FileReader}} can use a different encoding depending on
 the blob's type and passed in encoding name.
 

--- a/index.bs
+++ b/index.bs
@@ -572,45 +572,34 @@ It must act as follows:
 ### The {{Blob/stream()}} method ### {#stream-method-algo}
 
 The <dfn method for=Blob>stream()</dfn> method, when invoked, must return
-the result of [=getting a stream for a Blob=] for the [=context object=].
-
-To <dfn lt="get a stream for a Blob|getting a stream for a Blob">get a stream for a {{Blob}}</dfn>
-|blob|, run the following steps:
-
-1. Let |stream| be the result of [=construct a ReadableStream object|constructing=] a
-   {{ReadableStream}} object.
-1. Run the following steps [=in parallel=]:
-  1. While not all bytes of |blob| have been read:
-    1. Let |bytes| be the byte sequence that results from reading a [=chunk=] from |blob|.
-    1. If a [=file read error=] occured while reading |bytes|, [$ReadableStream/error$]
-       |stream| with a [=failure reason=] and abort these steps.
-    1. [=ReadableStream/Enqueue=] |bytes| into |stream|.
-
-    Issue: We need to specify more concretely what reading from a Blob actually does,
-    and what possible errors can happen.
-1. Return |stream|.
+the result of calling [=get stream=] on the [=context object=].
 
 ### The {{Blob/text()}} method ### {#text-method-algo}
 
 The <dfn method for=Blob>text()</dfn> method, when invoked, must run these steps:
 
-1. Let |stream| be the the result of [=getting a stream for a Blob=] for the [=context object=].
+1. Let |stream| be the result of calling [=get stream=] on the [=context object=].
 1. Let |reader| be the result of [=get a reader|getting a reader=] from |stream|.
    If that threw an exception, return a new promise rejected with that exception.
 1. Let |promise| be the result of [=read all bytes|reading all bytes=] from |stream| with |reader|.
 1. Return the result of transforming |promise| by a fulfillment handler that returns the result of
    running [=UTF-8 decode=] on its first argument.
 
+Note: This is different from the behavior of {{FileReader/readAsText()}} to align better
+with the behavior of {{Body/text()|Body.text()}}. Specifically this method will always
+use UTF-8 as encoding, while {{FileReader}} can use a different encoding depending on
+the blob's type and passed in encoding name.
+
 ### The {{Blob/arrayBuffer()}} method ### {#arraybuffer-method-algo}
 
 The <dfn method for=Blob>arrayBuffer()</dfn> method, when invoked, must run these steps:
 
-1. Let |stream| be the the result of [=getting a stream for a Blob=] for the [=context object=].
+1. Let |stream| be the result of calling [=get stream=] on the [=context object=].
 1. Let |reader| be the result of [=get a reader|getting a reader=] from |stream|.
    If that threw an exception, return a new promise rejected with that exception.
 1. Let |promise| be the result of [=read all bytes|reading all bytes=] from |stream| with |reader|.
 1. Return the result of transforming |promise| by a fulfillment handler that returns
-   a new {{ArrayBuffer} whose contents are its first argument.
+   a new {{ArrayBuffer}} whose contents are its first argument.
 
 <!--
 ████████ ████ ██       ████████


### PR DESCRIPTION
This fixes #40 

For now this just more or less copies the hand-wavy text of "perform a read operation". We'll need to better specify what actually reading from a blob does. Separately in a follow-up I would also like to rephrase the existing FileReader/FileReaderSync spec text in terms of readable stream operations, being much more precise when and how state is updated and events are queued.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/pull/117.html" title="Last updated on Mar 26, 2019, 4:36 PM UTC (42f8a45)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/117/795750f...42f8a45.html" title="Last updated on Mar 26, 2019, 4:36 PM UTC (42f8a45)">Diff</a>