### PR TITLE
Update to Web IDL changes to optional dictionary defaulting

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -221,7 +221,7 @@ Further normative definition of <a>snapshot state</a> can be found for {{File}}s
 
 <xmp class="idl">
 [Constructor(optional sequence<BlobPart> blobParts,
-             optional BlobPropertyBag options),
+             optional BlobPropertyBag options = {}),
  Exposed=(Window,Worker), Serializable]
 interface Blob {
 
@@ -298,8 +298,7 @@ user agents must run the following steps:
 
 1. Let |bytes| be the result of [=processing blob parts=] given {{blobParts}} and {{Blob/Blob(blobParts, options)/options}}.
 
-1. If the {{BlobPropertyBag/type}} member of the optional {{Blob/Blob(blobParts, options)/options}} argument is provided
-  and is not the empty string,
+1. If the {{BlobPropertyBag/type}} member of the {{Blob/Blob(blobParts, options)/options}} argument is not the empty string,
   run the following sub-steps:
 
   1. Let |t| be the {{BlobPropertyBag/type}} dictionary member.
@@ -646,7 +645,7 @@ and must follow the <dfn export>file type guidelines</dfn> below:
 <pre class="idl">
 [Constructor(sequence&lt;BlobPart> fileBits,
              USVString fileName,
-             optional FilePropertyBag options),
+             optional FilePropertyBag options = {}),
  Exposed=(Window,Worker), Serializable]
 interface File : Blob {
   readonly attribute DOMString name;
@@ -699,8 +698,7 @@ user agents must run the following steps:
   Note: Underlying OS filesystems use differing conventions for file name;
   with constructed files, mandating UTF-16 lessens ambiquity when file names are converted to <a>byte</a> sequences.
 
-3. If the optional {{FilePropertyBag}} dictionary argument is used,
-  then run the following substeps:
+3. Process {{FilePropertyBag}} dictionary argument by running the following substeps:
 
   1. If the {{BlobPropertyBag/type}} member is provided and is not the empty string,
     let |t| be set to the {{BlobPropertyBag/type}} dictionary member.


### PR DESCRIPTION
This is part of https://github.com/heycam/webidl/issues/758

For *normative* changes, the following tasks have been completed:

 * [X] Modified Web platform tests  - IDL changes will be picked up automatically. 

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [X] [Gecko](https://bugs.chromium.org/p/chromium/issues/detail?id=948139) 

The following bug needs to be fixed in Blink first:
https://bugs.chromium.org/p/chromium/issues/detail?id=984949


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/pull/134.html" title="Last updated on Jul 23, 2019, 9:56 PM UTC (2fd5e66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/134/e17e0dc...2fd5e66.html" title="Last updated on Jul 23, 2019, 9:56 PM UTC (2fd5e66)">Diff</a>