### PR TITLE
Add bytes() method to Blob for reading bytes into a Uint8Array

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -300,7 +300,7 @@ interface Blob {
   [NewObject] ReadableStream stream();
   [NewObject] Promise<USVString> text();
   [NewObject] Promise<ArrayBuffer> arrayBuffer();
-  [NewObject] Promise<ArrayBuffer> bytes();
+  [NewObject] Promise<Uint8Array> bytes();
 };
 
 enum EndingType { "transparent", "native" };

--- a/index.bs
+++ b/index.bs
@@ -300,6 +300,7 @@ interface Blob {
   [NewObject] ReadableStream stream();
   [NewObject] Promise<USVString> text();
   [NewObject] Promise<ArrayBuffer> arrayBuffer();
+  [NewObject] Promise<ArrayBuffer> bytes();
 };
 
 enum EndingType { "transparent", "native" };
@@ -631,6 +632,17 @@ The <dfn method for=Blob>arrayBuffer()</dfn> method, when invoked, must run thes
 1. Let |promise| be the result of [=read all bytes|reading all bytes=] from |stream| with |reader|.
 1. Return the result of transforming |promise| by a fulfillment handler that returns
    a new {{ArrayBuffer}} whose contents are its first argument.
+
+### The {{Blob/bytes()}} method ### {#bytes-method-algo}
+
+The <dfn method for=Blob>bytes()</dfn> method, when invoked, must run these steps:
+
+1. Let |stream| be the result of calling [=get stream=] on [=this=].
+1. Let |reader| be the result of [=get a reader|getting a reader=] from |stream|.
+   If that threw an exception, return a new promise rejected with that exception.
+1. Let |promise| be the result of [=read all bytes|reading all bytes=] from |stream| with |reader|.
+1. Return the result of transforming |promise| by a fulfillment handler that returns
+   a new {{Uint8Array}} wrapping an {{ArrayBuffer}} containing its first argument.
 
 <!--
 ████████ ████ ██       ████████


### PR DESCRIPTION
Edit: Replaced by https://github.com/w3c/FileAPI/pull/198.

---

The Fetch API [is getting](https://github.com/whatwg/fetch/pull/1753) a `Uint8Array`-returning `bytes()` method alongside its existing `arrayBuffer()` method, following [the principle](https://github.com/w3ctag/design-principles/pull/480) that APIs should generally vend byte buffers as `Uint8Array`s.

This PR makes the same change for `Blob`, which has its own distinct `arrayBuffer` method.

I'm assuming this is uncontroversial given the support from the three major implementations for doing this on `Body`, but I can open an issue and solicit explicit support separately if you'd prefer. ~~I'll write tests if I get a signal that this is able to go forward.~~ Tests written, see link.

 * [x] Modified Web platform tests ([link to pull request](https://github.com/web-platform-tests/wpt/pull/46232))

Implementation commitment:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=274119)
 * [ ] Chromium (https://issues.chromium.org/issues/340200022)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1896509)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bakkot/FileAPI/pull/197.html" title="Last updated on May 13, 2024, 10:34 PM UTC (7257898)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/197/5f1f9f5...bakkot:7257898.html" title="Last updated on May 13, 2024, 10:34 PM UTC (7257898)">Diff</a>