### PR TITLE
Remove Previous Version from .bs file

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11,7 +11,6 @@ Status: ED
 ED: https://w3c.github.io/FileAPI/
 TR: https://www.w3.org/TR/FileAPI/
 Repository: w3c/FileAPI
-Previous Version: https://www.w3.org/TR/2019/WD-FileAPI-20190531/
 !Tests: <a href=https://github.com/web-platform-tests/wpt/tree/master/FileAPI>web-platform-tests FileAPI/</a> (<a href=https://github.com/web-platform-tests/wpt/labels/FileAPI>ongoing work</a>)
 Abstract: This specification provides an API for representing file objects in web applications,
   as well as programmatically selecting them and accessing their data. This includes:


### PR DESCRIPTION
When publishing to WD the correct previous version gets added anyway, and having (an incorrect) previous version mentions in the .bs file actually breaks auto-publishing. 

This should fix `"Retrieved "previous" and "latest" documents, but their contents don't match.` errors from echidna.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/pull/169.html" title="Last updated on Apr 21, 2021, 11:21 PM UTC (4a01382)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/169/dcff0c6...4a01382.html" title="Last updated on Apr 21, 2021, 11:21 PM UTC (4a01382)">Diff</a>