### PR TITLE
Modernize Blob constructor a tiny bit

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -216,7 +216,7 @@ if any such underlying storage exists.
 Further normative definition of <a>snapshot state</a> can be found for {{File}}s.
 
 <pre class="idl">
-[Constructor(optional sequence&lt;BlobPart> blobParts,
+[Constructor(optional sequence&lt;BlobPart> blobParts = [],
              optional BlobPropertyBag options),
  Exposed=(Window,Worker), Serializable]
 interface Blob {
@@ -278,29 +278,22 @@ which runs these steps:
 ## Constructors ## {#constructorBlob}
 
 <div algorithm="blob-constructor">
-The {{Blob()}} constructor can be invoked with zero or more parameters.
 When the {{Blob()}} constructor is invoked,
 user agents must run the following steps:
 
-1. If invoked with zero parameters,
-  return a new {{Blob}} object consisting of 0 bytes,
-  with {{Blob/size}} set to 0,
-  and with {{Blob/type}} set to the empty string.
-
 1. Let |bytes| be the result of [=processing blob parts=] given {{blobParts}} and {{Blob/Blob(blobParts, options)/options}}.
 
-1. If the {{BlobPropertyBag/type}} member of the optional {{Blob/Blob(blobParts, options)/options}} argument is provided
-  and is not the empty string,
-  run the following sub-steps:
+1. Let |t| be the empty string.
 
-  1. Let |t| be the {{BlobPropertyBag/type}} dictionary member.
-    If |t| contains any characters outside the range U+0020 to U+007E,
-    then set |t| to the empty string and return from these substeps.
+1. If {{Blob/Blob(blobParts, options)/options}}["{{BlobPropertyBag/type}}"] does not contain any characters outside the range U+0020 to U+007E, inclusive, then:
+
+  1. Set |t| to {{Blob/Blob(blobParts, options)/options}}["{{BlobPropertyBag/type}}"].
+
   1. Convert every character in |t| to [=ASCII lowercase=].
 
 1. Return a {{Blob}} object referring to |bytes| as its associated <a>byte</a> sequence,
   with its {{Blob/size}} set to the length of |bytes|,
-  and its {{Blob/type}} set to the value of |t| from the substeps above.
+  and its {{Blob/type}} set to |t|.
 
 </div>
 
@@ -1729,6 +1722,6 @@ This specification was originally developed by the SVG Working Group. Many thank
 
 Thanks to Robin Berjon, Jonas Sicking and Vsevolod Shmyroff for editing the original specification.
 
-Special thanks to Olli Pettay, Nikunj Mehta, Garrett Smith, Aaron Boodman, Michael Nordman, Jian Li, Dmitry Titov, Ian Hickson, Darin Fisher, Sam Weinig, Adrian Bateman and Julian Reschke.
+Special thanks to Boris Zbarsky, Olli Pettay, Nikunj Mehta, Garrett Smith, Aaron Boodman, Michael Nordman, Jian Li, Dmitry Titov, Ian Hickson, Darin Fisher, Sam Weinig, Adrian Bateman, and Julian Reschke.
 
 Thanks to the W3C WebApps WG, and to participants on the public-webapps@w3.org listserv


### PR DESCRIPTION
All implementations do something different for new Blob(undefined, { type: "x/x" }). Let's do something simple.

Fixes #54.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/pull/125.html" title="Last updated on May 16, 2019, 6:58 AM UTC (abb6af3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/125/9977ce8...abb6af3.html" title="Last updated on May 16, 2019, 6:58 AM UTC (abb6af3)">Diff</a>