### PR TITLE
Add `textStream()` method to `Blob` interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -647,18 +647,14 @@ The <dfn method for=Blob>bytes()</dfn> method, when invoked, must run these step
 
 ### The {{Blob/textStream()}} method ### {#text-stream-method-algo}
 
-The <dfn method for=Blob>textStream()</dfn> method, when invoked, must run these steps:
+The <dfn method for=Blob>textStream()</dfn> method steps are:
 
 1. Let |stream| be the result of calling [=get stream=] on [=this=].
 1. Let |decoder| be a new {{TextDecoderStream}} in [=this=]'s [=relevant realm=].
 1. [=set up a text decoder stream|Set up=] |decoder| with [=UTF-8=].
 1. Return the result of calling |stream|, [=pipe through|piped through=] |decoder|.
 
-Note: This is different from the behavior of {{FileReader/readAsText()}} to align better
-with the behavior of {{Body/textStream()|Fetch's textStream()}}. Specifically this method will always
-use UTF-8 as encoding, while {{FileReader}} can use a different encoding depending on
-the blob's type and passed in encoding name.
-
+Note: This differs from {{FileReader/readAsText()}} in that it always uses the [=UTF-8=] encoding.
 <!--
 ████████ ████ ██       ████████
 ██        ██  ██       ██

--- a/index.bs
+++ b/index.bs
@@ -300,6 +300,7 @@ interface Blob {
   [NewObject] ReadableStream stream();
   [NewObject] Promise<USVString> text();
   [NewObject] Promise<ArrayBuffer> arrayBuffer();
+  [NewObject] ReadableStream textStream();
   [NewObject] Promise<Uint8Array> bytes();
 };
 
@@ -643,6 +644,11 @@ The <dfn method for=Blob>bytes()</dfn> method, when invoked, must run these step
 1. Let |promise| be the result of [=read all bytes|reading all bytes=] from |stream| with |reader|.
 1. Return the result of transforming |promise| by a fulfillment handler that returns
    a new {{Uint8Array}} wrapping an {{ArrayBuffer}} containing its first argument.
+
+### The {{Blob/textStream()}} method ### {#text-stream-method-algo}
+
+The <dfn method for=Blob>textStream()</dfn> method, when invoked, must return
+the result of calling [=get stream=] on [=this=], [=pipe through|piped through=] a new {{TextDecoderStream}} object.
 
 <!--
 ████████ ████ ██       ████████

--- a/index.bs
+++ b/index.bs
@@ -647,8 +647,17 @@ The <dfn method for=Blob>bytes()</dfn> method, when invoked, must run these step
 
 ### The {{Blob/textStream()}} method ### {#text-stream-method-algo}
 
-The <dfn method for=Blob>textStream()</dfn> method, when invoked, must return
-the result of calling [=get stream=] on [=this=], [=pipe through|piped through=] a new {{TextDecoderStream}} object.
+The <dfn method for=Blob>textStream()</dfn> method, when invoked, must run these steps:
+
+1. Let |stream| be the result of calling [=get stream=] on [=this=].
+1. Let |decoder| be a new {{TextDecoderStream}} in [=this=]'s [=relevant realm=].
+1. [=set up a text decoder stream|Set up=] |decoder| with [=UTF-8=].
+1. Return the result of calling |stream|, [=pipe through|piped through=] |decoder|.
+
+Note: This is different from the behavior of {{FileReader/readAsText()}} to align better
+with the behavior of {{Body/textStream()|Fetch's textStream()}}. Specifically this method will always
+use UTF-8 as encoding, while {{FileReader}} can use a different encoding depending on
+the blob's type and passed in encoding name.
 
 <!--
 ████████ ████ ██       ████████


### PR DESCRIPTION
Add textStream method to Blob interface for streaming text.

Part of https://github.com/whatwg/fetch/issues/1861

For *normative* changes, the following tasks have been completed:

 * [x] Modified Web platform tests (https://github.com/web-platform-tests/wpt/pull/60356)

Implementation commitment:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=316191)
 * [x] Chromium (https://issues.chromium.org/issues/514448226)
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=2044628)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/noamr/FileAPI/pull/221.html" title="Last updated on Jun 3, 2026, 11:20 AM UTC (69f5c87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/FileAPI/221/13757c2...noamr:69f5c87.html" title="Last updated on Jun 3, 2026, 11:20 AM UTC (69f5c87)">Diff</a>