### PR TITLE
Partition Blob URL revocation by Storage Key

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1512,14 +1512,24 @@ A [=blob URL store=] is a [=map=]
 where [=map/keys=] are [=valid URL strings=]
 and [=map/values=] are [=blob URL Entries=].
 
-A <dfn export>blob URL entry</dfn> consists of
-an <dfn export for="blob URL entry">object</dfn> (of type {{Blob}} or {{MediaSource}}),
-and an <dfn export for="blob URL entry">environment</dfn> (an [=environment settings object=]).
-
 [=map/Keys=] in the [=blob URL store=] (also known as <dfn lt="blob URL|object URL" export>blob URLs</dfn>)
 are [=valid URL strings=] that when [=URL parser|parsed=]
 result in a [=/URL=] with a [=url/scheme=] equal to "`blob`",
 an [=empty host=], and a [=url/path=] consisting of one element itself also a [=valid URL string=].
+
+A <dfn export>blob URL entry</dfn> is used to store an object of type {{Blob}} or {{MediaSource}}.
+
+A [=blob URL entry=] has an <dfn export for="blob URL entry">environment</dfn> (an [=environment settings object=]).
+
+<div algorithm="obtainBlobObject">
+To <dfn export id=blob-url-obtain-object>obtain a blob object</dfn> given a [=blob URL entry=] |blobUrlEntry|, an [=environment=] |environment|, and an optional boolean |isNavigation| (default false):
+
+1. Let |isAuthorized| be true.
+1. If |isNavigation| is false, let |isAuthorized| be the result of [=checking for same-partition blob URL usage=] with |blobUrlEntry| and |environment|.
+1. If |isAuthorized| is false, then return failure.
+1. Return |blobUrlEntry|'s object.
+
+</div>
 
 <div algorithm="createBlobURL">
 To <dfn id="unicodeBlobURL" lt="generate a new blob URL|generating a new blob URL">
@@ -1595,6 +1605,22 @@ as the serialization of the origin of the environment that created the blob URL,
 but for opaque origins the origin itself might be distinct. This difference isn't
 observable though, since a revoked blob URL can't be resolved/fetched anymore anyway.
 
+### Access restrictions on blob URLs ### {#partitioningOfBlobUrls}
+
+<a>Blob URLs</a> can only be fetched from environments where the [=storage key=] matches that of
+the environment where the <a>blob URL</a> was created. <a>blob URL</a> navigations are not subject
+to this restriction.
+
+<div algorithm="checkForSamePartitionBlobUrlUsage">
+To <dfn export id=blob-url-partition-check>check for same-partition blob URL usage</dfn> given a [=blob URL entry=] |blobUrlEntry| and an [=environment=] |environment|:
+
+1. Let |blobStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |blobUrlEntry|'s [=blob URL entry/environment=].
+1. Let |environmentStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |environment|.
+1. If |blobStorageKey| is not [=storage key/equal=] to |environmentStorageKey|, then return false.
+1. Otherwise, return true.
+
+</div>
+
 <h4 id="lifeTime" dfn for="blob url" lt="lifetime|lifetime stipulation" export>Lifetime of blob URLs</h4>
 
 This specification extends the [=unloading document cleanup steps=] with the following steps:
@@ -1633,12 +1659,12 @@ The <dfn method for=URL id="dfn-revokeObjectURL">revokeObjectURL(|url|)</dfn> st
 1. Let |url record| be the result of [=URL parser|parsing=] |url|.
 1. If |url record|'s [=url/scheme=] is not "`blob`", return.
 1. Let |entry| be |url record|'s [=blob URL entry=].
-1. Let |blobStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |entry|'s [=blob URL entry/environment=].
-1. Let |currentStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with the [=current settings object=].
-1. If |blobStorageKey| is not [=storage key/equal=] to |currentStorageKey|, return.
+1. If |entry| is null, return.
+1. Let |isAuthorized| be the result of [=checking for same-partition blob URL usage=] with |entry| and the [=current settings object=].
+1. If |isAuthorized| is false, return.
 1. [=Remove an entry from the Blob URL Store=] for |url|.
 
-Note: This means that rather than throwing some kind of error, attempting to revoke a URL that isn't registered or that was registered from an environment with a different storage key will silently fail.
+Note: This means that rather than throwing some kind of error, attempting to revoke a URL that isn't registered or that was registered from an environment in a different storage partition will silently fail.
 User agents might display a message on the error console if this happens.
 
 Note: Attempts to dereference |url| after it has been revoked will result in a [=network error=].

--- a/index.bs
+++ b/index.bs
@@ -1512,12 +1512,12 @@ A [=blob URL store=] is a [=map=]
 where [=map/keys=] are [=valid URL strings=]
 and [=map/values=] are [=blob URL Entries=].
 
-A <dfn export>blob URL entry</dfn> consists of an <i>object</i> (of type {{Blob}} or
-{{MediaSource}}), and an <dfn export for="blob URL entry">environment</dfn> (an
+A <dfn export>blob URL entry</dfn> consists of an <dfn for="blob URL entry">object</dfn> (of type
+{{Blob}} or {{MediaSource}}), and an <dfn export for="blob URL entry">environment</dfn> (an
 [=environment settings object=]).
 
-Note: Specifications must use the [=obtain a blob object=] algorithm to access a
-[=blob URL entry=]'s <i>object</i>.
+Note: Specifications have to use the [=obtain a blob object=] algorithm to access a
+[=blob URL entry=]'s [=blob URL entry/object=].
 
 [=map/Keys=] in the [=blob URL store=] (also known as <dfn lt="blob URL|object URL" export>blob URLs</dfn>)
 are [=valid URL strings=] that when [=URL parser|parsed=]
@@ -1531,7 +1531,7 @@ To <dfn export id=blob-url-obtain-object>obtain a blob object</dfn> given a [=bl
 1. Let |isAuthorized| be true.
 1. If |environment| is not the string "`navigation`", then set |isAuthorized| to the result of [=checking for same-partition blob URL usage=] with |blobUrlEntry| and |environment|.
 1. If |isAuthorized| is false, then return failure.
-1. Return |blobUrlEntry|'s object.
+1. Return |blobUrlEntry|'s [=blob URL entry/object=].
 
 </div>
 
@@ -1612,7 +1612,7 @@ observable though, since a revoked blob URL can't be resolved/fetched anymore an
 ### Access restrictions on blob URLs ### {#partitioningOfBlobUrls}
 
 <a>Blob URLs</a> can only be fetched from environments where the [=storage key=] matches that of
-the environment where the <a>blob URL</a> was created. <a>blob URL</a> navigations are not subject
+the environment where the <a>blob URL</a> was created. <a>Blob URL</a> navigations are not subject
 to this restriction.
 
 <div algorithm="checkForSamePartitionBlobUrlUsage">
@@ -1621,7 +1621,7 @@ To <dfn export id=blob-url-partition-check>check for same-partition blob URL usa
 1. Let |blobStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |blobUrlEntry|'s [=blob URL entry/environment=].
 1. Let |environmentStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |environment|.
 1. If |blobStorageKey| is not [=storage key/equal=] to |environmentStorageKey|, then return false.
-1. Otherwise, return true.
+1. Return true.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1526,7 +1526,8 @@ an [=empty host=], and a [=url/path=] consisting of one element itself also a [=
 
 <div algorithm="obtainBlobObject">
 To <dfn export id=blob-url-obtain-object>obtain a blob object</dfn> given a [=blob URL entry=]
-|blobUrlEntry|, an [=environment settings object=] or the string "`navigation`" |environment|:
+|blobUrlEntry| and an [=environment settings object=] or the string "`navigation`" |environment|,
+perform the following steps. They return an [=blob URL entry/object=].
 
 1. Let |isAuthorized| be true.
 1. If |environment| is not the string "`navigation`", then set |isAuthorized| to the result of [=checking for same-partition blob URL usage=] with |blobUrlEntry| and |environment|.
@@ -1616,7 +1617,7 @@ the environment where the <a>blob URL</a> was created. <a>Blob URL</a> navigatio
 to this restriction.
 
 <div algorithm="checkForSamePartitionBlobUrlUsage">
-To <dfn export id=blob-url-partition-check>check for same-partition blob URL usage</dfn> given a [=blob URL entry=] |blobUrlEntry| and an [=environment settings object=] |environment|:
+To <dfn>check for same-partition blob URL usage</dfn> given a [=blob URL entry=] |blobUrlEntry| and an [=environment settings object=] |environment|, perform the following steps. They return a boolean.
 
 1. Let |blobStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |blobUrlEntry|'s [=blob URL entry/environment=].
 1. Let |environmentStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |environment|.

--- a/index.bs
+++ b/index.bs
@@ -1512,20 +1512,25 @@ A [=blob URL store=] is a [=map=]
 where [=map/keys=] are [=valid URL strings=]
 and [=map/values=] are [=blob URL Entries=].
 
+A <dfn export>blob URL entry</dfn> consists of an <i>object</i> (of type {{Blob}} or
+{{MediaSource}}), and an <dfn export for="blob URL entry">environment</dfn> (an
+[=environment settings object=]).
+
+Note: Specifications must use the [=obtain a blob object=] algorithm to access a
+[=blob URL entry=]'s <i>object</i>.
+
 [=map/Keys=] in the [=blob URL store=] (also known as <dfn lt="blob URL|object URL" export>blob URLs</dfn>)
 are [=valid URL strings=] that when [=URL parser|parsed=]
 result in a [=/URL=] with a [=url/scheme=] equal to "`blob`",
 an [=empty host=], and a [=url/path=] consisting of one element itself also a [=valid URL string=].
 
-A <dfn export>blob URL entry</dfn> is used to store an object of type {{Blob}} or {{MediaSource}}.
-
-A [=blob URL entry=] has an <dfn export for="blob URL entry">environment</dfn> (an [=environment settings object=]).
-
 <div algorithm="obtainBlobObject">
-To <dfn export id=blob-url-obtain-object>obtain a blob object</dfn> given a [=blob URL entry=] |blobUrlEntry|, an [=environment=] |environment|, and an optional boolean |isNavigation| (default false):
+To <dfn export id=blob-url-obtain-object>obtain a blob object</dfn> given a [=blob URL entry=]
+|blobUrlEntry|, an [=environment=] or the string "`navigation`" |environment|:
 
 1. Let |isAuthorized| be true.
-1. If |isNavigation| is false, let |isAuthorized| be the result of [=checking for same-partition blob URL usage=] with |blobUrlEntry| and |environment|.
+1. If |environment| is not the string "`navigation`", then set |isAuthorized| to the result of
+[=checking for same-partition blob URL usage=] with |blobUrlEntry| and |environment|.
 1. If |isAuthorized| is false, then return failure.
 1. Return |blobUrlEntry|'s object.
 
@@ -1656,12 +1661,12 @@ return the result of [=adding an entry to the blob URL store=] for |obj|.
 <div algorithm="revokeObjectURL">
 The <dfn method for=URL id="dfn-revokeObjectURL">revokeObjectURL(|url|)</dfn> static method must run these steps:
 
-1. Let |url record| be the result of [=URL parser|parsing=] |url|.
-1. If |url record|'s [=url/scheme=] is not "`blob`", return.
-1. Let |entry| be |url record|'s [=blob URL entry=].
-1. If |entry| is null, return.
+1. Let |urlRecord| be the result of [=URL parser|parsing=] |url|.
+1. If |urlRecord|'s [=url/scheme=] is not "`blob`", return.
+1. Let |entry| be |urlRecord|'s [=blob URL entry=].
+1. If |entry| is null, then return.
 1. Let |isAuthorized| be the result of [=checking for same-partition blob URL usage=] with |entry| and the [=current settings object=].
-1. If |isAuthorized| is false, return.
+1. If |isAuthorized| is false, then return.
 1. [=Remove an entry from the Blob URL Store=] for |url|.
 
 Note: This means that rather than throwing some kind of error, attempting to revoke a URL that isn't registered or that was registered from an environment in a different storage partition will silently fail.

--- a/index.bs
+++ b/index.bs
@@ -1529,8 +1529,7 @@ To <dfn export id=blob-url-obtain-object>obtain a blob object</dfn> given a [=bl
 |blobUrlEntry|, an [=environment=] or the string "`navigation`" |environment|:
 
 1. Let |isAuthorized| be true.
-1. If |environment| is not the string "`navigation`", then set |isAuthorized| to the result of
-[=checking for same-partition blob URL usage=] with |blobUrlEntry| and |environment|.
+1. If |environment| is not the string "`navigation`", then set |isAuthorized| to the result of [=checking for same-partition blob URL usage=] with |blobUrlEntry| and |environment|.
 1. If |isAuthorized| is false, then return failure.
 1. Return |blobUrlEntry|'s object.
 

--- a/index.bs
+++ b/index.bs
@@ -1630,7 +1630,7 @@ return the result of [=adding an entry to the blob URL store=] for |obj|.
 <div algorithm="revokeObjectURL">
 The <dfn method for=URL id="dfn-revokeObjectURL">revokeObjectURL(|url|)</dfn> static method must run these steps:
 
-1. 1. Let |entry| be the result of [=resolving the blob URL=] |url|.
+1. Let |entry| be the result of [=resolving the blob URL=] |url|.
 1. If |entry| is failure, return.
 1. Let |blobStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |entry|'s [=environment settings object=].
 1. Let |currentStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with the [=current settings object=].

--- a/index.bs
+++ b/index.bs
@@ -1526,7 +1526,7 @@ an [=empty host=], and a [=url/path=] consisting of one element itself also a [=
 
 <div algorithm="obtainBlobObject">
 To <dfn export id=blob-url-obtain-object>obtain a blob object</dfn> given a [=blob URL entry=]
-|blobUrlEntry|, an [=environment=] or the string "`navigation`" |environment|:
+|blobUrlEntry|, an [=environment settings object=] or the string "`navigation`" |environment|:
 
 1. Let |isAuthorized| be true.
 1. If |environment| is not the string "`navigation`", then set |isAuthorized| to the result of [=checking for same-partition blob URL usage=] with |blobUrlEntry| and |environment|.
@@ -1616,7 +1616,7 @@ the environment where the <a>blob URL</a> was created. <a>blob URL</a> navigatio
 to this restriction.
 
 <div algorithm="checkForSamePartitionBlobUrlUsage">
-To <dfn export id=blob-url-partition-check>check for same-partition blob URL usage</dfn> given a [=blob URL entry=] |blobUrlEntry| and an [=environment=] |environment|:
+To <dfn export id=blob-url-partition-check>check for same-partition blob URL usage</dfn> given a [=blob URL entry=] |blobUrlEntry| and an [=environment settings object=] |environment|:
 
 1. Let |blobStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |blobUrlEntry|'s [=blob URL entry/environment=].
 1. Let |environmentStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |environment|.

--- a/index.bs
+++ b/index.bs
@@ -1570,7 +1570,7 @@ run the following steps:
 ## Dereferencing Model for blob URLs ## {#requestResponseModel}
 
 <div algorithm="resolveURL">
-To <dfn export id=blob-url-resolve lt="resolve a blob URL|resolving the blob URL">resolve a blob URL</dfn> given a [=URL=] |url|:
+To <dfn export id=blob-url-resolve>resolve a blob URL</dfn> given a [=URL=] |url|:
 
 1. [=Assert=]: |url|'s [=url/scheme=] is "`blob`".
 1. Let |store| be the user agent's [=blob URL store=].
@@ -1630,14 +1630,15 @@ return the result of [=adding an entry to the blob URL store=] for |obj|.
 <div algorithm="revokeObjectURL">
 The <dfn method for=URL id="dfn-revokeObjectURL">revokeObjectURL(|url|)</dfn> static method must run these steps:
 
-1. Let |entry| be the result of [=resolving the blob URL=] |url|.
-1. If |entry| is failure, return.
-1. Let |blobStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |entry|'s [=environment settings object=].
+1. Let |url record| be the result of [=URL parser|parsing=] |url|.
+1. If |url record|'s [=url/scheme=] is not "`blob`", return.
+1. Let |entry| be |url record|'s [=blob URL entry=].
+1. Let |blobStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |entry|'s [=blob URL entry/environment=].
 1. Let |currentStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with the [=current settings object=].
 1. If |blobStorageKey| is not [=storage key/equal=] to |currentStorageKey|, return.
 1. [=Remove an entry from the Blob URL Store=] for |url|.
 
-Note: This means that rather than throwing some kind of error, attempting to revoke a URL that isn't registered will silently fail.
+Note: This means that rather than throwing some kind of error, attempting to revoke a URL that isn't registered or that was registered from an environment with a different storage key will silently fail.
 User agents might display a message on the error console if this happens.
 
 Note: Attempts to dereference |url| after it has been revoked will result in a [=network error=].

--- a/index.bs
+++ b/index.bs
@@ -1570,7 +1570,7 @@ run the following steps:
 ## Dereferencing Model for blob URLs ## {#requestResponseModel}
 
 <div algorithm="resolveURL">
-To <dfn export id=blob-url-resolve>resolve a blob URL</dfn> given a [=URL=] |url|:
+To <dfn export id=blob-url-resolve lt="resolve a blob URL|resolving the blob URL">resolve a blob URL</dfn> given a [=URL=] |url|:
 
 1. [=Assert=]: |url|'s [=url/scheme=] is "`blob`".
 1. Let |store| be the user agent's [=blob URL store=].
@@ -1630,11 +1630,11 @@ return the result of [=adding an entry to the blob URL store=] for |obj|.
 <div algorithm="revokeObjectURL">
 The <dfn method for=URL id="dfn-revokeObjectURL">revokeObjectURL(|url|)</dfn> static method must run these steps:
 
-1. Let |url record| be the result of [=URL parser|parsing=] |url|.
-1. If |url record|'s [=url/scheme=] is not "`blob`", return.
-1. Let |origin| be the [=url/origin=] of |url record|.
-1. Let |settings| be the [=current settings object=].
-1. If |origin| is not [=same origin=] with |settings|'s [=environment settings object/origin=], return.
+1. 1. Let |entry| be the result of [=resolving the blob URL=] |url|.
+1. If |entry| is failure, return.
+1. Let |blobStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with |entry|'s [=environment settings object=].
+1. Let |currentStorageKey| be the result of [=obtaining a storage key for non-storage purposes=] with the [=current settings object=].
+1. If |blobStorageKey| is not [=storage key/equal=] to |currentStorageKey|, return.
 1. [=Remove an entry from the Blob URL Store=] for |url|.
 
 Note: This means that rather than throwing some kind of error, attempting to revoke a URL that isn't registered will silently fail.


### PR DESCRIPTION
Part of the changes discussed in https://github.com/w3c/FileAPI/issues/153#issuecomment-2330085478

This updates URL.revokeObjectURL to not allow revoking a Blob URL except from contexts with the same Storage Key as the one in which the Blob URL was created. A corresponding PR will update the Fetch spec to incorporate similar Storage Key checks into Blob URL fetches.

I considered incorporating the Storage Key checks into the "resolve a blob URL" algorithm instead, but it seemed that this would require an environment settings object to be available as part of https://url.spec.whatwg.org/#url-parsing, and I'm not sure whether that is the case / a change we want.

For *normative* changes, the following tasks have been completed:

 * [x] Modified Web platform tests (link to pull request)
 - https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/external/wpt/FileAPI/BlobURL/cross-partition.tentative.https.html

Implementation commitment:

 * [x] WebKit - Already implemented partitioning by top-level origin, considering partitioning by top-level site - https://github.com/w3c/FileAPI/issues/153#issuecomment-2332086739
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=40057646)
 * [x] Gecko - Already implemented - https://github.com/w3c/FileAPI/issues/153#issuecomment-2332288047


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/recvfrom/FileAPI/pull/201.html" title="Last updated on Dec 4, 2024, 5:29 AM UTC (5a9047c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/201/f6247a2...recvfrom:5a9047c.html" title="Last updated on Dec 4, 2024, 5:29 AM UTC (5a9047c)">Diff</a>