### PR TITLE
Return a byte stream from "get stream" algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -330,7 +330,7 @@ A {{Blob}} |blob| has an associated <dfn export for=Blob>get stream</dfn> algori
 which runs these steps:
 
 1. Let |stream| be a [=new=] {{ReadableStream}} created in |blob|'s [=relevant Realm=].
-1. [=ReadableStream/Set up=] |stream|.
+1. [=ReadableStream/set up with byte reading support|Set up=] |stream| with byte reading support.
 1. Run the following steps [=in parallel=]:
   1. While not all bytes of |blob| have been read:
     1. Let |bytes| be the [=byte sequence=] that results from reading a [=chunk=] from |blob|, or


### PR DESCRIPTION
Closes #186 

Paired with https://github.com/whatwg/fetch/pull/1593.

For *normative* changes, the following tasks have been completed:

 * [x] Modified Web platform tests
   * https://github.com/web-platform-tests/wpt/pull/37925
   * https://github.com/web-platform-tests/wpt/pull/37910 (which depends on "get stream")

Implementation commitment:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=250550)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1189621) @ricea
 * [x] Gecko (Shipped)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/pull/188.html" title="Last updated on Jan 13, 2023, 8:33 AM UTC (cc4ea2f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/188/d134dae...cc4ea2f.html" title="Last updated on Jan 13, 2023, 8:33 AM UTC (cc4ea2f)">Diff</a>