### PR TITLE
fix: no special character replacement in fileName

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -690,8 +690,7 @@ user agents must run the following steps:
 
 
 2. Let |n| be a new string of the same size as the {{fileName}} argument to the constructor.
-  Copy every character from {{fileName}} to |n|,
-  replacing any "/" character (U+002F SOLIDUS) with a ":" (U+003A COLON).
+  Copy every character from {{fileName}} to |n|.
 
   Note: Underlying OS filesystems use differing conventions for file name;
   with constructed files, mandating UTF-16 lessens ambiquity when file names are converted to <a>byte</a> sequences.

--- a/index.bs
+++ b/index.bs
@@ -689,8 +689,7 @@ user agents must run the following steps:
   and {{File/File(fileBits, fileName, options)/options}}.
 
 
-2. Let |n| be a new string of the same size as the {{fileName}} argument to the constructor.
-  Copy every character from {{fileName}} to |n|.
+2. Let |n| be the {{fileName}} argument to the constructor.
 
   Note: Underlying OS filesystems use differing conventions for file name;
   with constructed files, mandating UTF-16 lessens ambiquity when file names are converted to <a>byte</a> sequences.


### PR DESCRIPTION
Closes #41

For *normative* changes, the following tasks have been completed:

 * [x] Modified Web platform tests (https://github.com/web-platform-tests/wpt/commit/106157f2901e5ad6b21c37ecdfa9ed4cdfe6ac47)

Implementation commitment:

 * [x] WebKit (matches current behaviour)
 * [x] Chromium (matches current behaviour)
 * [x] Gecko (matches current behaviour)

See "No replacement when using special character in fileName" test at https://wpt.fyi/results/FileAPI/file/File-constructor.html?label=master&label=experimental&aligned


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lucacasonato/FileAPI/pull/171.html" title="Last updated on Apr 27, 2021, 11:54 AM UTC (d2d6200)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/171/d56cd86...lucacasonato:d2d6200.html" title="Last updated on Apr 27, 2021, 11:54 AM UTC (d2d6200)">Diff</a>