### PR TITLE
Removed extra "be" in sentence.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -443,7 +443,7 @@ To <dfn lt="convert line endings to native|converting line endings to native">
 convert line endings to native</dfn> in a [=string=] |s|,
 run the following steps:
 
-1. Let |native line ending| be be the [=code point=] U+000A LF.
+1. Let |native line ending| be the [=code point=] U+000A LF.
 
 1. If the underlying platform's conventions are
   to represent newlines as a carriage return and line feed sequence,


### PR DESCRIPTION
Simple grammatical correction.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/KristofferStrube/FileAPI/pull/200.html" title="Last updated on Oct 24, 2024, 7:53 PM UTC (c44ac94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/200/85b18bc...KristofferStrube:c44ac94.html" title="Last updated on Oct 24, 2024, 7:53 PM UTC (c44ac94)">Diff</a>