### PR TITLE
Add missing close call to blob-get-stream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -347,6 +347,7 @@ which runs these steps:
 
     Issue: We need to specify more concretely what reading from a Blob actually does,
     what possible errors can happen, perhaps something about chunk sizes, etc.
+  1. Perform [=ReadableStream/close=] on |stream|.
 1. Return |stream|.
 
 </div>


### PR DESCRIPTION
Otherwise reading the stream will never end up finishing when it is read, even once all chunks are finished.

I think this is what all engines would already do (e.g WebKit: https://github.com/WebKit/WebKit/blob/fcb00789e9e97821473027e844e7bf12a32b8a99/Source/WebCore/fileapi/Blob.cpp#L351).

WPT tests already rely on this being done from what I understand.

Closes #???

For *normative* changes, the following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shannonbooth/FileAPI/pull/205.html" title="Last updated on Dec 7, 2024, 3:36 AM UTC (6218658)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/205/77b2086...shannonbooth:6218658.html" title="Last updated on Dec 7, 2024, 3:36 AM UTC (6218658)">Diff</a>