### PR TITLE
CI: Set W3C status in spec-prod config file

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -18,4 +18,4 @@ jobs:
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-webappsec/2015Mar/0170.html
           W3C_BUILD_OVERRIDE: |
             shortname: FileAPI
-            specStatus: WD
+            status: WD

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -18,3 +18,4 @@ jobs:
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-webappsec/2015Mar/0170.html
           W3C_BUILD_OVERRIDE: |
             shortname: FileAPI
+            specStatus: WD


### PR DESCRIPTION
In order for Echidna-based autopublishing to TR space to succeed, the document status can’t be ED but instead must be WD or CR. So this change sets it to WD in the spec-prod config file.

Otherwise, without this change, Echidna throws an exception:

https://labs.w3.org/echidna/api/status?id=9433f07f-8e57-4c89-a06e-9c9afd347da9

> Error: [EXCEPTION] The document could not be parsed, it's neither a TR document nor a Member Submission.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/pull/168.html" title="Last updated on Apr 21, 2021, 5:51 AM UTC (14bf1da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/168/12e1aa1...14bf1da.html" title="Last updated on Apr 21, 2021, 5:51 AM UTC (14bf1da)">Diff</a>